### PR TITLE
Update the controller image tag

### DIFF
--- a/k8s/deploy/deployment.yaml
+++ b/k8s/deploy/deployment.yaml
@@ -88,9 +88,7 @@ spec:
       serviceAccountName: agentic-net-gw-controller-sa
       containers:
         - name: manager
-          # TODO: The image is currently not available.
-          # Needs to wait until https://github.com/kubernetes-sigs/kube-agentic-networking/issues/41 is done.
-          image: registry.k8s.io/agentic-net/agentic-networking-controller:latest
+          image: registry.k8s.io/agentic-net/agentic-networking-controller:v20260130-5d7ea35
           imagePullPolicy: Always
           command:
             - "/manager"


### PR DESCRIPTION
**What this PR does / why we need it**:
The current image tag `latest` does not work. The image tags available on https://console.cloud.google.com/artifacts/docker/k8s-staging-images/us-central1/agentic-net?pli=1 are `main` and `v20260130-5d7ea35`. I picked `v20260130-5d7ea35` for better stability.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
