### PR TITLE
Handling resource deletion or modification of dependent object

### DIFF
--- a/pkg/constants/controller.go
+++ b/pkg/constants/controller.go
@@ -28,4 +28,13 @@ const (
 
 	// XDSServerServiceName is the name of the Service that exposes the xDS server.
 	XDSServerServiceName = "agentic-net-xds-server"
+
+	// Finalizers: block deletion until no dependents reference the resource.
+
+	// GatewayClassFinalizer is set on GatewayClass; removed when no Gateways use this class.
+	GatewayClassFinalizer = ProjectName + "/gatewayclass-finalizer"
+	// GatewayFinalizer is set on Gateway; removed when no HTTPRoutes reference it and proxy is cleaned up.
+	GatewayFinalizer = ProjectName + "/gateway-finalizer"
+	// XBackendFinalizer is set on XBackend; removed when no XAccessPolicy targets it.
+	XBackendFinalizer = ProjectName + "/xbackend-finalizer"
 )

--- a/pkg/controller/accesspolicy.go
+++ b/pkg/controller/accesspolicy.go
@@ -73,8 +73,8 @@ func (c *Controller) onAccessPolicyDelete(obj interface{}) {
 	c.enqueueGatewaysForAccessPolicy(policy)
 }
 
-// TODO: When an AccessPolicy is deleted, we need to consider how to handle the gateway reconcile
-// i.e. recalculating the xDS configuration without this AccessPolicy.
+// enqueueGatewaysForAccessPolicy enqueues Gateways so they are reconciled; when an
+// XAccessPolicy is deleted this ensures stale policy rules are removed from Envoy/xDS config.
 func (c *Controller) enqueueGatewaysForAccessPolicy(policy *agenticv0alpha0.XAccessPolicy) {
 	for _, targetRef := range policy.Spec.TargetRefs {
 		if !isXBackendTargetRef(targetRef) {

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -17,9 +17,12 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -28,6 +31,7 @@ import (
 
 	agenticv0alpha0 "sigs.k8s.io/kube-agentic-networking/api/v0alpha0"
 	agenticinformers "sigs.k8s.io/kube-agentic-networking/k8s/client/informers/externalversions/api/v0alpha0"
+	"sigs.k8s.io/kube-agentic-networking/pkg/constants"
 )
 
 func (c *Controller) setupBackendEventHandlers(backendInformer agenticinformers.XBackendInformer) error {
@@ -42,6 +46,7 @@ func (c *Controller) setupBackendEventHandlers(backendInformer agenticinformers.
 func (c *Controller) onBackendAdd(obj interface{}) {
 	backend := obj.(*agenticv0alpha0.XBackend)
 	klog.V(4).InfoS("Adding Backend", "backend", klog.KObj(backend))
+	c.enqueueBackendForFinalizer(backend)
 	c.enqueueGatewaysForBackend(backend)
 }
 
@@ -50,6 +55,7 @@ func (c *Controller) onBackendUpdate(old, new interface{}) {
 	newBackend := new.(*agenticv0alpha0.XBackend)
 	if newBackend.Generation != oldBackend.Generation || newBackend.DeletionTimestamp != oldBackend.DeletionTimestamp || !reflect.DeepEqual(newBackend.Annotations, oldBackend.Annotations) {
 		klog.V(4).InfoS("Updating Backend", "backend", klog.KObj(oldBackend))
+		c.enqueueBackendForFinalizer(newBackend)
 		c.enqueueGatewaysForBackend(newBackend)
 	}
 }
@@ -69,11 +75,75 @@ func (c *Controller) onBackendDelete(obj interface{}) {
 		}
 	}
 	klog.V(4).InfoS("Deleting Backend", "backend", klog.KObj(backend))
+	c.enqueueBackendForFinalizer(backend)
 	c.enqueueGatewaysForBackend(backend)
 }
 
-// TODO: When a Backend is deleted, we need to consider how to handle the gateway reconcile.
-// i.e. recalculating the xDS configuration without this Backend.
+// enqueueBackendForFinalizer enqueues the XBackend for finalizer sync only (add/remove finalizer based on XAccessPolicy targetRefs). It does not enqueue Gateways.
+func (c *Controller) enqueueBackendForFinalizer(backend *agenticv0alpha0.XBackend) {
+	key := backend.Namespace + "/" + backend.Name
+	c.backendFinalizerQueue.Add(key)
+}
+
+// syncBackendFinalizer manages the XBackend finalizer.
+func (c *Controller) syncBackendFinalizer(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("invalid backend key %s: %w", key, err))
+		return nil
+	}
+	backend, err := c.agentic.backendLister.XBackends(namespace).Get(name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	newBackend := backend.DeepCopy()
+
+	if backend.DeletionTimestamp != nil {
+		if hasAccessPoliciesTargetingBackend(c, backend) {
+			klog.V(4).InfoS("XBackend has XAccessPolicies still targeting it, blocking deletion", "backend", klog.KObj(backend))
+			return nil
+		}
+		if removeFinalizer(&newBackend.ObjectMeta, constants.XBackendFinalizer) {
+			if _, err := c.agentic.client.AgenticV0alpha0().XBackends(namespace).Update(ctx, newBackend, metav1.UpdateOptions{}); err != nil {
+				return fmt.Errorf("failed to remove finalizer from XBackend: %w", err)
+			}
+		}
+		return nil
+	}
+
+	if ensureFinalizer(&newBackend.ObjectMeta, constants.XBackendFinalizer) {
+		if _, err := c.agentic.client.AgenticV0alpha0().XBackends(namespace).Update(ctx, newBackend, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to add finalizer to XBackend: %w", err)
+		}
+	}
+	return nil
+}
+
+// hasAccessPoliciesTargetingBackend returns true if any XAccessPolicy has a targetRef to the given backend.
+func hasAccessPoliciesTargetingBackend(c *Controller, backend *agenticv0alpha0.XBackend) bool {
+	policies, err := c.agentic.accessPolicyLister.XAccessPolicies(backend.Namespace).List(labels.Everything())
+	if err != nil {
+		klog.V(4).ErrorS(err, "failed to list XAccessPolicies for XBackend finalizer")
+		return true
+	}
+	for _, policy := range policies {
+		for _, targetRef := range policy.Spec.TargetRefs {
+			if !isXBackendTargetRef(targetRef) {
+				// TODO: Set status condition on AccessPolicy to indicate unsupported targetRef.
+				continue
+			}
+			if string(targetRef.Name) == backend.Name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// enqueueGatewaysForBackend enqueues Gateways that reference this backend
 func (c *Controller) enqueueGatewaysForBackend(backend *agenticv0alpha0.XBackend) {
 	routes, err := c.gateway.httprouteLister.List(labels.Everything())
 	if err != nil {

--- a/pkg/controller/backend_test.go
+++ b/pkg/controller/backend_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	agenticv0alpha0 "sigs.k8s.io/kube-agentic-networking/api/v0alpha0"
+	agenticlisters "sigs.k8s.io/kube-agentic-networking/k8s/client/listers/api/v0alpha0"
+)
+
+func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
+	ns := "default"
+	backendName := "my-backend"
+
+	t.Run("no policies in namespace", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		c := &Controller{
+			agentic: agenticNetResources{
+				accessPolicyLister: agenticlisters.NewXAccessPolicyLister(indexer),
+			},
+		}
+		backend := &agenticv0alpha0.XBackend{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: backendName},
+		}
+		if hasAccessPoliciesTargetingBackend(c, backend) {
+			t.Error("expected false when no policies exist in namespace")
+		}
+	})
+
+	t.Run("policy targets different backend", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		policy := &agenticv0alpha0.XAccessPolicy{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "policy-1"},
+			Spec: agenticv0alpha0.AccessPolicySpec{
+				TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+					{
+						LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+							Group: agenticv0alpha0.GroupName,
+							Kind:  "XBackend",
+							Name:  gatewayv1.ObjectName("other-backend"),
+						},
+					},
+				},
+				Rules: []agenticv0alpha0.AccessRule{{Name: "rule1"}},
+			},
+		}
+		if err := indexer.Add(policy); err != nil {
+			t.Fatalf("indexer.Add: %v", err)
+		}
+		c := &Controller{
+			agentic: agenticNetResources{
+				accessPolicyLister: agenticlisters.NewXAccessPolicyLister(indexer),
+			},
+		}
+		backend := &agenticv0alpha0.XBackend{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: backendName},
+		}
+		if hasAccessPoliciesTargetingBackend(c, backend) {
+			t.Error("expected false when policy targets a different backend")
+		}
+	})
+
+	t.Run("policy targets this backend", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		policy := &agenticv0alpha0.XAccessPolicy{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "policy-1"},
+			Spec: agenticv0alpha0.AccessPolicySpec{
+				TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+					{
+						LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+							Group: agenticv0alpha0.GroupName,
+							Kind:  "XBackend",
+							Name:  gatewayv1.ObjectName(backendName),
+						},
+					},
+				},
+				Rules: []agenticv0alpha0.AccessRule{{Name: "rule1"}},
+			},
+		}
+		if err := indexer.Add(policy); err != nil {
+			t.Fatalf("indexer.Add: %v", err)
+		}
+		c := &Controller{
+			agentic: agenticNetResources{
+				accessPolicyLister: agenticlisters.NewXAccessPolicyLister(indexer),
+			},
+		}
+		backend := &agenticv0alpha0.XBackend{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: backendName},
+		}
+		if !hasAccessPoliciesTargetingBackend(c, backend) {
+			t.Error("expected true when a policy targets this backend")
+		}
+	})
+
+	t.Run("policy targets this backend by name but wrong group is skipped", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		policy := &agenticv0alpha0.XAccessPolicy{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "policy-1"},
+			Spec: agenticv0alpha0.AccessPolicySpec{
+				TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+					{
+						LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+							Group: "other.group",
+							Kind:  "XBackend",
+							Name:  gatewayv1.ObjectName(backendName),
+						},
+					},
+				},
+				Rules: []agenticv0alpha0.AccessRule{{Name: "rule1"}},
+			},
+		}
+		if err := indexer.Add(policy); err != nil {
+			t.Fatalf("indexer.Add: %v", err)
+		}
+		c := &Controller{
+			agentic: agenticNetResources{
+				accessPolicyLister: agenticlisters.NewXAccessPolicyLister(indexer),
+			},
+		}
+		backend := &agenticv0alpha0.XBackend{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: backendName},
+		}
+		if hasAccessPoliciesTargetingBackend(c, backend) {
+			t.Error("expected false when only targetRef has wrong group (not XBackend)")
+		}
+	})
+
+	t.Run("multiple targetRefs one matches backend", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		policy := &agenticv0alpha0.XAccessPolicy{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "policy-1"},
+			Spec: agenticv0alpha0.AccessPolicySpec{
+				TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+					{
+						LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+							Group: agenticv0alpha0.GroupName,
+							Kind:  "XBackend",
+							Name:  gatewayv1.ObjectName("other-backend"),
+						},
+					},
+					{
+						LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+							Group: agenticv0alpha0.GroupName,
+							Kind:  "XBackend",
+							Name:  gatewayv1.ObjectName(backendName),
+						},
+					},
+				},
+				Rules: []agenticv0alpha0.AccessRule{{Name: "rule1"}},
+			},
+		}
+		if err := indexer.Add(policy); err != nil {
+			t.Fatalf("indexer.Add: %v", err)
+		}
+		c := &Controller{
+			agentic: agenticNetResources{
+				accessPolicyLister: agenticlisters.NewXAccessPolicyLister(indexer),
+			},
+		}
+		backend := &agenticv0alpha0.XBackend{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: backendName},
+		}
+		if !hasAccessPoliciesTargetingBackend(c, backend) {
+			t.Error("expected true when one targetRef matches this backend")
+		}
+	})
+}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewaylisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1"
+)
+
+func TestHasHTTPRoutesReferencingGateway(t *testing.T) {
+	gwNamespace := "default"
+	gwName := "my-gateway"
+
+	t.Run("no routes", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		c := &Controller{
+			gateway: gatewayResources{
+				httprouteLister: gatewaylisters.NewHTTPRouteLister(indexer),
+			},
+		}
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: gwName},
+		}
+		if hasHTTPRoutesReferencingGateway(c, gw) {
+			t.Error("expected false when no HTTPRoutes exist")
+		}
+	})
+
+	t.Run("route with no parentRefs", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: "route-1"},
+			Spec:       gatewayv1.HTTPRouteSpec{},
+		}
+		if err := indexer.Add(route); err != nil {
+			t.Fatalf("indexer.Add: %v", err)
+		}
+		c := &Controller{
+			gateway: gatewayResources{
+				httprouteLister: gatewaylisters.NewHTTPRouteLister(indexer),
+			},
+		}
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: gwName},
+		}
+		if hasHTTPRoutesReferencingGateway(c, gw) {
+			t.Error("expected false when route has no parentRefs")
+		}
+	})
+
+	t.Run("route references different gateway", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: "route-1"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName("other-gateway")},
+					},
+				},
+			},
+		}
+		if err := indexer.Add(route); err != nil {
+			t.Fatalf("indexer.Add: %v", err)
+		}
+		c := &Controller{
+			gateway: gatewayResources{
+				httprouteLister: gatewaylisters.NewHTTPRouteLister(indexer),
+			},
+		}
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: gwName},
+		}
+		if hasHTTPRoutesReferencingGateway(c, gw) {
+			t.Error("expected false when route references a different gateway")
+		}
+	})
+
+	t.Run("route references this gateway (same namespace)", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: "route-1"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(gwName)},
+					},
+				},
+			},
+		}
+		if err := indexer.Add(route); err != nil {
+			t.Fatalf("indexer.Add: %v", err)
+		}
+		c := &Controller{
+			gateway: gatewayResources{
+				httprouteLister: gatewaylisters.NewHTTPRouteLister(indexer),
+			},
+		}
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: gwName},
+		}
+		if !hasHTTPRoutesReferencingGateway(c, gw) {
+			t.Error("expected true when route references this gateway in same namespace")
+		}
+	})
+
+	t.Run("route in other namespace references this gateway via parentRef.Namespace", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "other-ns", Name: "route-1"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Name:      gatewayv1.ObjectName(gwName),
+							Namespace: ptrGatewayNamespace(gwNamespace),
+						},
+					},
+				},
+			},
+		}
+		if err := indexer.Add(route); err != nil {
+			t.Fatalf("indexer.Add: %v", err)
+		}
+		c := &Controller{
+			gateway: gatewayResources{
+				httprouteLister: gatewaylisters.NewHTTPRouteLister(indexer),
+			},
+		}
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: gwName},
+		}
+		if !hasHTTPRoutesReferencingGateway(c, gw) {
+			t.Error("expected true when route in other namespace references this gateway via parentRef.Namespace")
+		}
+	})
+
+	t.Run("route has wrong Group in parentRef", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		otherGroup := gatewayv1.Group("other.group")
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: "route-1"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Group: &otherGroup,
+							Kind:  ptrGatewayKind("Gateway"),
+							Name:  gatewayv1.ObjectName(gwName),
+						},
+					},
+				},
+			},
+		}
+		if err := indexer.Add(route); err != nil {
+			t.Fatalf("indexer.Add: %v", err)
+		}
+		c := &Controller{
+			gateway: gatewayResources{
+				httprouteLister: gatewaylisters.NewHTTPRouteLister(indexer),
+			},
+		}
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: gwName},
+		}
+		if hasHTTPRoutesReferencingGateway(c, gw) {
+			t.Error("expected false when parentRef has wrong Group")
+		}
+	})
+
+	t.Run("multiple parentRefs one references this gateway", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: "route-1"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName("other-gateway")},
+						{Name: gatewayv1.ObjectName(gwName)},
+					},
+				},
+			},
+		}
+		if err := indexer.Add(route); err != nil {
+			t.Fatalf("indexer.Add: %v", err)
+		}
+		c := &Controller{
+			gateway: gatewayResources{
+				httprouteLister: gatewaylisters.NewHTTPRouteLister(indexer),
+			},
+		}
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: gwName},
+		}
+		if !hasHTTPRoutesReferencingGateway(c, gw) {
+			t.Error("expected true when one parentRef references this gateway")
+		}
+	})
+}
+
+func ptrGatewayNamespace(ns string) *gatewayv1.Namespace {
+	n := gatewayv1.Namespace(ns)
+	return &n
+}
+
+func ptrGatewayKind(kind string) *gatewayv1.Kind {
+	k := gatewayv1.Kind(kind)
+	return &k
+}

