### PR TITLE
Add a second agent example built by LangChain SDK

### DIFF
--- a/quickstart/additional-agent-examples/langchain-agent/Dockerfile
+++ b/quickstart/additional-agent-examples/langchain-agent/Dockerfile
@@ -1,0 +1,24 @@
+# Use an official Python runtime as a parent image
+FROM python:3.12-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the application code
+COPY agent.py .
+
+# Make port 8501 available to the world outside this container
+EXPOSE 8501
+
+# Configure Streamlit
+ENV STREAMLIT_SERVER_HEADLESS=true
+ENV STREAMLIT_SERVER_ADDRESS=0.0.0.0
+
+# Run the application
+CMD ["streamlit", "run", "agent.py", "--server.address=0.0.0.0", "--server.port=8501" ,"--server.enableCORS=false", "--server.enableXsrfProtection=false"]

--- a/quickstart/additional-agent-examples/langchain-agent/agent.py
+++ b/quickstart/additional-agent-examples/langchain-agent/agent.py
@@ -1,0 +1,145 @@
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import litellm
+import streamlit as st
+import logging
+import os
+import asyncio
+import contextlib
+from langchain_litellm import ChatLiteLLM
+from langchain.agents import create_agent 
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.tools import load_mcp_tools
+from langchain_core.messages import HumanMessage, AIMessage
+
+# Turn on LiteLLM debugging to catch Hugging Face routing errors
+litellm.set_verbose = True
+
+logging.basicConfig(
+    level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+st.set_page_config(page_title="LangChain Agent", page_icon="🤖")
+st.title("🤖 LangChain Agent")
+
+# 1. Environment Variable Check
+envoy_service = os.environ.get("ENVOY_SERVICE")
+if not envoy_service:
+    st.error("Please set the ENVOY_SERVICE environment variable.")
+    st.stop()
+
+api_key = os.getenv("HF_TOKEN")
+if not api_key:
+    st.error("Please set the HF_TOKEN environment variable.")
+    st.stop()
+
+hf_model = os.getenv("HF_MODEL")
+if not hf_model:
+    st.error("Please set the HF_MODEL environment variable.")
+    st.stop()
+
+# 2. Chat History
+if "messages" not in st.session_state:
+     st.session_state.messages = [
+        AIMessage(content="Hello! I am your Agent that uses MCP to access tools. How can I help?")
+    ]
+
+# 3. Display Chat Messages
+for msg in st.session_state.messages:
+    if isinstance(msg, HumanMessage):
+        with st.chat_message("user"):
+            st.write(msg.content)
+    elif isinstance(msg, AIMessage):
+        with st.chat_message("assistant"):
+            st.write(msg.content)
+
+# 4. Define the Async Agent Interaction
+async def run_agent_interaction(user_input, chat_history):
+    """
+    Connects to MCP, creates agent, and processes the new message
+    while preserving the context of previous messages.
+    """
+    mcp_config = {}
+
+    mcp_config["deepwiki"] = {
+        "url": f"http://{envoy_service}/remote/mcp",
+            "transport": "streamable_http",
+    }
+
+    mcp_config["everythingmcp"] = {
+        "url": f"http://{envoy_service}/local/mcp",
+            "transport": "streamable_http",
+    }
+
+    try:
+        logger.info(f"Attempting to create MultiServerMCPClient with config: {mcp_config}")
+        client = MultiServerMCPClient(mcp_config)
+        logger.info("MultiServerMCPClient created successfully.")
+    except Exception as e:
+        logger.error(f"Failed to create MultiServerMCPClient: {e}")
+
+    # Start MCP Sessions for all configured servers
+    async with contextlib.AsyncExitStack() as stack:
+        tools = []
+        for name in mcp_config.keys():
+            session = await stack.enter_async_context(client.session(name))
+            tools.extend(await load_mcp_tools(session))
+        try:
+            logger.info(f"Attempting to create agent with tools: {tools}")
+            # Define the LLM using LiteLLM
+            llm = ChatLiteLLM(
+                model=hf_model,
+                api_key=api_key,
+                temperature=0.7,
+            )
+            # Create the Agent
+            agent = create_agent(
+                model=llm,
+                tools=tools,
+                system_prompt="You must use the available tools to answer the user's question. If you don't know the answer, say you can not find available tools to answer the question.",
+            )
+            logger.info("Agent created successfully.")
+        except Exception as e:
+            logger.error(f"Failed to create agent: {e}")
+            return "Sorry, I am having trouble setting up the tools to answer your question right now."
+        # Prepare the full message history (Context)
+        messages = chat_history + [HumanMessage(content=user_input)]
+        try:
+            # Invoke Agent
+            response = await agent.ainvoke({"messages": messages})
+            return response["messages"][-1].content
+        except Exception as e:
+            logger.error(f"Agent invocation failed: {e}")
+            return f"An error occurred while generating a response: {str(e)}"
+
+# 5. Handle User Input
+if prompt := st.chat_input("Ask me anything..."):
+    # Display user message immediately
+    with st.chat_message("user"):
+        st.write(prompt)
+
+    # Show a spinner while the agent works
+    with st.spinner("Thinking..."):
+        # Run the async agent loop
+        response_text = asyncio.run(
+            run_agent_interaction(prompt, st.session_state.messages)
+        )
+        # Display AI response
+        with st.chat_message("assistant"):
+            st.write(response_text)
+        # Update Session State History
+        st.session_state.messages.append(HumanMessage(content=prompt))
+        st.session_state.messages.append(AIMessage(content=response_text))

--- a/quickstart/additional-agent-examples/langchain-agent/deployment.yaml
+++ b/quickstart/additional-agent-examples/langchain-agent/deployment.yaml
@@ -1,0 +1,139 @@
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: adk-agent-sa
+  namespace: quickstart-ns
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: langchain-agent
+  namespace: quickstart-ns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: langchain-agent
+  template:
+    metadata:
+      labels:
+        app: langchain-agent
+    spec:
+      serviceAccountName: adk-agent-sa
+      initContainers:
+        - name: proxy-init
+          image: alpine:latest
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+          command:
+            - sh
+            - -c
+            - |
+              apk add iptables
+              # Redirect all outbound TCP traffic on port 10001 to Envoy (localhost:10001)
+              # EXCEPT traffic coming from Envoy itself (UID 1337) to avoid infinite loops.
+              iptables -t nat -A OUTPUT -p tcp --dport 10001 -m owner ! --uid-owner 1337 -j REDIRECT --to-ports 10001
+      containers:
+        - name: langchain-agent
+          # TODO: Replace with the image from registry.k8s.io/agentic-net registry 
+          image: <PLACEHOLDER_FOR_ADK_AGENT_IMAGE>
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "512Mi"
+              cpu: "1"
+              ephemeral-storage: "128Mi"
+            requests:
+              memory: "512Mi"
+              cpu: "1"
+              ephemeral-storage: "128Mi"
+          ports:
+            - containerPort: 8501
+          env:
+            - name: PORT
+              value: "8051"
+            - name: ENVOY_SERVICE
+              # This is the address of the Envoy sidecar
+              value: "127.0.0.1:10001"
+            - name: HF_MODEL
+              value: "huggingface/deepseek-ai/DeepSeek-R1-0528"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-secret
+                  key: hf-token-key
+        - name: envoy
+          image: envoyproxy/envoy:v1.36-latest
+          imagePullPolicy: Always
+          securityContext:
+            runAsUser: 1337
+          command: ["/usr/local/bin/envoy"]
+          args: ["-c", "/etc/envoy/bootstrap/envoy.yaml", "-l", "trace", "--log-path", "/dev/stderr"]
+          ports:
+          - name: envoy
+            containerPort: 10001
+          volumeMounts:
+          - name: envoy-sidecar-configs
+            mountPath: /etc/envoy
+            readOnly: true
+          - name: agent-identity-mtls
+            mountPath: /run/agent-identity-mtls
+            readOnly: true
+      volumes:
+      - name: envoy-sidecar-configs
+        configMap:
+          name: sidecar-envoy-configs
+          items:
+            - key: envoy.yaml
+              path: bootstrap/envoy.yaml
+            - key: spiffe_identity.yaml
+              path: sds/spiffe_identity.yaml
+            - key: spiffe_trust.yaml
+              path: sds/spiffe_trust.yaml
+      - name: agent-identity-mtls
+        projected:
+          sources:
+          - clusterTrustBundle:
+              signerName: kube-agentic-networking.sigs.k8s.io/identity
+              labelSelector:
+                matchLabels:
+                  "kube-agentic-networking.sigs.k8s.io/canarying":             "live"
+                  "kube-agentic-networking.sigs.k8s.io/workload-trust-domain": "cluster.local"
+                  "kube-agentic-networking.sigs.k8s.io/peer-trust-domain":     "cluster.local"
+              path: cluster.local.trust-bundle.pem
+          - podCertificate:
+              signerName: kube-agentic-networking.sigs.k8s.io/identity
+              keyType: ECDSAP256
+              credentialBundlePath: credential-bundle.pem
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: langchain-agent-svc
+  namespace: quickstart-ns
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      targetPort: 8501
+      name: langchain-agent
+    - port: 10001
+      targetPort: 10001
+      name: envoy
+  selector:
+    app: langchain-agent

--- a/quickstart/additional-agent-examples/langchain-agent/requirements.txt
+++ b/quickstart/additional-agent-examples/langchain-agent/requirements.txt
@@ -1,0 +1,4 @@
+streamlit
+langchain
+langchain-litellm
+langchain-mcp-adapters


### PR DESCRIPTION
Add a second Agent example.

The image field is a placeholder for now. It is to be updated with the official image.
I will update the quickstart guide once we build the official image.


/kind documentation

Ref  #109


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE

```
