### PR TITLE
Updating the Zoom Meeting Link for the regular working group meeting 

### DIFF
--- a/site-src/contributing/index.md
+++ b/site-src/contributing/index.md
@@ -43,6 +43,6 @@ Our community meetings are held weekly on **Thursday at 4PM UTC** ([convert to y
 
 - [Meeting Notes](https://docs.google.com/document/d/1EQET_VWe_IAINyQhVj-wduZg99gBaObpz9612eZ1iYg/edit?tab=t.0#heading=h.q1zi45aa3n69)
 - [Zoom (client) Meeting Link](https://zoom.us/j/92037420986)
-- [Zoom (web) Meeting Link](https://zoom.us/j/94686253452/join)
+- [Zoom (web) Meeting Link](https://zoom.us/j/92037420986/join)
 
 Meeting agendas and notes are maintained in the [meeting notes](https://docs.google.com/document/d/1EQET_VWe_IAINyQhVj-wduZg99gBaObpz9612eZ1iYg/edit?tab=t.0#heading=h.q1zi45aa3n69) doc. Feel free to add topics for discussion at an upcoming meeting.


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it**:
The Zoom Link is wrong

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Yes the meeting link changes for Zoom
```
