### PR TITLE
fix: Fix quickstart links on docs-site and reformat bring-your-own-agent

### DIFF
--- a/quickstart/quickstart.md
+++ b/quickstart/quickstart.md
@@ -176,7 +176,7 @@ kubectl create secret generic hf-secret -n quickstart-ns --from-literal=hf-token
 
 ⚠️ **Warning**: Free-tier HuggingFace accounts have strict monthly rate limits, which are easily exceeded.
 
-> **Note** You can use other HuggingFace models that support chat and tool calling by modifying the `HF_MODEL` environment variable in the [agent deployment manifest](/quickstart/adk-agent/deployment.yaml). For details on configuring other generative AI models with ADK agents, refer to the [ADK documentation](https://google.github.io/adk-docs/agents/models/).
+> **Note** You can use other HuggingFace models that support chat and tool calling by modifying the `HF_MODEL` environment variable in the [agent deployment manifest](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/quickstart/adk-agent/deployment.yaml). For details on configuring other generative AI models with ADK agents, refer to the [ADK documentation](https://google.github.io/adk-docs/agents/models/).
 
 ### Step 5.2: Configure and Deploy the AI Agent
 
@@ -351,7 +351,7 @@ You can also integrate your own agent by following these steps:
 
 3. **Create the Envoy sidecar ConfigMap**
 
-    The Envoy sidecar needs a ConfigMap with its bootstrap and SDS configurations for mTLS. Use the template at [`quickstart/adk-agent/sidecar/sidecar-configs.yaml`](/quickstart/adk-agent/sidecar/sidecar-configs.yaml):
+    The Envoy sidecar needs a ConfigMap with its bootstrap and SDS configurations for mTLS. Refer to the [sidecar configs template](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/quickstart/adk-agent/sidecar/sidecar-configs.yaml):
 
     a.  **Copy the template** and update `metadata.namespace` to your agent's namespace:
 
@@ -370,7 +370,7 @@ You can also integrate your own agent by following these steps:
 
 4. **Add the Envoy sidecar to your agent deployment**
 
-    Add an **`envoy` sidecar container** to your Deployment spec with the `envoy-sidecar-configs` and `agent-identity-mtls` volumes. The `envoy-sidecar-configs` tells Envoy how to connect, and `agent-identity-mtls` gives it the credentials to authenticate (see the [ADK agent deployment](/quickstart/adk-agent/deployment.yaml) for reference). Add `--disable-hot-restart` to the Envoy args if the hot restart socket conflicts in your environment.
+    Add an **`envoy` sidecar container** to your Deployment spec with the `envoy-sidecar-configs` and `agent-identity-mtls` volumes. The `envoy-sidecar-configs` tells Envoy how to connect, and `agent-identity-mtls` gives it the credentials to authenticate (see the [ADK agent deployment](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/quickstart/adk-agent/deployment.yaml) for reference). Add `--disable-hot-restart` to the Envoy args if the hot restart socket conflicts in your environment.
 
     > **Note**: The ADK agent deployment also includes a `proxy-init` init container with iptables rules. This is **not required** — the Envoy sidecar already listens on port 10001 within the pod, so `127.0.0.1:10001` (configured in step 5) reaches it directly. Omitting it avoids the `NET_ADMIN` capability requirement and speeds up pod startup.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->

/kind documentation

**What this PR does / why we need it**:

- I noticed some of the "relative" links from our quickstart do not work on the docs site. This happens because our quickstart is not in the same dir as the docs site (site-src). It would be best to not duplicate the docs, and I didn't want to entirely move the quickstart currently - so absolute links may be the only way to get this to work in both Github markdown and the docs site but does come with risks if those are moved.
- Reformat bring-your-own-agent section as dropdown details to appear less "required" re suggestion here: https://github.com/kubernetes-sigs/kube-agentic-networking/issues/120#issuecomment-3969510112

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Part of #107 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
