### PR TITLE
Increase timeout value for adk-agent cloudbuild

### DIFF
--- a/quickstart/adk-agent/cloudbuild.yaml
+++ b/quickstart/adk-agent/cloudbuild.yaml
@@ -3,7 +3,7 @@
 # - https://cloud.google.com/cloud-build/docs/build-config
 
 # this must be specified in seconds. If omitted, defaults to 600s (10 mins)
-timeout: 3600s
+timeout: 7200s
 # this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->

/kind cleanup

**What this PR does / why we need it**:

We need to increase the timeout value for adk-agent cloudbuild to 7200s (2 hours) to avoid timeout errors during the build process.

ADK agent needs longer time to build because we build milti-arch images. In particular, the arm64 portion of the build is performed using QEMU emulation, which is extremely CPU-intensive. This is especially impactful during the pip install stage for large packages like `google-adk` and `litellm`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
