### PR TITLE
Implement enqueueGatewaysForService with HTTPRoute backend matching

### DIFF
--- a/.github/workflows/controller-e2e-test.yaml
+++ b/.github/workflows/controller-e2e-test.yaml
@@ -40,13 +40,19 @@ jobs:
       run: |
         kubectl apply -f k8s/crds/
 
-    - name: Deploy Controller
+    # Create namespace and CA secret before deploying the controller so the pod
+    # can start immediately.
+    - name: Create agentic-net-system namespace
       run: |
-        kubectl apply -f k8s/deploy/deployment.yaml
+        kubectl create namespace agentic-net-system --dry-run=client -o yaml | kubectl apply -f -
 
     - name: Create agentic identity CA
       run: |
         go run ./cmd/agentic-net-tool -- make-ca-pool-secret --ca-id=v1 --namespace=agentic-net-system --name=agentic-identity-ca-pool
+
+    - name: Deploy Controller
+      run: |
+        kubectl apply -f k8s/deploy/deployment.yaml
 
     - name: Wait for controller to be ready
       run: |
@@ -83,9 +89,11 @@ jobs:
       if: failure()
       run: |
         kubectl get all -n e2e-test-ns
-        kubectl get gateway -n e2e-test-ns
+        kubectl get gateway -n e2e-test-ns -o yaml
         kubectl get xaccesspolicies -n e2e-test-ns
         kubectl get xbackends -n e2e-test-ns
+        kubectl get pods -n e2e-test-ns -o wide
         kubectl logs -n e2e-test-ns -l app=mcp-everything --tail=100
-        # Log for the envoy proxy
         kubectl logs -n e2e-test-ns -l "kube-agentic-networking.sigs.k8s.io/gateway-name=e2e-gateway" --all-containers --tail=100
+        echo "--- Controller logs (last 200 lines) ---"
+        kubectl logs deployment/agentic-net-controller -n agentic-net-system --all-containers --tail=200

