### PR TITLE
Add ServiceRef index on HTTPRoute informer for scalable Service updates

### DIFF
--- a/cmd/agentic-net-controller/main.go
+++ b/cmd/agentic-net-controller/main.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -101,6 +102,16 @@ func main() {
 	sharedKubeInformers := kubeinformers.NewSharedInformerFactory(kubeClient, *resyncPeriod)
 	sharedGwInformers := gatewayinformers.NewSharedInformerFactory(gatewayClientset, *resyncPeriod)
 	sharedAgenticInformers := agenticinformers.NewSharedInformerFactory(agenticClientset, *resyncPeriod)
+
+	// Register ServiceRef index on HTTPRoute informer before Start so Service updates
+	// only look up HTTPRoutes that reference that Service instead of listing all.
+	httpRouteInformer := sharedGwInformers.Gateway().V1().HTTPRoutes().Informer()
+	if err := httpRouteInformer.AddIndexers(map[string]cache.IndexFunc{
+		controller.ServiceRefIndex: controller.HTTPRouteServiceRefIndexFunc,
+	}); err != nil {
+		klog.ErrorS(err, "Failed to add ServiceRef index to HTTPRoute informer")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+	}
 
 	c, err := controller.New(
 		ctx,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -73,7 +73,8 @@ type gatewayResources struct {
 	gatewayLister gatewaylisters.GatewayLister
 	gatewaySynced cache.InformerSynced
 
-	httprouteLister       gatewaylisters.HTTPRouteLister
+	httprouteLister      gatewaylisters.HTTPRouteLister
+	httprouteIndexer     cache.Indexer
 	referenceGrantLister gatewaylistersv1beta1.ReferenceGrantLister
 	httprouteSynced      cache.InformerSynced
 	referenceGrantSynced cache.InformerSynced
@@ -98,10 +99,10 @@ type Controller struct {
 	agenticIdentityTrustDomain string
 	envoyImage                 string
 
-	gatewayqueue            workqueue.TypedRateLimitingInterface[string]
-	backendFinalizerQueue   workqueue.TypedRateLimitingInterface[string]
-	xdsServer               *xds.Server
-	translator              *translator.Translator
+	gatewayqueue          workqueue.TypedRateLimitingInterface[string]
+	backendFinalizerQueue workqueue.TypedRateLimitingInterface[string]
+	xdsServer             *xds.Server
+	translator            *translator.Translator
 }
 
 // New returns a new *Controller with the event handlers setup for types we are interested in.
@@ -115,11 +116,11 @@ func New(
 	namespaceInformer corev1informers.NamespaceInformer,
 	serviceInformer corev1informers.ServiceInformer,
 	secretInformer corev1informers.SecretInformer,
-	gatewayClassInformer    gatewayinformers.GatewayClassInformer,
-	gatewayInformer         gatewayinformers.GatewayInformer,
-	httprouteInformer       gatewayinformers.HTTPRouteInformer,
+	gatewayClassInformer gatewayinformers.GatewayClassInformer,
+	gatewayInformer gatewayinformers.GatewayInformer,
+	httprouteInformer gatewayinformers.HTTPRouteInformer,
 	referenceGrantInformer gatewayinformersv1beta1.ReferenceGrantInformer,
-	backendInformer         agenticinformers.XBackendInformer,
+	backendInformer agenticinformers.XBackendInformer,
 	accessPolicyInformer agenticinformers.XAccessPolicyInformer,
 ) (*Controller, error) {
 	c := &Controller{
@@ -133,15 +134,16 @@ func New(
 			secretSynced: secretInformer.Informer().HasSynced,
 		},
 		gateway: gatewayResources{
-			client:             gwClientSet,
-			gatewayClassLister: gatewayClassInformer.Lister(),
-			gatewayClassSynced: gatewayClassInformer.Informer().HasSynced,
-			gatewayLister:      gatewayInformer.Lister(),
-			gatewaySynced:      gatewayInformer.Informer().HasSynced,
-			httprouteLister:       httprouteInformer.Lister(),
-			referenceGrantLister:  referenceGrantInformer.Lister(),
-			httprouteSynced:       httprouteInformer.Informer().HasSynced,
-			referenceGrantSynced:  referenceGrantInformer.Informer().HasSynced,
+			client:               gwClientSet,
+			gatewayClassLister:   gatewayClassInformer.Lister(),
+			gatewayClassSynced:   gatewayClassInformer.Informer().HasSynced,
+			gatewayLister:        gatewayInformer.Lister(),
+			gatewaySynced:        gatewayInformer.Informer().HasSynced,
+			httprouteLister:      httprouteInformer.Lister(),
+			httprouteIndexer:     httprouteInformer.Informer().GetIndexer(),
+			referenceGrantLister: referenceGrantInformer.Lister(),
+			httprouteSynced:      httprouteInformer.Informer().HasSynced,
+			referenceGrantSynced: referenceGrantInformer.Informer().HasSynced,
 		},
 		agentic: agenticNetResources{
 			client:             agenticClientSet,
@@ -172,6 +174,7 @@ func New(
 		secretInformer.Lister(),
 		gatewayInformer.Lister(),
 		httprouteInformer.Lister(),
+		referenceGrantInformer.Lister(),
 		accessPolicyInformer.Lister(),
 		backendInformer.Lister(),
 	)

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -26,9 +26,37 @@ import (
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"sigs.k8s.io/kube-agentic-networking/pkg/translator"
 )
+
+// ServiceRefIndex is the name of the index that maps Service namespace/name to HTTPRoutes
+// that reference that Service in their backendRefs (direct refs only, not XBackend).
+const ServiceRefIndex = "serviceRef"
+
+// HTTPRouteServiceRefIndexFunc returns index keys "namespace/name" for each Service
+// referenced by an HTTPRoute's backendRefs (skips XBackend refs).
+func HTTPRouteServiceRefIndexFunc(obj interface{}) ([]string, error) {
+	route, ok := obj.(*gatewayv1.HTTPRoute)
+	if !ok {
+		return nil, nil
+	}
+	var keys []string
+	for _, rule := range route.Spec.Rules {
+		for _, backend := range rule.BackendRefs {
+			if isXBackendRef(backend.BackendRef) {
+				continue
+			}
+			backendNS := route.Namespace
+			if backend.Namespace != nil {
+				backendNS = string(*backend.Namespace)
+			}
+			keys = append(keys, backendNS+"/"+string(backend.Name))
+		}
+	}
+	return keys, nil
+}
 
 func (c *Controller) setupServiceEventHandlers(informer corev1informers.ServiceInformer) error {
 	_, err := informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -86,20 +114,46 @@ func (c *Controller) enqueueGatewaysForService(svc *corev1.Service) {
 }
 
 // enqueueGatewaysForServiceDirectHTTPRouteRefs enqueues Gateways for HTTPRoutes
-// that reference this Service directly in their backendRefs
+// that reference this Service directly in their backendRefs. Uses the ServiceRef
+// index so we only consider routes that reference this Service instead of listing all.
 func (c *Controller) enqueueGatewaysForServiceDirectHTTPRouteRefs(svc *corev1.Service) {
+	if c.gateway.httprouteIndexer == nil {
+		c.enqueueGatewaysForServiceDirectHTTPRouteRefsList(svc)
+		return
+	}
+	svcKey := svc.Namespace + "/" + svc.Name
+	objs, err := c.gateway.httprouteIndexer.ByIndex(ServiceRefIndex, svcKey)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	for _, obj := range objs {
+		route := obj.(*gatewayv1.HTTPRoute)
+		// Cross-namespace refs require a ReferenceGrant in the backend namespace.
+		if !translator.AllowedByReferenceGrant(route.Namespace, svc.Namespace, c.gateway.referenceGrantLister) {
+			continue
+		}
+		klog.V(4).InfoS(
+			"HTTPRoute references Service directly",
+			"service", klog.KObj(svc),
+			"httproute", klog.KObj(route),
+		)
+		c.enqueueGatewaysForHTTPRoute(route.Spec.ParentRefs, route.Namespace)
+	}
+}
+
+// enqueueGatewaysForServiceDirectHTTPRouteRefsList is the list-based implementation
+// used when the ServiceRef index is not available (e.g. in tests).
+func (c *Controller) enqueueGatewaysForServiceDirectHTTPRouteRefsList(svc *corev1.Service) {
 	routes, err := c.gateway.httprouteLister.List(labels.Everything())
 	if err != nil {
 		runtime.HandleError(err)
 		return
 	}
-
 	for _, route := range routes {
 		matched := false
-
 		for _, rule := range route.Spec.Rules {
 			for _, backend := range rule.BackendRefs {
-				// Skip XBackend refs; see isXBackendRef in backend.go.
 				if isXBackendRef(backend.BackendRef) {
 					continue
 				}
@@ -107,31 +161,18 @@ func (c *Controller) enqueueGatewaysForServiceDirectHTTPRouteRefs(svc *corev1.Se
 				if backend.Namespace != nil {
 					backendNS = string(*backend.Namespace)
 				}
-
-				if backendNS == svc.Namespace &&
-					string(backend.Name) == svc.Name {
-
-					// Cross-namespace refs require a ReferenceGrant in the backend namespace.
-					// See https://gateway-api.sigs.k8s.io/api-types/referencegrant/
+				if backendNS == svc.Namespace && string(backend.Name) == svc.Name {
 					if !translator.AllowedByReferenceGrant(route.Namespace, backendNS, c.gateway.referenceGrantLister) {
 						continue
 					}
 					matched = true
-
-					klog.V(4).InfoS(
-						"HTTPRoute references Service directly",
-						"service", klog.KObj(svc),
-						"httproute", klog.KObj(route),
-					)
 					break
 				}
 			}
-
 			if matched {
 				break
 			}
 		}
-
 		if matched {
 			c.enqueueGatewaysForHTTPRoute(route.Spec.ParentRefs, route.Namespace)
 		}

--- a/pkg/translator/backend.go
+++ b/pkg/translator/backend.go
@@ -25,6 +25,7 @@ import (
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
+	corev1 "k8s.io/api/core/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	agenticv0alpha0 "sigs.k8s.io/kube-agentic-networking/api/v0alpha0"
@@ -34,10 +35,51 @@ import (
 const (
 	// The timeout for new network connections to hosts in the cluster.
 	defaultConnectTimeout = 5 * time.Second
+	// Default service port when BackendRef.Port is not set.
+	defaultServicePort = 80
 )
 
-func (t *Translator) fetchBackend(namespace string, backendRef gatewayv1.BackendRef) (*agenticv0alpha0.XBackend, error) {
-	// 1. Validate that the Kind is Backend.
+// routeBackend represents either an XBackend or a direct Service reference for HTTPRoute backendRefs.
+// Used so we can build clusters and route action from both without duplicating caller logic.
+type routeBackend struct {
+	clusterName string
+	xbackend    *agenticv0alpha0.XBackend // nil if this is a direct Service ref
+	svcNS       string
+	svcName     string
+	svcPort     int32
+}
+
+func (rb *routeBackend) ClusterName() string { return rb.clusterName }
+
+// Hostname returns the host rewrite for external backends; empty for Service or in-cluster XBackend.
+func (rb *routeBackend) Hostname() string {
+	if rb.xbackend != nil && rb.xbackend.Spec.MCP.Hostname != nil {
+		return *rb.xbackend.Spec.MCP.Hostname
+	}
+	return ""
+}
+
+// XBackend returns the XBackend when this is an XBackend ref; nil for direct Service refs (no RBAC from XAccessPolicy).
+func (rb *routeBackend) XBackend() *agenticv0alpha0.XBackend { return rb.xbackend }
+
+// isServiceRef returns true if the BackendRef refers to a core Service (Kind nil or "Service", Group nil or "").
+func isServiceRef(backendRef gatewayv1.BackendRef) bool {
+	kind := "Service"
+	if backendRef.Kind != nil {
+		kind = string(*backendRef.Kind)
+	}
+	group := ""
+	if backendRef.Group != nil {
+		group = string(*backendRef.Group)
+	}
+	return (kind == "Service" || kind == "") && (group == "" || group == "core")
+}
+
+func (t *Translator) fetchBackend(namespace string, backendRef gatewayv1.BackendRef) (*routeBackend, error) {
+	if isServiceRef(backendRef) {
+		return t.fetchServiceBackend(namespace, backendRef)
+	}
+	// XBackend path
 	if backendRef.Kind != nil && *backendRef.Kind != "XBackend" {
 		return nil, &ControllerError{
 			Reason:  string(gatewayv1.RouteReasonInvalidKind),
@@ -50,7 +92,6 @@ func (t *Translator) fetchBackend(namespace string, backendRef gatewayv1.Backend
 		ns = string(*backendRef.Namespace)
 	}
 
-	// 2. Fetch the Backend resource.
 	backend, err := t.backendLister.XBackends(ns).Get(string(backendRef.Name))
 	if err != nil {
 		return nil, &ControllerError{
@@ -59,10 +100,8 @@ func (t *Translator) fetchBackend(namespace string, backendRef gatewayv1.Backend
 		}
 	}
 
-	// 3. Check if the referenced Service exists.
 	if svcName := backend.Spec.MCP.ServiceName; svcName != nil {
 		if _, err := t.serviceLister.Services(ns).Get(*svcName); err != nil {
-			fmt.Printf("Service lookup error for backend %s/%s, error: %v\n", ns, backendRef.Name, err)
 			return nil, &ControllerError{
 				Reason:  string(gatewayv1.RouteReasonBackendNotFound),
 				Message: fmt.Sprintf("failed to get Backend service %s/%s: %v", ns, *svcName, err),
@@ -70,8 +109,55 @@ func (t *Translator) fetchBackend(namespace string, backendRef gatewayv1.Backend
 		}
 	}
 
-	// TODO: Do we need to check hostname resolution for external MCP backends?
-	return backend, nil
+	return &routeBackend{
+		clusterName: fmt.Sprintf(constants.ClusterNameFormat, backend.Namespace, backend.Name),
+		xbackend:    backend,
+	}, nil
+}
+
+// fetchServiceBackend resolves a direct Service backendRef (Kind Service or nil).
+func (t *Translator) fetchServiceBackend(routeNamespace string, backendRef gatewayv1.BackendRef) (*routeBackend, error) {
+	ns := routeNamespace
+	if backendRef.Namespace != nil {
+		ns = string(*backendRef.Namespace)
+	}
+	if t.referenceGrantLister != nil && ns != routeNamespace {
+		if !AllowedByReferenceGrant(routeNamespace, ns, t.referenceGrantLister) {
+			return nil, &ControllerError{
+				Reason:  string(gatewayv1.RouteReasonRefNotPermitted),
+				Message: fmt.Sprintf("cross-namespace reference to Service %s/%s not permitted by ReferenceGrant", ns, backendRef.Name),
+			}
+		}
+	}
+	svc, err := t.serviceLister.Services(ns).Get(string(backendRef.Name))
+	if err != nil {
+		return nil, &ControllerError{
+			Reason:  string(gatewayv1.RouteReasonBackendNotFound),
+			Message: fmt.Sprintf("failed to get Service %s/%s: %v", ns, backendRef.Name, err),
+		}
+	}
+	port := resolveServicePort(svc, backendRef.Port)
+	return &routeBackend{
+		clusterName: fmt.Sprintf(constants.ClusterNameFormat, ns, string(backendRef.Name)),
+		svcNS:       ns,
+		svcName:     string(backendRef.Name),
+		svcPort:     port,
+	}, nil
+}
+
+func resolveServicePort(svc *corev1.Service, backendPort *gatewayv1.PortNumber) int32 {
+	if backendPort != nil {
+		for _, p := range svc.Spec.Ports {
+			if int32(p.Port) == int32(*backendPort) {
+				return int32(p.Port)
+			}
+		}
+		return int32(*backendPort)
+	}
+	if len(svc.Spec.Ports) > 0 {
+		return int32(svc.Spec.Ports[0].Port)
+	}
+	return defaultServicePort
 }
 
 func convertBackendToCluster(backend *agenticv0alpha0.XBackend) (*clusterv3.Cluster, error) {
@@ -116,14 +202,33 @@ func convertBackendToCluster(backend *agenticv0alpha0.XBackend) (*clusterv3.Clus
 	return cluster, nil
 }
 
-func buildClustersFromBackends(backends []*agenticv0alpha0.XBackend) ([]*clusterv3.Cluster, error) {
+// buildClustersFromRouteBackends builds Envoy clusters from a mix of XBackend and direct Service refs.
+func buildClustersFromRouteBackends(backends []*routeBackend) ([]*clusterv3.Cluster, error) {
 	var clusters []*clusterv3.Cluster
-	for _, backend := range backends {
-		cluster, err := convertBackendToCluster(backend)
+	for _, rb := range backends {
+		var cluster *clusterv3.Cluster
+		var err error
+		if rb.xbackend != nil {
+			cluster, err = convertBackendToCluster(rb.xbackend)
+		} else {
+			cluster, err = convertServiceRefToCluster(rb.svcNS, rb.svcName, rb.svcPort)
+		}
 		if err != nil {
 			return nil, err
 		}
 		clusters = append(clusters, cluster)
 	}
 	return clusters, nil
+}
+
+func convertServiceRefToCluster(ns, name string, port int32) (*clusterv3.Cluster, error) {
+	clusterName := fmt.Sprintf(constants.ClusterNameFormat, ns, name)
+	serviceFQDN := fmt.Sprintf("%s.%s.svc.cluster.local", name, ns)
+	cluster := &clusterv3.Cluster{
+		Name:                 clusterName,
+		ConnectTimeout:       durationpb.New(defaultConnectTimeout),
+		ClusterDiscoveryType: &clusterv3.Cluster_Type{Type: clusterv3.Cluster_STRICT_DNS},
+		LoadAssignment:       createClusterLoadAssignment(clusterName, serviceFQDN, uint32(port)),
+	}
+	return cluster, nil
 }

--- a/pkg/translator/httproute.go
+++ b/pkg/translator/httproute.go
@@ -41,10 +41,10 @@ import (
 // It now correctly handles RequestHeaderModifier filters.
 func (t *Translator) translateHTTPRouteToEnvoyRoutes(
 	httpRoute *gatewayv1.HTTPRoute,
-) ([]*routev3.Route, []*agenticv0alpha0.XBackend, metav1.Condition) {
+) ([]*routev3.Route, []*routeBackend, metav1.Condition) {
 
 	var envoyRoutes []*routev3.Route
-	var allValidBackends []*agenticv0alpha0.XBackend
+	var allValidBackends []*routeBackend
 	overallCondition := createSuccessCondition(httpRoute.Generation)
 
 	for ruleIndex, rule := range httpRoute.Spec.Rules {
@@ -257,19 +257,19 @@ func processRequestHeaderModifierFilter(f *gatewayv1.HTTPHeaderFilter) ([]*corev
 	return headersToAdd, headersToRemove
 }
 
-// buildHTTPRouteAction returns an action, a list of *valid* BackendRefs, and a structured error.
+// buildHTTPRouteAction returns an action, a list of *valid* route backends (XBackend or Service), and a structured error.
 func (t *Translator) buildHTTPRouteAction(namespace string,
-	backendRefs []gatewayv1.HTTPBackendRef) (*routev3.RouteAction, []*agenticv0alpha0.XBackend, error) {
+	backendRefs []gatewayv1.HTTPBackendRef) (*routev3.RouteAction, []*routeBackend, error) {
 
 	weightedClusters := &routev3.WeightedCluster{}
-	var validBackends []*agenticv0alpha0.XBackend
+	var validBackends []*routeBackend
 
 	for _, httpBackendRef := range backendRefs {
-		backend, err := t.fetchBackend(namespace, httpBackendRef.BackendRef)
+		rb, err := t.fetchBackend(namespace, httpBackendRef.BackendRef)
 		if err != nil {
 			return nil, nil, err
 		}
-		validBackends = append(validBackends, backend)
+		validBackends = append(validBackends, rb)
 		weight := int32(1)
 		if httpBackendRef.Weight != nil {
 			weight = *httpBackendRef.Weight
@@ -279,23 +279,21 @@ func (t *Translator) buildHTTPRouteAction(namespace string,
 		}
 
 		clusterWeight := &routev3.WeightedCluster_ClusterWeight{
-			Name:   fmt.Sprintf(constants.ClusterNameFormat, backend.Namespace, backend.Name),
+			Name:   rb.ClusterName(),
 			Weight: &wrapperspb.UInt32Value{Value: uint32(weight)},
 		}
 
-		// The HostRewriteLiteral is set on the individual clusterWeight within the WeightedCluster.
-		// This ensures that for external backends with a specified hostname, Envoy rewrites
-		// the Host header to the correct external hostname before forwarding the request.
-		if backend.Spec.MCP.Hostname != nil {
+		if host := rb.Hostname(); host != "" {
 			clusterWeight.HostRewriteSpecifier = &routev3.WeightedCluster_ClusterWeight_HostRewriteLiteral{
-				HostRewriteLiteral: *backend.Spec.MCP.Hostname,
+				HostRewriteLiteral: host,
 			}
 		}
 
-		clusterWeight.TypedPerFilterConfig, err = t.buildPerClusterRBACFilterConfig(t.accessPolicyLister, backend)
-		if err != nil {
-			klog.Errorf("Failed to build per-cluster RBAC config for backend %s/%s: %v", backend.Namespace, backend.Name, err)
-			// Continue without RBAC config for this cluster if it fails to build.
+		if rb.XBackend() != nil {
+			clusterWeight.TypedPerFilterConfig, err = t.buildPerClusterRBACFilterConfig(t.accessPolicyLister, rb.XBackend())
+			if err != nil {
+				klog.Errorf("Failed to build per-cluster RBAC config for backend %s: %v", rb.ClusterName(), err)
+			}
 		}
 		// TODO(guicassolato): Add per-route ext_authz config - to populate context_metadata with info about which AccessPolicy rule matched
 		weightedClusters.Clusters = append(weightedClusters.Clusters, clusterWeight)

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -42,6 +42,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 	gatewaylisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1"
+	gatewaylistersv1beta1 "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1beta1"
 	agenticlisters "sigs.k8s.io/kube-agentic-networking/k8s/client/listers/api/v0alpha0"
 	"sigs.k8s.io/kube-agentic-networking/pkg/constants"
 )
@@ -71,6 +72,7 @@ type Translator struct {
 	secretLister               corev1listers.SecretLister
 	gatewayLister              gatewaylisters.GatewayLister
 	httprouteLister            gatewaylisters.HTTPRouteLister
+	referenceGrantLister       gatewaylistersv1beta1.ReferenceGrantLister // optional, for Service ref cross-namespace validation
 	accessPolicyLister         agenticlisters.XAccessPolicyLister
 	backendLister              agenticlisters.XBackendLister
 }
@@ -84,6 +86,7 @@ func New(
 	secretLister corev1listers.SecretLister,
 	gatewayLister gatewaylisters.GatewayLister,
 	httpRouteLister gatewaylisters.HTTPRouteLister,
+	referenceGrantLister gatewaylistersv1beta1.ReferenceGrantLister,
 	accessPolicyLister agenticlisters.XAccessPolicyLister,
 	backendLister agenticlisters.XBackendLister,
 ) *Translator {
@@ -96,6 +99,7 @@ func New(
 		secretLister,
 		gatewayLister,
 		httpRouteLister,
+		referenceGrantLister,
 		accessPolicyLister,
 		backendLister,
 	}
@@ -240,7 +244,7 @@ func (t *Translator) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 					}
 					httpRouteStatuses[key] = currentParentStatuses
 
-					clusters, err := buildClustersFromBackends(allValidBackends)
+					clusters, err := buildClustersFromRouteBackends(allValidBackends)
 					if err != nil {
 						return nil, nil, nil, fmt.Errorf("failed to build clusters from HTTPRoute %s/%s: %w", httpRoute.Namespace, httpRoute.Name, err)
 					}

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -181,6 +181,7 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 				coreInformerFactory.Core().V1().Secrets().Lister(),
 				gwInformerFactory.Gateway().V1().Gateways().Lister(),
 				gwInformerFactory.Gateway().V1().HTTPRoutes().Lister(),
+				nil, // referenceGrantLister
 				agenticInformerFactory.Agentic().V0alpha0().XAccessPolicies().Lister(),
 				agenticInformerFactory.Agentic().V0alpha0().XBackends().Lister(),
 			)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

- ServiceRef index on HTTPRoute informer
Register a custom index on the HTTPRoute informer that maps Service namespace/name to HTTPRoutes that reference that Service in their backendRefs. On Service add/update/delete we now use ByIndex instead of listing all HTTPRoutes and iterating, avoiding O(N) work per Service change in clusters with many routes.
In clusters with many HTTPRoutes, every Service add/update/delete previously listed all routes and iterated to find references. That is O(N) per Service event. With the index, we do an O(1) index lookup and only process routes that reference the Service, making Service-driven reconciliation scale with the number of affected routes instead of total routes.

- HTTPRoute → Service support
The translator now accepts direct backendRef to a core Service (Kind Service or nil). Previously only XBackend refs were allowed. This PR adds resolution of Service refs (including ReferenceGrant for cross-namespace and port resolution) and builds Envoy clusters for them via routeBackend and buildClustersFromRouteBackends.

**Which issue(s) this PR fixes**:
Fixes #117 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
