### PR TITLE
Update owners to include david-martin

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,5 +2,8 @@
 
 approvers:
   - LiorLieberman
-  - guicassolato
+  - david-martin
   - yuzisun
+
+emeritus_approvers:
+  - guicassolato


### PR DESCRIPTION
Adding myself to approvers, and Gui to emeritus_approvers, now that https://github.com/kubernetes/org/pull/5955 has merged.
This was a temporary arrangement, and agreed on slack with @LiorLieberman and @guicassolato.

Thanks for covering @guicassolato and getting things moving.