### PR TITLE
Remove envoy cluster for K8s API server

### DIFF
--- a/pkg/constants/envoynames.go
+++ b/pkg/constants/envoynames.go
@@ -33,8 +33,6 @@ const (
 	VHostNameFormat = "%s-vh-%d-%s"
 	// ClusterNameFormat is the format string for Envoy cluster names, becoming `<namespace>-<backend-name>`.
 	ClusterNameFormat = "%s-%s"
-	// K8sAPIClusterName is the name of the cluster that points to the Kubernetes API server.
-	K8sAPIClusterName = "kubernetes_api_cluster"
 
 	// EnvoyBootstrapMountPath is the path where the Envoy bootstrap configuration is mounted.
 	EnvoyBootstrapMountPath = "/etc/envoy/bootstrap"

--- a/pkg/translator/backend.go
+++ b/pkg/translator/backend.go
@@ -127,38 +127,3 @@ func buildClustersFromBackends(backends []*agenticv0alpha0.XBackend) ([]*cluster
 	}
 	return clusters, nil
 }
-
-func buildK8sApiCluster() (*clusterv3.Cluster, error) {
-	tlsContext := &tlsv3.UpstreamTlsContext{
-		Sni: "kubernetes.default.svc",
-		CommonTlsContext: &tlsv3.CommonTlsContext{
-			ValidationContextType: &tlsv3.CommonTlsContext_ValidationContext{
-				ValidationContext: &tlsv3.CertificateValidationContext{
-					TrustedCa: &corev3.DataSource{
-						Specifier: &corev3.DataSource_Filename{
-							// This tells Envoy to trust the K8s API server's cert
-							Filename: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
-						},
-					},
-				},
-			},
-		},
-	}
-	anyTlsContext, err := anypb.New(tlsContext)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal UpstreamTlsContext: %w", err)
-	}
-
-	cluster := &clusterv3.Cluster{
-		Name:                 constants.K8sAPIClusterName,
-		ClusterDiscoveryType: &clusterv3.Cluster_Type{Type: clusterv3.Cluster_LOGICAL_DNS},
-		LoadAssignment:       createClusterLoadAssignment(constants.K8sAPIClusterName, "kubernetes.default.svc", 443), // Use port 443 for HTTPS
-		TransportSocket: &corev3.TransportSocket{
-			Name: "envoy.transport_sockets.tls",
-			ConfigType: &corev3.TransportSocket_TypedConfig{
-				TypedConfig: anyTlsContext,
-			},
-		},
-	}
-	return cluster, nil
-}

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -343,12 +343,6 @@ func (t *Translator) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 		clustersSlice = append(clustersSlice, cluster)
 	}
 
-	k8sApiCluster, err := buildK8sApiCluster()
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to build kubernetes_api_cluster: %w", err)
-	}
-	clustersSlice = append(clustersSlice, k8sApiCluster)
-
 	orderedStatuses := make([]gatewayv1.ListenerStatus, len(gateway.Spec.Listeners))
 	for i, listener := range gateway.Spec.Listeners {
 		orderedStatuses[i] = allListenerStatuses[listener.Name]

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -154,7 +154,7 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 			}{
 				listenerNames: []string{"listener-10001"},
 				routeNames:    []string{"route-10001"},
-				clusterNames:  []string{"quickstart-ns-local-mcp-backend", "kubernetes_api_cluster"},
+				clusterNames:  []string{"quickstart-ns-local-mcp-backend"},
 				spiffeID:      "spiffe://cluster.local/ns/quickstart-ns/sa/adk-agent-sa",
 			},
 		},


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->

/kind cleanup

**What this PR does / why we need it**:

The envoy cluster for K8s API server is no longer needed after #93 because we now use mTLS authentication for verifying the client identity.

As a result, envoy no longer needs to communicate with K8s API server to fetch the public key for verifying the client identity.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #93

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
