### PR TITLE
Repo structure to host proposals, apis

### DIFF
--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,5 +1,17 @@
-# Proposals Best Practices
+# Proposals
 
+Design proposals and enhancement documents for Kubernetes Agentic Networking.
+
+Browse proposals on the [documentation site](https://kube-agentic-networking.sigs.k8s.io/proposals/overview/) (Enhancements), where the list is generated from proposal files in this directory.
 
 ## Naming
-The directory of the proposal should lead with a 4-digit PR number (will move to 5,6,... should our PR count get that high), followed by kebab-cased title. The PR number is not known until the PR is cut, so development can use a placeholder, ex. XXXX-my-proposal. PR number is used b/c it is unique & chronological, allowing the default ordering of proposals to follow the timeline of development.
+
+- Use a **4-digit number** (PR number when available) followed by a **kebab-cased title**: `NNNN-short-title.md`.
+- Examples: `0008-ToolAuthAPI.md`, `0059-AccessPolicyTargetRefs.md`.
+- While developing, you can use a placeholder (e.g. `XXXX-my-proposal.md`) and rename to the PR number when the PR is opened.
+- The number gives a chronological order to proposals.
+
+## Adding a new proposal
+
+1. Create a new markdown file under `docs/proposals/` with the naming above.
+2. Include: context, goals, design (API changes, behavior), and alternatives considered.

--- a/site-src/reference/.pages
+++ b/site-src/reference/.pages
@@ -1,3 +1,4 @@
 title: Reference
 nav:
   - API Specification: spec.md
+  - API Design: api-design.md

--- a/site-src/reference/api-design.md
+++ b/site-src/reference/api-design.md
@@ -6,7 +6,8 @@ This document describes the design of the project's custom APIs and how they fit
 
 An **XBackend** represents a backend that agents or tools call into—for example, an MCP server. It is namespaced and is referenced by HTTPRoute `BackendRef`s (and by XAccessPolicy targetRefs).
 
-!note: The project is in the process of moving to use the Gateway API's XBackend defined [here](https://github.com/kubernetes-sigs/gateway-api/blob/main/geps/gep-4894/index.md)
+> [!NOTE:] 
+> The project is in the process of moving to use the Gateway API's XBackend defined [here](https://github.com/kubernetes-sigs/gateway-api/blob/main/geps/gep-4894/index.md)
 
 ## XAccessPolicy
 

--- a/site-src/reference/api-design.md
+++ b/site-src/reference/api-design.md
@@ -6,6 +6,8 @@ This document describes the design of the project's custom APIs and how they fit
 
 An **XBackend** represents a backend that agents or tools call into—for example, an MCP server. It is namespaced and is referenced by HTTPRoute `BackendRef`s (and by XAccessPolicy targetRefs).
 
+!note: The project is in the process of moving to use the Gateway API's XBackend defined [here](https://github.com/kubernetes-sigs/gateway-api/blob/main/geps/gep-4894/index.md)
+
 ## XAccessPolicy
 
 An **XAccessPolicy** is an authorization policy: it defines *who* can access *what* for the backends it targets. It targets Gateways or XBackends via `targetRefs` and contains rules that describe allowed (or denied) sources and optional authorization (e.g. which tools or methods).

--- a/site-src/reference/api-design.md
+++ b/site-src/reference/api-design.md
@@ -1,0 +1,17 @@
+# API design
+
+This document describes the design of the project's custom APIs and how they fit with the Gateway API. Note that this API is still in an early alpha state and could still change significantly.
+
+## XBackend
+
+An **XBackend** represents a backend that agents or tools call into—for example, an MCP server. It is namespaced and is referenced by HTTPRoute `BackendRef`s (and by XAccessPolicy targetRefs).
+
+## XAccessPolicy
+
+An **XAccessPolicy** is an authorization policy: it defines *who* can access *what* for the backends it targets. It targets Gateways or XBackends via `targetRefs` and contains rules that describe allowed (or denied) sources and optional authorization (e.g. which tools or methods).
+
+## Relationship to Gateway API
+
+The project is built on top of the Gateway API and works with Gateway resources (Gateway, GatewayClass, and route types such as HTTPRoute; GRPCRoute may be supported later). Route resources can reference XBackends via BackendRef. **XBackend** and **XAccessPolicy** are custom resources that extend these Gateway resources.
+
+Proposals that introduce or change these APIs are listed under [Enhancements](../proposals/overview.md) on this site (source files live in `docs/proposals/` in the repository).


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Added repo-structure documentation so contributors know where to find and add proposals, APIs, and docs. It adds docs/REPO_STRUCTURE.md, docs/api/README.md (API types, CRDs, clients, and relation to Gateway API), updates docs/proposals/README.md, and updates the main README with links to proposals, APIs, and the structure doc. This gives a single place to look for layout and contribution conventions.

**Which issue(s) this PR fixes**:
*Automatically closes linked issue when PR is merged.
Fixes #14 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