--- a/pkg/controller/finalizers.go
+++ b/pkg/controller/finalizers.go
@@ -1,0 +1,53 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// ensureFinalizer adds the given finalizer to objectMeta if not present.
+func ensureFinalizer(objectMeta *metav1.ObjectMeta, finalizer string) bool {
+	if objectMeta.Finalizers == nil {
+		objectMeta.Finalizers = []string{finalizer}
+		return true
+	}
+	if sets.New(objectMeta.Finalizers...).Has(finalizer) {
+		return false
+	}
+	objectMeta.Finalizers = append(objectMeta.Finalizers, finalizer)
+	return true
+}
+
+// removeFinalizer removes the given finalizer from objectMeta if present.
+func removeFinalizer(objectMeta *metav1.ObjectMeta, finalizer string) bool {
+	if objectMeta.Finalizers == nil {
+		return false
+	}
+	newFinalizers := make([]string, 0, len(objectMeta.Finalizers))
+	for _, f := range objectMeta.Finalizers {
+		if f != finalizer {
+			newFinalizers = append(newFinalizers, f)
+		}
+	}
+	if len(newFinalizers) == len(objectMeta.Finalizers) {
+		return false
+	}
+	objectMeta.Finalizers = newFinalizers
+	return true
+}

--- a/pkg/controller/finalizers_test.go
+++ b/pkg/controller/finalizers_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const testFinalizer = "test.example.com/finalizer"
+
+func TestEnsureFinalizer(t *testing.T) {
+	t.Run("nil finalizers", func(t *testing.T) {
+		obj := &metav1.ObjectMeta{}
+		changed := ensureFinalizer(obj, testFinalizer)
+		if !changed {
+			t.Error("expected true when Finalizers was nil")
+		}
+		if len(obj.Finalizers) != 1 || obj.Finalizers[0] != testFinalizer {
+			t.Errorf("expected Finalizers to be [%q], got %v", testFinalizer, obj.Finalizers)
+		}
+	})
+
+	t.Run("empty finalizers slice", func(t *testing.T) {
+		obj := &metav1.ObjectMeta{Finalizers: []string{}}
+		changed := ensureFinalizer(obj, testFinalizer)
+		if !changed {
+			t.Error("expected true when Finalizers was empty")
+		}
+		if len(obj.Finalizers) != 1 || obj.Finalizers[0] != testFinalizer {
+			t.Errorf("expected Finalizers to be [%q], got %v", testFinalizer, obj.Finalizers)
+		}
+	})
+
+	t.Run("finalizer already present", func(t *testing.T) {
+		obj := &metav1.ObjectMeta{Finalizers: []string{testFinalizer}}
+		changed := ensureFinalizer(obj, testFinalizer)
+		if changed {
+			t.Error("expected false when finalizer already present")
+		}
+		if len(obj.Finalizers) != 1 || obj.Finalizers[0] != testFinalizer {
+			t.Errorf("expected Finalizers unchanged [%q], got %v", testFinalizer, obj.Finalizers)
+		}
+	})
+
+	t.Run("other finalizers present, add new one", func(t *testing.T) {
+		obj := &metav1.ObjectMeta{Finalizers: []string{"other.example.com/keep"}}
+		changed := ensureFinalizer(obj, testFinalizer)
+		if !changed {
+			t.Error("expected true when adding new finalizer")
+		}
+		if len(obj.Finalizers) != 2 {
+			t.Errorf("expected 2 finalizers, got %v", obj.Finalizers)
+		}
+		has := false
+		for _, f := range obj.Finalizers {
+			if f == testFinalizer {
+				has = true
+				break
+			}
+		}
+		if !has {
+			t.Errorf("expected %q in Finalizers, got %v", testFinalizer, obj.Finalizers)
+		}
+	})
+}
+
+func TestRemoveFinalizer(t *testing.T) {
+	t.Run("nil finalizers", func(t *testing.T) {
+		obj := &metav1.ObjectMeta{}
+		changed := removeFinalizer(obj, testFinalizer)
+		if changed {
+			t.Error("expected false when Finalizers was nil")
+		}
+		if obj.Finalizers != nil {
+			t.Errorf("expected Finalizers to stay nil, got %v", obj.Finalizers)
+		}
+	})
+
+	t.Run("empty finalizers slice", func(t *testing.T) {
+		obj := &metav1.ObjectMeta{Finalizers: []string{}}
+		changed := removeFinalizer(obj, testFinalizer)
+		if changed {
+			t.Error("expected false when Finalizers was empty")
+		}
+		if len(obj.Finalizers) != 0 {
+			t.Errorf("expected Finalizers unchanged [], got %v", obj.Finalizers)
+		}
+	})
+
+	t.Run("finalizer not in list", func(t *testing.T) {
+		obj := &metav1.ObjectMeta{Finalizers: []string{"other.example.com/keep"}}
+		changed := removeFinalizer(obj, testFinalizer)
+		if changed {
+			t.Error("expected false when finalizer not present")
+		}
+		if len(obj.Finalizers) != 1 || obj.Finalizers[0] != "other.example.com/keep" {
+			t.Errorf("expected Finalizers unchanged, got %v", obj.Finalizers)
+		}
+	})
+
+	t.Run("finalizer only one in list", func(t *testing.T) {
+		obj := &metav1.ObjectMeta{Finalizers: []string{testFinalizer}}
+		changed := removeFinalizer(obj, testFinalizer)
+		if !changed {
+			t.Error("expected true when removing the only finalizer")
+		}
+		if len(obj.Finalizers) != 0 {
+			t.Errorf("expected empty Finalizers, got %v", obj.Finalizers)
+		}
+	})
+
+	t.Run("finalizer one of several", func(t *testing.T) {
+		obj := &metav1.ObjectMeta{
+			Finalizers: []string{"first.example.com/f", testFinalizer, "last.example.com/l"},
+		}
+		changed := removeFinalizer(obj, testFinalizer)
+		if !changed {
+			t.Error("expected true when removing finalizer from list")
+		}
+		if len(obj.Finalizers) != 2 {
+			t.Errorf("expected 2 finalizers left, got %v", obj.Finalizers)
+		}
+		for _, f := range obj.Finalizers {
+			if f == testFinalizer {
+				t.Errorf("expected %q removed from Finalizers, got %v", testFinalizer, obj.Finalizers)
+				break
+			}
+		}
+	})
+}

