### PR TITLE
Set DnsLookupFamily to ALL for external backends

### DIFF
--- a/pkg/translator/backend.go
+++ b/pkg/translator/backend.go
@@ -95,6 +95,7 @@ func convertBackendToCluster(backend *agenticv0alpha0.XBackend) (*clusterv3.Clus
 
 	// External MCP backend specified via backend.Spec.MCP.Hostname
 	cluster.ClusterDiscoveryType = &clusterv3.Cluster_Type{Type: clusterv3.Cluster_LOGICAL_DNS}
+	cluster.DnsLookupFamily = clusterv3.Cluster_ALL
 	cluster.LoadAssignment = createClusterLoadAssignment(clusterName, *backend.Spec.MCP.Hostname, uint32(backend.Spec.MCP.Port))
 	// TODO: A new field will probably be added to Backend to allow configuring TLS for external MCP backends.
 	// For now, we always enable TLS for external MCP backends.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->

/kind bug

**What this PR does / why we need it**:

**Problem:**

External MCP backends often resolve to both IPv4 and IPv6 addresses. In single-stack IPv4 environments (e.g., kind clusters), current Envoy cluster config is problematic.

Since cluster uses LOGICAL_DNS for external backends without specifying a DNS lookup family, the [DnsLookupFamily](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#enum-config-cluster-v3-cluster-dnslookupfamily) is default to AUTO, which means envoy will not automatically fallback to the IPv4 address if IPv6 address is available.

When Envoy detects IPv6 address first, the connection fails immediately with a `Network is unreachable` error.

**Change:**
Explicitly set DnsLookupFamily to ALL.

**Impact:**
This enables [Happy Eyeballs (RFC 8305)](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/connection_pooling#arch-overview-happy-eyeballs) behavior. Envoy will now attempt both address families in quick succession, ensuring successful IPv4 connectivity even when unreachable IPv6 addresses are returned by DNS.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Yes, set DnsLookupFamily to ALL for external backends' clusters to enable envoy proxy to attempt both ipv4 and ipv6 addresses.
```