--- a/cmd/agentic-net-controller/main.go
+++ b/cmd/agentic-net-controller/main.go
@@ -115,6 +115,7 @@ func main() {
 		sharedGwInformers.Gateway().V1().GatewayClasses(),
 		sharedGwInformers.Gateway().V1().Gateways(),
 		sharedGwInformers.Gateway().V1().HTTPRoutes(),
+		sharedGwInformers.Gateway().V1beta1().ReferenceGrants(),
 		sharedAgenticInformers.Agentic().V0alpha0().XBackends(),
 		sharedAgenticInformers.Agentic().V0alpha0().XAccessPolicies())
 	if err != nil {

--- a/k8s/deploy/deployment.yaml
+++ b/k8s/deploy/deployment.yaml
@@ -19,7 +19,7 @@ rules:
     resources: ["namespaces", "secrets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gatewayclasses", "gateways", "httproutes"]
+    resources: ["gatewayclasses", "gateways", "httproutes", "referencegrants"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gatewayclasses/status", "gateways/status", "httproutes/status"]

--- a/pkg/controller/gateway.go
+++ b/pkg/controller/gateway.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -41,9 +42,11 @@ func (c *Controller) setupGatewayEventHandlers(gatewayInformer gatewayinformers.
 
 func (c *Controller) onGatewayAdd(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-	if err == nil {
-		c.gatewayqueue.Add(key)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("couldn't get key for Gateway: %w", err))
+		return
 	}
+	c.gatewayqueue.Add(key)
 	klog.V(4).InfoS("Gateway added", "gateway", key)
 }
 

--- a/pkg/controller/service_test.go
+++ b/pkg/controller/service_test.go
@@ -1,0 +1,358 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewaylisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1"
+	gatewaylistersv1beta1 "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1beta1"
+
+	agenticv0alpha0 "sigs.k8s.io/kube-agentic-networking/api/v0alpha0"
+	agenticlisters "sigs.k8s.io/kube-agentic-networking/k8s/client/listers/api/v0alpha0"
+)
+
+// Test helper: build a minimal Controller that has only the dependencies needed for enqueueGatewaysForService.
+func testControllerForEnqueueGatewaysForService(
+	httpRouteIndexer cache.Indexer,
+	referenceGrantIndexer cache.Indexer,
+	backendIndexer cache.Indexer,
+) *Controller {
+	return &Controller{
+		gateway: gatewayResources{
+			httprouteLister:      gatewaylisters.NewHTTPRouteLister(httpRouteIndexer),
+			referenceGrantLister: gatewaylistersv1beta1.NewReferenceGrantLister(referenceGrantIndexer),
+		},
+		agentic: agenticNetResources{
+			backendLister: agenticlisters.NewXBackendLister(backendIndexer),
+		},
+		gatewayqueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "gateway"},
+		),
+	}
+}
+
+// drainGatewayQueue returns all keys that were added to the gateway queue.
+func drainGatewayQueue(c *Controller) []string {
+	var keys []string
+	for c.gatewayqueue.Len() > 0 {
+		key, shutdown := c.gatewayqueue.Get()
+		if shutdown {
+			break
+		}
+		keys = append(keys, key)
+		c.gatewayqueue.Done(key)
+	}
+	return keys
+}
+
+func TestEnqueueGatewaysForService_DirectHTTPRouteRef(t *testing.T) {
+	ns := "default"
+	svcName := "my-svc"
+	gwName := "my-gateway"
+
+	httpRouteIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	refGrantIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	backendIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: ns},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: gatewayv1.ObjectName(gwName)},
+				},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName(svcName),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	_ = httpRouteIndexer.Add(route)
+
+	c := testControllerForEnqueueGatewaysForService(httpRouteIndexer, refGrantIndexer, backendIndexer)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: ns},
+	}
+
+	c.enqueueGatewaysForService(svc)
+	keys := drainGatewayQueue(c)
+
+	if len(keys) != 1 || keys[0] != ns+"/"+gwName {
+		t.Errorf("expected one gateway key %q, got %v", ns+"/"+gwName, keys)
+	}
+}
+
+func TestEnqueueGatewaysForService_ViaXBackend(t *testing.T) {
+	ns := "default"
+	svcName := "my-svc"
+	gwName := "my-gateway"
+
+	httpRouteIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	refGrantIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	backendIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+	backend := &agenticv0alpha0.XBackend{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-backend", Namespace: ns},
+		Spec: agenticv0alpha0.BackendSpec{
+			MCP: agenticv0alpha0.MCPBackend{
+				ServiceName: ptr.To(svcName),
+				Port:        3000,
+			},
+		},
+	}
+	_ = backendIndexer.Add(backend)
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: ns},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: gatewayv1.ObjectName(gwName)},
+				},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name:  gatewayv1.ObjectName("my-backend"),
+									Group: ptr.To(gatewayv1.Group(agenticv0alpha0.GroupName)),
+									Kind:  ptr.To(gatewayv1.Kind("XBackend")),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	_ = httpRouteIndexer.Add(route)
+
+	c := testControllerForEnqueueGatewaysForService(httpRouteIndexer, refGrantIndexer, backendIndexer)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: ns},
+	}
+
+	c.enqueueGatewaysForService(svc)
+	keys := drainGatewayQueue(c)
+
+	if len(keys) != 1 || keys[0] != ns+"/"+gwName {
+		t.Errorf("expected one gateway key %q (via XBackend), got %v", ns+"/"+gwName, keys)
+	}
+}
+
+func TestEnqueueGatewaysForService_NoRefs_EnqueuesNothing(t *testing.T) {
+	ns := "default"
+	httpRouteIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	refGrantIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	backendIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+	c := testControllerForEnqueueGatewaysForService(httpRouteIndexer, refGrantIndexer, backendIndexer)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "orphan-svc", Namespace: ns},
+	}
+
+	c.enqueueGatewaysForService(svc)
+	keys := drainGatewayQueue(c)
+
+	if len(keys) != 0 {
+		t.Errorf("expected no gateway keys when no routes/backends reference the service, got %v", keys)
+	}
+}
+
+func TestEnqueueGatewaysForService_SkipsXBackendRefInDirectPath(t *testing.T) {
+	ns := "default"
+	svcName := "my-svc"
+	gwName := "my-gateway"
+
+	httpRouteIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	refGrantIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	backendIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+	// Route that references an XBackend named like the service.
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: ns},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: gatewayv1.ObjectName(gwName)},
+				},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name:  gatewayv1.ObjectName(svcName),
+									Group: ptr.To(gatewayv1.Group(agenticv0alpha0.GroupName)),
+									Kind:  ptr.To(gatewayv1.Kind("XBackend")),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	_ = httpRouteIndexer.Add(route)
+
+	c := testControllerForEnqueueGatewaysForService(httpRouteIndexer, refGrantIndexer, backendIndexer)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: ns},
+	}
+
+	c.enqueueGatewaysForServiceDirectHTTPRouteRefs(svc)
+	keys := drainGatewayQueue(c)
+
+	if len(keys) != 0 {
+		t.Errorf("expected no gateway keys from direct path when route references XBackend with same name, got %v", keys)
+	}
+}
+
+func TestEnqueueGatewaysForService_CrossNamespaceRef_RequiresReferenceGrant(t *testing.T) {
+	routeNS := "foo"
+	backendNS := "bar"
+	svcName := "bar-svc"
+	gwName := "my-gateway"
+
+	httpRouteIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	refGrantIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	backendIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+	// HTTPRoute in foo references Service bar-svc in bar.
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: routeNS},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: gatewayv1.ObjectName(gwName)},
+				},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name:      gatewayv1.ObjectName(svcName),
+									Namespace: ptr.To(gatewayv1.Namespace(backendNS)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	_ = httpRouteIndexer.Add(route)
+
+	// ReferenceGrant in bar allowing HTTPRoutes from foo to reference Services.
+	refGrant := &gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{Name: "allow-foo", Namespace: backendNS},
+		Spec: gatewayv1beta1.ReferenceGrantSpec{
+			From: []gatewayv1beta1.ReferenceGrantFrom{
+				{
+					Group:     gatewayv1beta1.Group(gatewayv1.GroupName),
+					Kind:      gatewayv1beta1.Kind("HTTPRoute"),
+					Namespace: gatewayv1beta1.Namespace(routeNS),
+				},
+			},
+			To: []gatewayv1beta1.ReferenceGrantTo{
+				{Group: gatewayv1beta1.Group(""), Kind: gatewayv1beta1.Kind("Service")},
+			},
+		},
+	}
+	_ = refGrantIndexer.Add(refGrant)
+
+	c := testControllerForEnqueueGatewaysForService(httpRouteIndexer, refGrantIndexer, backendIndexer)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: backendNS},
+	}
+
+	c.enqueueGatewaysForService(svc)
+	keys := drainGatewayQueue(c)
+
+	if len(keys) != 1 || keys[0] != routeNS+"/"+gwName {
+		t.Errorf("expected one gateway key %q when ReferenceGrant allows cross-namespace ref, got %v", routeNS+"/"+gwName, keys)
+	}
+}
+
+func TestEnqueueGatewaysForService_CrossNamespaceRef_WithoutReferenceGrant_EnqueuesNothing(t *testing.T) {
+	routeNS := "foo"
+	backendNS := "bar"
+	svcName := "bar-svc"
+
+	httpRouteIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	refGrantIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	backendIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+	// HTTPRoute in foo references Service in bar, but no ReferenceGrant.
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: routeNS},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name:      gatewayv1.ObjectName(svcName),
+									Namespace: ptr.To(gatewayv1.Namespace(backendNS)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	_ = httpRouteIndexer.Add(route)
+
+	c := testControllerForEnqueueGatewaysForService(httpRouteIndexer, refGrantIndexer, backendIndexer)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: backendNS},
+	}
+
+	c.enqueueGatewaysForServiceDirectHTTPRouteRefs(svc)
+	keys := drainGatewayQueue(c)
+
+	if len(keys) != 0 {
+		t.Errorf("expected no gateway keys when cross-namespace ref has no ReferenceGrant, got %v", keys)
+	}
+}

