### PR TITLE
Remove obsolete command from quickstart guide

### DIFF
--- a/quickstart/quickstart.md
+++ b/quickstart/quickstart.md
@@ -66,7 +66,6 @@ Before you begin, ensure you have the following tools installed and configured:
   ```shell
   git clone https://github.com/kubernetes-sigs/kube-agentic-networking.git
   cd kube-agentic-networking
-  git switch mvp-quickstart
   ```
 
 ## 2. Set Up the Kubernetes Environment


### PR DESCRIPTION
`mvp-quickstart` branch does not exist.



**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind cleanup


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
