### PR TITLE
gatewayclass-validation

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -275,6 +275,14 @@ func (c *Controller) syncHandler(ctx context.Context, key string) error {
 		return err
 	}
 
+	// Only reconcile Gateways whose spec.gatewayClassName refers to a GatewayClass
+	if !c.isGatewayOwnedByController(gateway) {
+		logger.V(4).Info("Skipping Gateway: not owned by this controller (GatewayClass controllerName mismatch or GatewayClass not found)",
+			"gateway", klog.KRef(gateway.Namespace, gateway.Name),
+			"gatewayClassName", string(gateway.Spec.GatewayClassName))
+		return nil
+	}
+
 	logger.Info("Syncing gateway")
 
 	// Ensure Envoy proxy deployment and service exist.

--- a/pkg/controller/gatewayclass.go
+++ b/pkg/controller/gatewayclass.go
@@ -92,3 +92,17 @@ func (c *Controller) syncGatewayClass(key string) {
 		klog.InfoS("GatewayClass status updated", "gatewayclass", key)
 	}
 }
+
+// gateway class validation
+func (c *Controller) isGatewayOwnedByController(gateway *gatewayv1.Gateway) bool {
+	gwc, err := c.gateway.gatewayClassLister.Get(string(gateway.Spec.GatewayClassName))
+	if err != nil || gwc == nil {
+		if err != nil {
+			klog.V(4).ErrorS(err, "GatewayClass lookup failed for Gateway",
+				"gateway", klog.KObj(gateway),
+				"gatewayClassName", string(gateway.Spec.GatewayClassName))
+		}
+		return false
+	}
+	return gwc.Spec.ControllerName == constants.ControllerName
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
When reconciling a Gateway, the controller did not check that the Gateway’s spec.gatewayClassName referred to a GatewayClass this controller is responsible for. It reconciled every Gateway it saw, including those meant for other controllers.
This PR adds that validation: the controller now reconciles only Gateways whose spec.gatewayClassName points to a GatewayClass whose spec.controllerName equals this controller’s name. Gateways that reference a different GatewayClass or a missing/invalid one are skipped (no reconciliation).

**Which issue(s) this PR fixes**:
Fixes #89

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
