### PR TITLE
Make sure a repo clone is ready before creating the kind cluster

### DIFF
--- a/quickstart/quickstart.md
+++ b/quickstart/quickstart.md
@@ -55,6 +55,11 @@ graph TD
 
 Before you begin, ensure you have the following tools installed and configured:
 
+- **A local clone of this repository**:
+  ```shell
+  git clone https://github.com/kubernetes-sigs/kube-agentic-networking.git
+  cd kube-agentic-networking
+  ```
 - **A Kubernetes cluster**: Minimum version v1.35.0, with the PodCertificateRequest and ClusterTrustBundle features enabled. You can use a local cluster like `kind` or `minikube`, or a cloud-based one.
   ```shell
   kind create cluster --config=quickstart/kind-config.yaml
@@ -63,11 +68,6 @@ Before you begin, ensure you have the following tools installed and configured:
 - **A configured `kubectl` context**: Your `kubectl` should be pointing to the cluster you intend to use.
   ```shell
   kubectl config use-context <YOUR-CLUSTER-NAME>
-  ```
-- A local clone of this repository:
-  ```shell
-  git clone https://github.com/kubernetes-sigs/kube-agentic-networking.git
-  cd kube-agentic-networking
   ```
 
 ## 2. Set Up the Kubernetes Environment
@@ -103,6 +103,12 @@ Deploy the `everything` MCP reference server, which will act as the local tool p
 
 ```shell
 kubectl apply -f quickstart/mcpserver/deployment.yaml
+```
+
+Wait for the MCP server deployment to be ready:
+
+```shell
+kubectl wait --timeout=5m -n quickstart-ns deployment/mcp-everything --for=condition=Available
 ```
 
 ## 3. Deploy the Agentic Networking Controller


### PR DESCRIPTION
The kind cluster config is a part of the repo.

This PR also adds a command to check the MCP server is ready.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind cleanup


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