--- a/pkg/controller/gatewayclass_test.go
+++ b/pkg/controller/gatewayclass_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewaylisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1"
+)
+
+func TestHasGatewaysReferencingClass(t *testing.T) {
+	className := "my-gateway-class"
+
+	t.Run("no gateways", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		c := &Controller{
+			gateway: gatewayResources{
+				gatewayLister: gatewaylisters.NewGatewayLister(indexer),
+			},
+		}
+		if hasGatewaysReferencingClass(c, className) {
+			t.Error("expected false when no Gateways exist")
+		}
+	})
+
+	t.Run("gateway references different class", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw-1", Namespace: "default"},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: gatewayv1.ObjectName("other-class"),
+				Listeners:        []gatewayv1.Listener{{Name: "l1", Port: 80, Protocol: gatewayv1.HTTPProtocolType}},
+			},
+		}
+		if err := indexer.Add(gw); err != nil {
+			t.Fatalf("indexer.Add: %v", err)
+		}
+		c := &Controller{
+			gateway: gatewayResources{
+				gatewayLister: gatewaylisters.NewGatewayLister(indexer),
+			},
+		}
+		if hasGatewaysReferencingClass(c, className) {
+			t.Error("expected false when Gateway references a different class")
+		}
+	})
+
+	t.Run("gateway references this class", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw-1", Namespace: "default"},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: gatewayv1.ObjectName(className),
+				Listeners:        []gatewayv1.Listener{{Name: "l1", Port: 80, Protocol: gatewayv1.HTTPProtocolType}},
+			},
+		}
+		if err := indexer.Add(gw); err != nil {
+			t.Fatalf("indexer.Add: %v", err)
+		}
+		c := &Controller{
+			gateway: gatewayResources{
+				gatewayLister: gatewaylisters.NewGatewayLister(indexer),
+			},
+		}
+		if !hasGatewaysReferencingClass(c, className) {
+			t.Error("expected true when Gateway references this class")
+		}
+	})
+
+	t.Run("multiple gateways one references this class", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		for i, gwcName := range []string{"other-class", className, "another-class"} {
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw-" + string(rune('a'+i)), Namespace: "default"},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: gatewayv1.ObjectName(gwcName),
+					Listeners:        []gatewayv1.Listener{{Name: "l1", Port: 80, Protocol: gatewayv1.HTTPProtocolType}},
+				},
+			}
+			if err := indexer.Add(gw); err != nil {
+				t.Fatalf("indexer.Add: %v", err)
+			}
+		}
+		c := &Controller{
+			gateway: gatewayResources{
+				gatewayLister: gatewaylisters.NewGatewayLister(indexer),
+			},
+		}
+		if !hasGatewaysReferencingClass(c, className) {
+			t.Error("expected true when one Gateway references this class")
+		}
+	})
+}

