### PR TITLE
Add cloudbuild.yaml for adk-agent and mcp-server

### DIFF
--- a/hack/build/Makefile.common.in
+++ b/hack/build/Makefile.common.in
@@ -20,8 +20,11 @@
 # TODO: The registry is currently not ready.
 # 			Needs to wait https://github.com/kubernetes-sigs/kube-agentic-networking/issues/41 to be done.
 REGISTRY?=us-central1-docker.pkg.dev/k8s-staging-images/agentic-net
+
+REPO_ROOT?=$(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
+
 # Go version to use, respected by images that build go binaries
-GO_VERSION=$(shell cat $(CURDIR)/.go-version | head -n1)
+GO_VERSION?=$(shell cat $(REPO_ROOT)/.go-version | head -n1)
 
 # build with buildx
 PLATFORMS?=linux/amd64,linux/arm64
@@ -45,6 +48,6 @@ quick: build
 
 # enable buildx
 ensure-buildx:
-	$(CURDIR)/hack/build/init-buildx.sh
+	$(REPO_ROOT)/hack/build/init-buildx.sh
 
 .PHONY: push build quick ensure-buildx

--- a/quickstart/adk-agent/Makefile
+++ b/quickstart/adk-agent/Makefile
@@ -1,0 +1,1 @@
+include $(CURDIR)/../../hack/build/Makefile.common.in

--- a/quickstart/adk-agent/cloudbuild.yaml
+++ b/quickstart/adk-agent/cloudbuild.yaml
@@ -1,0 +1,27 @@
+# See
+# - https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md#build-example
+# - https://cloud.google.com/cloud-build/docs/build-config
+
+# this must be specified in seconds. If omitted, defaults to 600s (10 mins)
+timeout: 2700s
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  substitution_option: ALLOW_LOOSE
+  # Using a more powerful machine type can speed up docker builds.
+  machineType: "E2_HIGHCPU_8"
+steps:
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
+    entrypoint: make
+    env:
+    - IMAGE_NAME=quickstart-adk-agent
+    - TAG=$_GIT_TAG
+    - BASE_REF=$_PULL_BASE_REF
+    args: ['-C', 'quickstart/adk-agent', 'push']
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '12345'
+  # _PULL_BASE_REF will contain the ref that was pushed to to trigger this build -
+  # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
+  _PULL_BASE_REF: 'main'

--- a/quickstart/mcpserver/Makefile
+++ b/quickstart/mcpserver/Makefile
@@ -1,0 +1,1 @@
+include $(CURDIR)/../../hack/build/Makefile.common.in

--- a/quickstart/mcpserver/cloudbuild.yaml
+++ b/quickstart/mcpserver/cloudbuild.yaml
@@ -1,0 +1,25 @@
+# See
+# - https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md#build-example
+# - https://cloud.google.com/cloud-build/docs/build-config
+
+# This prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  substitution_option: ALLOW_LOOSE
+  # Using a more powerful machine type can speed up docker builds.
+  machineType: "E2_HIGHCPU_8"
+steps:
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
+    entrypoint: make
+    env:
+    - IMAGE_NAME=quickstart-everything-mcp
+    - TAG=$_GIT_TAG
+    - BASE_REF=$_PULL_BASE_REF
+    args: ['-C', 'quickstart/mcpserver', 'push']
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '12345'
+  # _PULL_BASE_REF will contain the ref that was pushed to to trigger this build -
+  # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
+  _PULL_BASE_REF: 'main'


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->

/kind feature

**What this PR does / why we need it**:

This PR adds cloudbuild.yaml files to automate the build and push processes for the adk-agent and mcp-server images. These artifacts are required for the quickstart guide.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #41 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Yes, automate the the build and push processes of adk-agent and everything-mcp-server images used in quickstart.
```
