### PR TITLE
Define GatewayClass in quickstart/policy/e2e.yaml

### DIFF
--- a/quickstart/policy/e2e.yaml
+++ b/quickstart/policy/e2e.yaml
@@ -1,10 +1,17 @@
 apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: kube-agentic-networking
+spec:
+  controllerName: sigs.k8s.io/kube-agentic-networking-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: agentic-net-gateway
   namespace: quickstart-ns
 spec:
-  gatewayClassName: cloud-provider-kind
+  gatewayClassName: kube-agentic-networking
   listeners:
     - protocol: HTTP
       port: 10001


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind bug
**What this PR does / why we need it**:

https://github.com/kubernetes-sigs/kube-agentic-networking/pull/91 requires a GatewayClass to be defined and referenced by the Gateway.

Without it, the controller will not reconcile the Gateway and will not provision proxy pod for the gateway.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #89 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