--- a/pkg/translator/referencegrant.go
+++ b/pkg/translator/referencegrant.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translator
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewaylistersv1beta1 "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1beta1"
+)
+
+// AllowedByReferenceGrant returns true if an HTTPRoute in routeNamespace is allowed
+// to reference a Service in backendNamespace per the Gateway API ReferenceGrant spec.
+// See https://gateway-api.sigs.k8s.io/api-types/referencegrant/
+func AllowedByReferenceGrant(
+	routeNamespace, backendNamespace string,
+	referenceGrantLister gatewaylistersv1beta1.ReferenceGrantLister,
+) bool {
+	if routeNamespace == backendNamespace {
+		return true
+	}
+	grants, err := referenceGrantLister.ReferenceGrants(backendNamespace).List(labels.Everything())
+	if err != nil {
+		return false
+	}
+	for _, g := range grants {
+		for _, from := range g.Spec.From {
+			if string(from.Namespace) != routeNamespace {
+				continue
+			}
+			if string(from.Group) != gatewayv1.GroupName {
+				continue
+			}
+			if string(from.Kind) != "HTTPRoute" {
+				continue
+			}
+			for _, to := range g.Spec.To {
+				// Core Services: empty group
+				if string(to.Group) != "" {
+					continue
+				}
+				if string(to.Kind) != "Service" {
+					continue
+				}
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -56,15 +56,15 @@ func TestControllerE2E(t *testing.T) {
 	t.Log("Waiting for resources to be ready...")
 	runKubectl(t, "wait", "--for=condition=Ready", "pod/e2e-tester", "-n", "e2e-test-ns", "--timeout=2m")
 	runKubectl(t, "wait", "--for=condition=available", "deployment/mcp-everything", "-n", "e2e-test-ns", "--timeout=2m")
-	// Wait for Gateway to be programmed and proxy to be up
+	// Wait for Gateway to be programmed and proxy to be up.
 	var proxyPodName string
 	err := retry(20, 5*time.Second, func() error {
-		// Find the pod using the standard gateway-name label
-		out := runKubectlOutput(t, "get", "pods", "-n", "e2e-test-ns", "-l", fmt.Sprintf("%s=e2e-gateway", constants.GatewayNameLabel), "-o", "jsonpath={.items[0].metadata.name}")
-		if out == "" {
+		out := runKubectlOutput(t, "get", "pods", "-n", "e2e-test-ns", "-l", fmt.Sprintf("%s=e2e-gateway", constants.GatewayNameLabel), "-o", "jsonpath={.items[*].metadata.name}")
+		names := strings.Fields(strings.TrimSpace(out))
+		if len(names) == 0 {
 			return fmt.Errorf("envoy proxy pod not found")
 		}
-		proxyPodName = out
+		proxyPodName = names[0]
 		return nil
 	})
 
@@ -77,11 +77,12 @@ func TestControllerE2E(t *testing.T) {
 	t.Log("Verifying Gateway status address and capturing IP...")
 	var gatewayIP string
 	err = retry(20, 2*time.Second, func() error {
-		out := runKubectlOutput(t, "get", "gateway", "e2e-gateway", "-n", "e2e-test-ns", "-o", "jsonpath={.status.addresses[0].value}")
-		if out == "" {
+		out := runKubectlOutput(t, "get", "gateway", "e2e-gateway", "-n", "e2e-test-ns", "-o", "jsonpath={.status.addresses[*].value}")
+		values := strings.Fields(strings.TrimSpace(out))
+		if len(values) == 0 {
 			return fmt.Errorf("gateway status address not found")
 		}
-		gatewayIP = out
+		gatewayIP = values[0]
 		t.Logf("Found Gateway status address: %s", gatewayIP)
 		return nil
 	})


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR implements enqueueGatewaysForService so that Gateway reconciliation runs when backend Services change. A change to a Service can affect Gateways in two ways: via HTTPRoutes that reference the Service, and via XBackends that reference the Service and are themselves referenced by HTTPRoutes. This implementation wires Service events into the Gateway reconciliation flow for both cases.

On Service add/update/delete, the controller now:
- Direct Service refs – Finds HTTPRoutes (across all namespaces) whose backendRefs reference this Service and enqueues their Gateways via enqueueGatewaysForHTTPRoute.
- Service via XBackend – Finds XBackends in the Service’s namespace whose spec.mcp.serviceName equals the Service name, then for each such XBackend calls enqueueGatewaysForBackend so Gateways for HTTPRoutes that use that XBackend are enqueued.

Added below test cases:
1. TestEnqueueGatewaysForService_DirectHTTPRouteRef - Ensures when a Service is referenced directly in an HTTPRoute, enqueueGatewaysForService enqueues the right Gateway.
2. TestEnqueueGatewaysForService_ViaXBackend - Ensures when a Service is referenced via an XBackend (spec.mcp.serviceName), enqueueGatewaysForService enqueues the right Gateway.
3. TestEnqueueGatewaysForService_NoRefs_EnqueuesNothing - Ensures no Gateways are enqueued when nothing references the Service.
4. TestEnqueueGatewaysForService_SkipsXBackendRefInDirectPath - Ensures the direct path only treats core Service refs as direct and does not treat an XBackend ref(even with the same name as the Service) as a direct Service ref.

**Which issue(s) this PR fixes**:
Fixes #47

```release-note
Implemented enqueueGatewaysForService with HTTPRoute backend matching
```
