### PR TITLE
Define GatewayClass resource in controller manifest

### DIFF
--- a/k8s/deploy/deployment.yaml
+++ b/k8s/deploy/deployment.yaml
@@ -167,3 +167,10 @@ spec:
   selector:
     app: agentic-net-controller
   type: ClusterIP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: kube-agentic-networking
+spec:
+  controllerName: sigs.k8s.io/kube-agentic-networking-controller

--- a/quickstart/policy/e2e.yaml
+++ b/quickstart/policy/e2e.yaml
@@ -1,11 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: GatewayClass
-metadata:
-  name: kube-agentic-networking
-spec:
-  controllerName: sigs.k8s.io/kube-agentic-networking-controller
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: agentic-net-gateway

--- a/tests/e2e/testdata/e2e-resources.yaml
+++ b/tests/e2e/testdata/e2e-resources.yaml
@@ -3,13 +3,6 @@ kind: Namespace
 metadata:
   name: e2e-test-ns
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: GatewayClass
-metadata:
-  name: kube-agentic-networking
-spec:
-  controllerName: sigs.k8s.io/kube-agentic-networking-controller
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->

/kind cleanup

**What this PR does / why we need it**:

Define GatewayClass resource in controller manifest. GatewayClass represents a class of Gateways that can be instantiated and it is expected to be created by the infrastructure provider for the user. See https://gateway-api.sigs.k8s.io/api-types/gatewayclass/

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
GatewayClass resource is now created during controller installation
```
