### PR TITLE
Inject Bearer Token for Envoy-to-K8s API Authentication

### DIFF
--- a/pkg/constants/envoynames.go
+++ b/pkg/constants/envoynames.go
@@ -41,4 +41,10 @@ const (
 	SAAuthTokenHeader = "x-k8s-sa-token"
 	// UserRoleHeader is the header populated with the subject claim from the JWT.
 	UserRoleHeader = "x-user-role"
+	// CredentialBearerSecretName is the name of the secret that holds the bearer token for credential injection.
+	CredentialBearerSecretName = "credential-bearer-secret"
+	// ServiceAccountTokenPath is the path to the Kubernetes service account token.
+	ServiceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	// ServiceAccountCACertPath is the path to the Kubernetes service account CA certificate.
+	ServiceAccountCACertPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 )

--- a/pkg/infra/envoy/bootstrap.yaml
+++ b/pkg/infra/envoy/bootstrap.yaml
@@ -14,6 +14,11 @@ dynamic_resources:
     ads: {}
 
 static_resources:
+  secrets:
+  - name: {{ .CredentialBearerSecretName }}
+    generic_secret:
+      secret:
+        filename: "{{ .ServiceAccountTokenPath }}"
   clusters:
   - name: xds_cluster
     type: STRICT_DNS

--- a/pkg/infra/envoy/resourcerender.go
+++ b/pkg/infra/envoy/resourcerender.go
@@ -35,10 +35,12 @@ import (
 var bootstrapTemplate string
 
 type configData struct {
-	Cluster             string
-	ID                  string
-	ControlPlaneAddress string
-	ControlPlanePort    int
+	Cluster                    string
+	ID                         string
+	ControlPlaneAddress        string
+	ControlPlanePort           int
+	CredentialBearerSecretName string
+	ServiceAccountTokenPath    string
 }
 
 // generateEnvoyBootstrapConfig returns an envoy config generated from config data
@@ -48,10 +50,12 @@ func generateEnvoyBootstrapConfig(cluster, id string) (string, error) {
 	}
 
 	data := &configData{
-		Cluster:             cluster,
-		ID:                  id,
-		ControlPlaneAddress: fmt.Sprintf("%s.%s.svc.cluster.local", constants.XDSServerServiceName, constants.AgenticNetSystemNamespace),
-		ControlPlanePort:    15001,
+		Cluster:                    cluster,
+		ID:                         id,
+		ControlPlaneAddress:        fmt.Sprintf("%s.%s.svc.cluster.local", constants.XDSServerServiceName, constants.AgenticNetSystemNamespace),
+		ControlPlanePort:           15001,
+		CredentialBearerSecretName: constants.CredentialBearerSecretName,
+		ServiceAccountTokenPath:    constants.ServiceAccountTokenPath,
 	}
 
 	t, err := template.New("gateway-config").Parse(bootstrapTemplate)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind feature

**What this PR does / why we need it**:

This change (complementary to #28) configures the Envoy proxy to authenticate its requests to the Kubernetes API server. It uses credential injector and header mutation filters to add a bearer token, sourced from a mounted service account token file, into the Authorization header of Envoy's requests.

This enables Envoy to securely communicate with the K8s API server using its service account token.

Without this change, Envoy would be unable to fetch JWKS from the K8s API server. Allowing anonymous access to these endpoints, a necessary workaround without this authentication mechanism, would introduce significant security concerns.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #19 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Yes, this change enables Envoy to authenticate its JWKS request to the K8s API server by injecting an SA token into its request header.  
```
