### PR TITLE
Introduce gateway-name label for resource discovery

### DIFF
--- a/pkg/constants/controller.go
+++ b/pkg/constants/controller.go
@@ -17,6 +17,9 @@ limitations under the License.
 package constants
 
 const (
+	// ProjectName is the name of the project.
+	ProjectName = "kube-agentic-networking.sigs.k8s.io"
+
 	// ControllerName is the name of the controller used in GatewayClass resources.
 	ControllerName = "sigs.k8s.io/kube-agentic-networking-controller"
 

--- a/pkg/constants/envoynames.go
+++ b/pkg/constants/envoynames.go
@@ -38,4 +38,7 @@ const (
 
 	// EnvoyBootstrapMountPath is the path where the Envoy bootstrap configuration is mounted.
 	EnvoyBootstrapMountPath = "/etc/envoy/bootstrap"
+
+	// GatewayNameLabel is the label key used to identify resources associated with a specific Gateway.
+	GatewayNameLabel = ProjectName + "/gateway-name"
 )

--- a/pkg/infra/agentidentity/agenticidentitysigner/agenticidentitysigner.go
+++ b/pkg/infra/agentidentity/agenticidentitysigner/agenticidentitysigner.go
@@ -31,17 +31,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/kube-agentic-networking/pkg/constants"
 	"sigs.k8s.io/kube-agentic-networking/pkg/infra/agentidentity/localca"
 	"sigs.k8s.io/kube-agentic-networking/pkg/infra/agentidentity/signercontroller"
 )
 
 const (
-	Name      = "kube-agentic-networking.sigs.k8s.io/identity"
-	CTBPrefix = "kube-agentic-networking.sigs.k8s.io:identity:"
+	Name      = constants.ProjectName + "/identity"
+	CTBPrefix = constants.ProjectName + ":identity:"
 
-	CanaryingLabel           = "kube-agentic-networking.sigs.k8s.io/canarying"
-	WorkloadTrustDomainLabel = "kube-agentic-networking.sigs.k8s.io/workload-trust-domain"
-	PeerTrustDomainLabel     = "kube-agentic-networking.sigs.k8s.io/peer-trust-domain"
+	CanaryingLabel           = constants.ProjectName + "/canarying"
+	WorkloadTrustDomainLabel = constants.ProjectName + "/workload-trust-domain"
+	PeerTrustDomainLabel     = constants.ProjectName + "/peer-trust-domain"
 )
 
 // CTBLabels returns the standard labels used for identifying and selecting

--- a/pkg/infra/envoy/resourcerender.go
+++ b/pkg/infra/envoy/resourcerender.go
@@ -144,21 +144,25 @@ func (r *ResourceManager) renderDeployment() *appsv1.Deployment {
 	replicas := int32(1)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            r.nodeID,
-			Namespace:       r.namespace,
+			Name:      r.nodeID,
+			Namespace: r.namespace,
+			Labels: map[string]string{
+				constants.GatewayNameLabel: r.gw.Name,
+			},
 			OwnerReferences: ownerRef(r.gw),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": r.nodeID,
+					constants.GatewayNameLabel: r.gw.Name,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": r.nodeID,
+						"app":                      r.nodeID,
+						constants.GatewayNameLabel: r.gw.Name,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -279,8 +283,11 @@ func (r *ResourceManager) renderService() *corev1.Service {
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            r.nodeID,
-			Namespace:       r.namespace,
+			Name:      r.nodeID,
+			Namespace: r.namespace,
+			Labels: map[string]string{
+				constants.GatewayNameLabel: r.gw.Name,
+			},
 			OwnerReferences: ownerRef(r.gw),
 		},
 		Spec: corev1.ServiceSpec{
@@ -296,8 +303,11 @@ func (r *ResourceManager) renderService() *corev1.Service {
 func (r *ResourceManager) renderServiceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            r.nodeID,
-			Namespace:       r.namespace,
+			Name:      r.nodeID,
+			Namespace: r.namespace,
+			Labels: map[string]string{
+				constants.GatewayNameLabel: r.gw.Name,
+			},
 			OwnerReferences: ownerRef(r.gw),
 		},
 	}

--- a/pkg/infra/envoy/resourcerender_test.go
+++ b/pkg/infra/envoy/resourcerender_test.go
@@ -79,6 +79,17 @@ func TestRenderDeployment(t *testing.T) {
 
 	dep := rm.renderDeployment()
 
+	// Verify Identification Labels
+	if dep.Labels[constants.GatewayNameLabel] != gw.Name {
+		t.Errorf("Deployment missing gateway name label: got %s, want %s", dep.Labels[constants.GatewayNameLabel], gw.Name)
+	}
+	if dep.Spec.Selector.MatchLabels[constants.GatewayNameLabel] != gw.Name {
+		t.Errorf("Deployment selector missing gateway name label: got %s, want %s", dep.Spec.Selector.MatchLabels[constants.GatewayNameLabel], gw.Name)
+	}
+	if dep.Spec.Template.Labels[constants.GatewayNameLabel] != gw.Name {
+		t.Errorf("Pod template missing gateway name label: got %s, want %s", dep.Spec.Template.Labels[constants.GatewayNameLabel], gw.Name)
+	}
+
 	// Verify Volume Mounts are ReadOnly
 	for _, m := range dep.Spec.Template.Spec.Containers[0].VolumeMounts {
 		if !m.ReadOnly {
@@ -133,5 +144,37 @@ func TestRenderDeployment(t *testing.T) {
 
 	if !foundCTB || !foundPC {
 		t.Errorf("Deployment projected volume missing sources: CTB=%v, PC=%v", foundCTB, foundPC)
+	}
+}
+
+func TestRenderService(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gw",
+			Namespace: "test-ns",
+		},
+	}
+	rm := NewResourceManager(nil, gw, "envoy-image", "cluster.local")
+
+	svc := rm.renderService()
+
+	if svc.Labels[constants.GatewayNameLabel] != gw.Name {
+		t.Errorf("Service missing gateway name label: got %s, want %s", svc.Labels[constants.GatewayNameLabel], gw.Name)
+	}
+}
+
+func TestRenderServiceAccount(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gw",
+			Namespace: "test-ns",
+		},
+	}
+	rm := NewResourceManager(nil, gw, "envoy-image", "cluster.local")
+
+	sa := rm.renderServiceAccount()
+
+	if sa.Labels[constants.GatewayNameLabel] != gw.Name {
+		t.Errorf("ServiceAccount missing gateway name label: got %s, want %s", sa.Labels[constants.GatewayNameLabel], gw.Name)
 	}
 }

--- a/pkg/infra/rendezvous/hasher.go
+++ b/pkg/infra/rendezvous/hasher.go
@@ -42,9 +42,11 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/kube-agentic-networking/pkg/constants"
 )
 
-const labelKey = "rendezvous.kube-agentic-networking.sigs.k8s.io"
+const labelKey = "rendezvous." + constants.ProjectName
 
 var (
 	leaseDuration      = 15 * time.Second


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->

/kind feature

**What this PR does / why we need it**:

*Changes:*

This PR adds a standardized label for gateway name, to all infrastructure resources (Deployments, Services, and ServiceAccounts) provisioned by the KAN controller for a gateway.

*Why this is needed:*

With the transition to mTLS and PodCertificate projected volumes, there is a deterministic delay while the Kubelet and the KAN Signer negotiate certificate issuance. Users and tests need a reliable way to wait for the Envoy proxy to be fully provisioned and ready before proceeding.

This label provides a stable selector for kubectl wait and other discovery operations.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Introduce standard gateway-name label for resource discovery and robust wait.
```
