### PR TITLE
Add a link to the GCR location for the agentic-networking controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 # Build the agentic-net-controller binary
+# The image will be pushed to https://console.cloud.google.com/artifacts/docker/k8s-staging-images/us-central1/agentic-net.
+
 # This will be overridden at build time by makefile to .go-version
 ARG GO_VERSION=1.25.5
 FROM golang:${GO_VERSION} AS builder


### PR DESCRIPTION
This is to test whether the docker image can be pushed post-submit (configured in https://github.com/kubernetes/test-infra/pull/36337).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
