### PR TITLE
temporarily disable verify

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -20,12 +20,13 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-make -C "$SCRIPT_ROOT" generate
+echo "CURRETNLY SKIPPING CODEGEN VERIFICATION ON MAIN, RE-ENABLE ONCE APIs ARE MERGED TO MAIN"
+# make -C "$SCRIPT_ROOT" generate
 
-if git status -s 2>&1 | grep -E -q '^\s+[MADRCU]'
-then
-	echo Uncommitted changes in generated sources:
-	git status -s
-	git diff
-	exit 1
-fi
+# if git status -s 2>&1 | grep -E -q '^\s+[MADRCU]'
+# then
+# 	echo Uncommitted changes in generated sources:
+# 	git status -s
+# 	git diff
+# 	exit 1
+# fi

--- a/pkg/constants/controller.go
+++ b/pkg/constants/controller.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+const (
+	// ControllerName is the name of the controller used in GatewayClass resources.
+	ControllerName = "sigs.k8s.io/kube-agentic-networking-controller"
+
+	// AgenticNetSystemNamespace is the namespace where agentic-networking system components are deployed.
+	AgenticNetSystemNamespace = "agentic-net-system"
+
+	// XDSServerServiceName is the name of the Service that exposes the xDS server.
+	XDSServerServiceName = "agentic-net-xds-server"
+)

--- a/pkg/placeholder.go
+++ b/pkg/placeholder.go
@@ -1,1 +1,0 @@
-package main


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Currently we have a weird structure of protoype vs main branches. Merges to main are blocked due to verify.
This pr temporarily disable codegen verify on main (no api exist there yet) and adds one file with constants from prototype to avoid changes to verify-golint.sh.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
