### PR TITLE
Add readme for two agent examples

### DIFF
--- a/quickstart/additional-agent-examples/langchain-agent/README.md
+++ b/quickstart/additional-agent-examples/langchain-agent/README.md
@@ -1,0 +1,27 @@
+# LangChain Agent with MCP Integration
+
+This directory contains a LangChain agent that demonstrates how to integrate with the Multi-Server MCP Client to access tools and interact with a language model. The agent is built using `langchain`, `litellm`, and `streamlit`.
+
+## Features
+
+- **Streamlit Web Interface**: A user-friendly chat interface for interacting with the agent.
+- **Multi-Server MCP Client**: Connects to multiple MCP servers to load and use tools.
+- **LiteLLM Integration**: Uses `litellm` to connect to a Hugging Face model, which can be configured to use other language models.
+
+## Cloud Build
+
+The `cloudbuild.yaml` file is configured to build and push the Docker image using Google Cloud Build. It uses the `Makefile` to execute the build and push commands.
+
+## Deployment
+
+The `deployment.yaml` file contains the Kubernetes manifests for deploying the LangChain agent into a kubernetes cluster.
+
+### Components
+
+-   **ServiceAccount**: `adk-agent-sa` - A service account for the agent.
+-   **Deployment**: `langchain-agent` - The deployment for the agent, which includes:
+    -   An `initContainer` that configures `iptables` to redirect traffic to the Envoy sidecar.
+    -   The LangChain agent container.
+    -   An Envoy sidecar container that proxies requests to the MCP servers.
+-   **Service**: `langchain-agent-svc` - A `LoadBalancer` service that exposes the LangChain agent and Envoy proxy.
+

--- a/quickstart/additional-agent-examples/openai-agent/README.md
+++ b/quickstart/additional-agent-examples/openai-agent/README.md
@@ -1,0 +1,28 @@
+# OpenAI Agent with MCP Integration
+
+This directory contains an agent that uses the OpenAI SDK to interact with a language model and dynamically loaded tools from MCP servers. The agent provides a chat interface using Gradio.
+
+## Features
+
+- **Gradio Web Interface**: A user-friendly chat interface for interacting with the agent.
+- **OpenAI SDK**: Uses the OpenAI SDK to communicate with a language model.
+- **Hugging Face Model**: Connects to a Hugging Face model through an OpenAI-compatible endpoint.
+- **Multi-Server MCP Client**: Connects to multiple MCP servers to load and use tools.
+
+## Cloud Build
+
+The `cloudbuild.yaml` file is configured to build and push the Docker image using Google Cloud Build.
+
+## Deployment
+
+The `deployment.yaml` file contains the Kubernetes manifests for deploying the agent into a kubernetes cluster.
+
+### Components
+
+-   **ServiceAccount**: `adk-agent-sa` - A service account for the agent.
+-   **Deployment**: `openai-agent` - The deployment for the agent, which includes:
+    -   An `initContainer` that configures `iptables` to redirect traffic to the Envoy sidecar.
+    -   The OpenAI agent container.
+    -   An Envoy sidecar container that proxies requests to the MCP servers.
+-   **Service**: `openai-agent-svc` - A `LoadBalancer` service that exposes the agent and Envoy proxy.
+


### PR DESCRIPTION
Add readme for two agent examples.

This will also trigger a cloud build for the agents' images.

/kind documentation


Ref #109

**Does this PR introduce a user-facing change?**:
```release-note
None
```
