### PR TITLE
Add a proposal for allowing AccessPolicy objects to target Gateway objects

### DIFF
--- a/docs/proposals/0059-AccessPolicyTargetRefs.md
+++ b/docs/proposals/0059-AccessPolicyTargetRefs.md
@@ -120,8 +120,9 @@ Currently, the `InlineTools` type of [AuthorizationRule](https://github.com/kube
 
 ## Support requirements in implementation
 
-* An implementation MUST support allowing `AccessPolicy` to target `Gateway` objects.
+* An implementation MUST support at least one of the following:
 
-* An implementation MAY support allowing `AccessPolicy` to target `Backend` objects.
+    * `AccessPolicy` objects targeting `Gateway` objects
+    * `AccessPolicy` objects targeting `Backend` objects
 
 * If an implementation supports allowing `AccessPolicy` to target both `Gateway` and `Backend` objects, it MUST support the evaluation flow described above.


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind feature

**What this PR does / why we need it**:

Currently, the [AccessPolicy](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/docs/proposals/0008-ToolAuthAPI.md#accesspolicy-crd) resource is only allowed to target [Backends](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/docs/proposals/0008-ToolAuthAPI.md#backend-crd).

This has scalability issues when a given Tool Authorization policy needs to be enforced for all the traffic managed by a [Gateway](https://gateway-api.sigs.k8s.io/api-types/gateway/) object.

This PR proposes allowing `AccessPolicy` to target `Gateway` objects.

This is to address https://github.com/kubernetes-sigs/kube-agentic-networking/issues/55.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