--- a/pkg/controller/httproute.go
+++ b/pkg/controller/httproute.go
@@ -70,8 +70,8 @@ func (c *Controller) onHTTPRouteDelete(obj interface{}) {
 	c.enqueueGatewaysForHTTPRoute(route.Spec.ParentRefs, route.Namespace)
 }
 
-// TODO: When an HTTPRoute is deleted, we need to consider how to handle the gateway reconcile
-// i.e. recalculating the xDS configuration without this HTTPRoute.
+// enqueueGatewaysForHTTPRoute enqueues Gateways so they are reconciled; when an HTTPRoute
+// is deleted this ensures stale rules for that route are removed from Envoy/xDS config.
 func (c *Controller) enqueueGatewaysForHTTPRoute(references []gatewayv1.ParentReference, localNamespace string) {
 	gatewaysToEnqueue := make(map[string]struct{})
 	for _, ref := range references {

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -211,7 +211,10 @@ func (t *Translator) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 
 			switch listener.Protocol {
 			case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType:
-				// 5. For each accepted HTTPRoute for this listener -> translate to Envoy routes
+				// For each accepted HTTPRoute for this listener -> translate to Envoy routes.
+				// Backends are only included when referenced by an HTTPRoute BackendRef. If an XBackend
+				// (and optionally XAccessPolicy) exists but no HTTPRoute routes traffic to it, no cluster
+				// or RBAC config is generated for that backend.
 				for _, httpRoute := range routesByListener[listener.Name] {
 					routes, allValidBackends, resolvedRefsCondition := t.translateHTTPRouteToEnvoyRoutes(httpRoute)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR implements handling of resource deletion so that when HTTPRoutes, XAccessPolicies, XBackends, or Services are deleted or updated, Envoy config and Kubernetes state stay correct and dependents are not left dangling.
Implementations

1. Stale Envoy rules
- On add/update/delete of HTTPRoute, XAccessPolicy, XBackend, or Service, the controller enqueues affected Gateways.
- Reconciliation rebuilds xDS from current listers each time. Deleted or changed resources are no longer in the listers, so their rules are dropped from Envoy config automatically.

2. Finalizers (block deletion until safe)
- GatewayClass
Finalizer is added; removed only when no Gateway has spec.gatewayClassName pointing to this class.
- Gateway
Finalizer is added; removed only when no HTTPRoute references it and the Envoy proxy has been deleted.
- XBackend
Dedicated finalizer queue/sync; finalizer removed only when no XAccessPolicy targets this backend.

Finalizer names use the API group (e.g. agentic.prototype.x-k8s.io/gatewayclass, agentic.prototype.x-k8s.io/gateway, agentic.prototype.x-k8s.io/xbackend).

3. Translator: behaviour when XAccessPolicy is “gone”
- When no XAccessPolicy targets a backend (e.g. after the policy is deleted), the translator emits an allow-all RBAC policy for that backend so all tool calls are allowed and old RBAC rules are effectively removed.
- Backends not referenced by any HTTPRoute do not get clusters or RBAC config.

4. Unit tests added
- TestRbacConfigFromAccessPolicy_DeletionBehaviour
Lister has no XAccessPolicy (simulates “policy deleted”). Asserts generated RBAC includes the allow-all policy and standard MCP policies.
- TestRbacConfigFromAccessPolicy_PolicyExists_NoAllowAll
Lister has one XAccessPolicy targeting the backend. Asserts generated RBAC does not include allow-all and does include the policy-derived rule.
Tests use a cache.Indexer-backed lister to simulate “after deletion” vs “policy present” without a full fake client.

**Which issue(s) this PR fixes**:
Fixes #88 

**Does this PR introduce a user-facing change?**:
```release-note
Handling resource deletion or modification of dependent object
```
