### PR TITLE
fix: Quickstart formatting

### DIFF
--- a/quickstart/quickstart.md
+++ b/quickstart/quickstart.md
@@ -50,6 +50,19 @@ graph TD
     style RemoteMCP fill:#f9f,stroke:#333,stroke-width:2px
 ```
 
+## Prerequisites
+
+Before you begin, ensure you have the following:
+
+- **[git](https://git-scm.com/downloads)**
+- **[kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)** (Kubernetes in Docker)
+- **[kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)**
+- **[Go](https://go.dev/doc/install)** (1.23+)
+- **[envsubst](https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html)** (typically included with `gettext`)
+- **A HuggingFace token** with ***"Make calls to Inference Providers"*** permission enabled. Follow [this guide](https://huggingface.co/docs/hub/en/security-tokens) to create one.
+
+> **Warning**: Free-tier HuggingFace accounts have strict monthly rate limits, which are easily exceeded.
+
 ## What the Script Does
 
 The `make quickstart` command runs a single script that automates the entire setup:
@@ -63,19 +76,6 @@ The `make quickstart` command runs a single script that automates the entire set
 7. **Applies network policies** (Gateway, HTTPRoutes, XBackends, XAccessPolicies) and waits for the Envoy proxy to be provisioned.
 8. **Deploys the AI agent** with an Envoy sidecar, configured with the discovered Gateway address and SPIFFE identity.
 9. **Sets up port-forwarding** to the agent UI on `localhost:8081`.
-
-## Prerequisites
-
-Before you begin, ensure you have the following:
-
-- **[git](https://git-scm.com/downloads)**
-- **[kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)** (Kubernetes in Docker)
-- **[kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)**
-- **[Go](https://go.dev/doc/install)** (1.23+)
-- **[envsubst](https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html)** (typically included with `gettext`)
-- **A HuggingFace token** with ***"Make calls to Inference Providers"*** permission enabled. Follow [this guide](https://huggingface.co/docs/hub/en/security-tokens) to create one.
-
-> **Warning**: Free-tier HuggingFace accounts have strict monthly rate limits, which are easily exceeded.
 
 ## Quickstart
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->

/kind documentation

**What this PR does / why we need it**:

- The quickstart script is mentioned before prerequisites, which would be necessary for running the script - this updates the order
- Updating the bring-your-own-agent formatting so this does not appear incorrectly in the table of contents on the site
- Replacing #123 after quickstart was restructured - fixing links for the remaining links, similar note: I noticed some of the "relative" links from our quickstart do not work on the docs site. This happens because our quickstart is not in the same dir as the docs site (site-src). It would be best to not duplicate the docs, and I didn't want to entirely move the quickstart currently - so absolute links may be the only way to get this to work in both Github markdown and the docs site but does come with risks if those are moved.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #139 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
