### PR TITLE
Use correct binary name in controller manifest

### DIFF
--- a/.github/workflows/controller-deploy-test.yaml
+++ b/.github/workflows/controller-deploy-test.yaml
@@ -1,0 +1,43 @@
+name: Controller Deployment Test
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Create kind cluster
+      uses: helm/kind-action@v1.12.0
+      with:
+        cluster_name: kind
+
+    - name: Install Gateway API CRDs
+      run: |
+        kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml
+
+    - name: Install Project CRDs
+      run: |
+        kubectl apply -f k8s/crds/
+
+    - name: Deploy Controller
+      run: |
+        kubectl apply -f k8s/deploy/deployment.yaml
+
+    - name: Wait for Controller to be ready
+      run: |
+        kubectl wait --for=condition=available --timeout=300s deployment/agentic-net-gw-controller -n agentic-net-system
+
+    - name: Debug on failure
+      if: failure()
+      run: |
+        kubectl get all -A
+        kubectl get events -A
+        kubectl describe deployment agentic-net-gw-controller -n agentic-net-system
+        kubectl logs deployment/agentic-net-gw-controller -n agentic-net-system --all-containers

--- a/k8s/deploy/deployment.yaml
+++ b/k8s/deploy/deployment.yaml
@@ -91,7 +91,7 @@ spec:
           image: registry.k8s.io/agentic-net/agentic-networking-controller:v20260130-5d7ea35
           imagePullPolicy: Always
           command:
-            - "/manager"
+            - "/agentic-net-controller"
           args:
             - "--proxy-image=envoyproxy/envoy:v1.36-latest"
             - "--worker-count=6"

--- a/quickstart/adk-agent/deployment.yaml
+++ b/quickstart/adk-agent/deployment.yaml
@@ -22,9 +22,11 @@ spec:
       serviceAccountName: adk-agent-sa
       containers:
         - name: adk-agent
+          # TODO: Set the image field to a container registry image built with the provided Dockerfile.
+          # Alternatively, wait for us-central1-docker.pkg.dev/k8s-staging-images/agentic-net/quickstart-adk-agent to become available.
+          # Reference: https://github.com/kubernetes-sigs/kube-agentic-networking/issues/41
+          # image: <PLACEHOLDER_FOR_ADK_AGENT_IMAGE>
           imagePullPolicy: Always
-          # TODO: Replace with the image from registry.k8s.io/agentic-net registry after https://github.com/kubernetes-sigs/kube-agentic-networking/issues/41 is done.
-          image: <PLACEHOLDER_FOR_ADK_AGENT_IMAGE>
           resources:
             limits:
               memory: "512Mi"

--- a/quickstart/mcpserver/deployment.yaml
+++ b/quickstart/mcpserver/deployment.yaml
@@ -15,8 +15,10 @@ spec:
     spec:
       containers:
         - name: mcp-everything
-          # TODO: Replace with the image from registry.k8s.io/agentic-net registry after https://github.com/kubernetes-sigs/kube-agentic-networking/issues/41 is done.
-          image: <PLACEHOLDER_FOR_MCP_EVERYTHING_IMAGE>
+          # TODO: Set the image field to a container registry image built with the provided Dockerfile.
+          # Alternatively, wait for us-central1-docker.pkg.dev/k8s-staging-images/agentic-net/quickstart-everything-mcp to become available.
+          # Reference: https://github.com/kubernetes-sigs/kube-agentic-networking/issues/41
+          # image: <PLACEHOLDER_FOR_MCP_EVERYTHING_IMAGE>
           ports:
             - containerPort: 3001
           env:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->

/kind bug

**What this PR does / why we need it**:

This PR fixes the controller startup failure by updating deployment manifests
to reference the correct binary name and improving image configuration handling.

*Changes:*
- Updated k8s/deploy/deployment.yaml to use `/agentic-net-controller` as the
  container command (previously used `/manager` but it has been renamed in Dockerfile.). This bug has caused the controller to fail with CrashLoopBackOff due to missing binary:
`exec: "/manager": stat /manager: no such file or directory`.
- Commented out image fields in ADK and mcpserver deployments to
  require explicit image configuration. This ensures users must explicitly set container registry images or wait for
  official releases, avoiding confusing ImagePullBackOff errors during quickstart like seen in https://github.com/kubernetes-sigs/kube-agentic-networking/pull/29#discussion_r2730092225
- Additionally, added a GitHub Actions workflow to automate deployment test for the
controller.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Part of #41 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
