### PR TITLE
Handle Gateway with multiple listeners on the same port

### DIFF
--- a/pkg/infra/envoy/resourcerender.go
+++ b/pkg/infra/envoy/resourcerender.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
+	"sort"
 	"text/template"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -272,14 +273,25 @@ func (r *ResourceManager) renderDeployment() *appsv1.Deployment {
 }
 
 func (r *ResourceManager) renderService() *corev1.Service {
-	ports := []corev1.ServicePort{}
+	portsMap := make(map[int32]corev1.ServicePort)
 	for _, listener := range r.gw.Spec.Listeners {
-		ports = append(ports, corev1.ServicePort{
-			Name:     string(listener.Name),
-			Port:     int32(listener.Port),
-			Protocol: corev1.ProtocolTCP, // TODO : Support other protocols if needed.
-		})
+		port := int32(listener.Port)
+		if _, ok := portsMap[port]; !ok {
+			portsMap[port] = corev1.ServicePort{
+				Name:     string(listener.Name),
+				Port:     port,
+				Protocol: corev1.ProtocolTCP, // TODO : Support other protocols if needed.
+			}
+		}
 	}
+
+	ports := make([]corev1.ServicePort, 0, len(portsMap))
+	for _, port := range portsMap {
+		ports = append(ports, port)
+	}
+	sort.Slice(ports, func(i, j int) bool {
+		return ports[i].Port < ports[j].Port
+	})
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/infra/envoy/resourcerender_test.go
+++ b/pkg/infra/envoy/resourcerender_test.go
@@ -148,18 +148,105 @@ func TestRenderDeployment(t *testing.T) {
 }
 
 func TestRenderService(t *testing.T) {
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-gw",
-			Namespace: "test-ns",
+	testCases := []struct {
+		name          string
+		listeners     []gatewayv1.Listener
+		expectedPorts []corev1.ServicePort
+	}{
+		{
+			name: "single listener",
+			listeners: []gatewayv1.Listener{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: "HTTP",
+				},
+			},
+			expectedPorts: []corev1.ServicePort{
+				{
+					Name: "http",
+					Port: 80,
+				},
+			},
+		},
+		{
+			name: "duplicate ports",
+			listeners: []gatewayv1.Listener{
+				{
+					Name:     "https-1",
+					Port:     443,
+					Protocol: "HTTPS",
+				},
+				{
+					Name:     "https-2",
+					Port:     443,
+					Protocol: "HTTPS",
+				},
+			},
+			expectedPorts: []corev1.ServicePort{
+				{
+					Name: "https-1",
+					Port: 443,
+				},
+			},
+		},
+		{
+			name: "multiple unique ports",
+			listeners: []gatewayv1.Listener{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: "HTTP",
+				},
+				{
+					Name:     "https",
+					Port:     443,
+					Protocol: "HTTPS",
+				},
+			},
+			expectedPorts: []corev1.ServicePort{
+				{
+					Name: "http",
+					Port: 80,
+				},
+				{
+					Name: "https",
+					Port: 443,
+				},
+			},
 		},
 	}
-	rm := NewResourceManager(nil, gw, "envoy-image", "cluster.local")
 
-	svc := rm.renderService()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gw",
+					Namespace: "test-ns",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: tc.listeners,
+				},
+			}
+			rm := NewResourceManager(nil, gw, "envoy-image", "cluster.local")
 
-	if svc.Labels[constants.GatewayNameLabel] != gw.Name {
-		t.Errorf("Service missing gateway name label: got %s, want %s", svc.Labels[constants.GatewayNameLabel], gw.Name)
+			svc := rm.renderService()
+
+			if svc.Labels[constants.GatewayNameLabel] != gw.Name {
+				t.Errorf("Service missing gateway name label: got %s, want %s", svc.Labels[constants.GatewayNameLabel], gw.Name)
+			}
+			if len(svc.Spec.Ports) != len(tc.expectedPorts) {
+				t.Fatalf("expected %d ports, got %d", len(tc.expectedPorts), len(svc.Spec.Ports))
+			}
+			for i, port := range svc.Spec.Ports {
+				if port.Port != tc.expectedPorts[i].Port {
+					t.Errorf("port mismatch at index %d: got %d, want %d", i, port.Port, tc.expectedPorts[i].Port)
+				}
+				if port.Name != tc.expectedPorts[i].Name {
+					t.Errorf("port name mismatch at index %d: got %s, want %s", i, port.Name, tc.expectedPorts[i].Name)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/translator/listener.go
+++ b/pkg/translator/listener.go
@@ -173,6 +173,13 @@ func (t *Translator) translateListenerToFilterChain(lis gatewayv1.Listener, rout
 	// Add TLS transport socket config if the listener uses HTTPS or TLS protocol.
 	// https://github.com/kubernetes-sigs/kube-agentic-networking/issues/95
 	if lis.Protocol == gatewayv1.HTTPSProtocolType || lis.Protocol == gatewayv1.TLSProtocolType {
+		if lis.Hostname != nil && *lis.Hostname != "" {
+			if filterChain.FilterChainMatch == nil {
+				filterChain.FilterChainMatch = &listener.FilterChainMatch{}
+			}
+			filterChain.FilterChainMatch.ServerNames = []string{string(*lis.Hostname)}
+		}
+
 		tlsContext, err := buildDownstreamTLSContext()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build TLS context for listener %s: %w", lis.Name, err)

--- a/pkg/translator/listener_test.go
+++ b/pkg/translator/listener_test.go
@@ -17,11 +17,25 @@ limitations under the License.
 package translator
 
 import (
+	"reflect"
 	"testing"
 
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	apiv0alpha0 "sigs.k8s.io/kube-agentic-networking/api/v0alpha0"
+	agenticlisters "sigs.k8s.io/kube-agentic-networking/k8s/client/listers/api/v0alpha0"
 	"sigs.k8s.io/kube-agentic-networking/pkg/constants"
 )
+
+type mockAccessPolicyLister struct {
+	agenticlisters.XAccessPolicyLister
+}
+
+func (m *mockAccessPolicyLister) List(selector labels.Selector) (ret []*apiv0alpha0.XAccessPolicy, err error) {
+	return nil, nil
+}
 
 func TestBuildDownstreamTLSContext(t *testing.T) {
 	anyContext, err := buildDownstreamTLSContext()
@@ -52,5 +66,68 @@ func TestBuildDownstreamTLSContext(t *testing.T) {
 	validation := common.GetValidationContextSdsSecretConfig()
 	if validation == nil || validation.Name != constants.SpiffeTrustSdsConfigName {
 		t.Errorf("Trust SDS secret config name mismatch")
+	}
+}
+
+func TestTranslateListenerToFilterChain(t *testing.T) {
+	mockLister := &mockAccessPolicyLister{}
+	translator := &Translator{}
+
+	testCases := []struct {
+		name                string
+		listener            gatewayv1.Listener
+		expectedServerNames []string
+	}{
+		{
+			name: "HTTPS with hostname",
+			listener: gatewayv1.Listener{
+				Name:     "https",
+				Port:     443,
+				Protocol: gatewayv1.HTTPSProtocolType,
+				Hostname: ptr.To(gatewayv1.Hostname("example.com")),
+			},
+			expectedServerNames: []string{"example.com"},
+		},
+		{
+			name: "HTTPS with wildcard hostname",
+			listener: gatewayv1.Listener{
+				Name:     "https-wildcard",
+				Port:     443,
+				Protocol: gatewayv1.HTTPSProtocolType,
+				Hostname: ptr.To(gatewayv1.Hostname("*.example.com")),
+			},
+			expectedServerNames: []string{"*.example.com"},
+		},
+		{
+			name: "HTTP without hostname",
+			listener: gatewayv1.Listener{
+				Name:     "http",
+				Port:     80,
+				Protocol: gatewayv1.HTTPProtocolType,
+			},
+			expectedServerNames: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc, err := translator.translateListenerToFilterChain(tc.listener, "route-config", mockLister)
+			if err != nil {
+				t.Fatalf("failed to translate listener: %v", err)
+			}
+
+			if len(tc.expectedServerNames) > 0 {
+				if fc.FilterChainMatch == nil {
+					t.Fatal("expected FilterChainMatch to be set")
+				}
+				if !reflect.DeepEqual(fc.FilterChainMatch.ServerNames, tc.expectedServerNames) {
+					t.Errorf("expected ServerNames %v, got %v", tc.expectedServerNames, fc.FilterChainMatch.ServerNames)
+				}
+			} else {
+				if fc.FilterChainMatch != nil && len(fc.FilterChainMatch.ServerNames) > 0 {
+					t.Errorf("expected no ServerNames in FilterChainMatch, got %v", fc.FilterChainMatch.ServerNames)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->

/kind bug

**What this PR does / why we need it**:

This PR fixes two critical issues encountered when a Gateway resource defines multiple listeners on the same port with different hostnames (e.g., for SNI routing).

***1. Fix Service creation failure due to duplicate ports:***

The controller was previously attempting to create a Kubernetes Service with one port entry for every listener. If multiple listeners shared the same port (like 443), Kubernetes rejected the Service as invalid.

This fix updated the ResourceManager to deduplicate these ports and ensure a deterministic order by sorting them.

***2. Fix Envoy configuration rejection due to ambiguous filter chains:***

Per the [Gateway API spec](https://gateway-api.sigs.k8s.io/reference/spec/#listener), 
- TLS: The Listener Hostname MUST match the SNI.
- HTTP: The Listener Hostname MUST match the Host header of the request.
- HTTPS: The Listener Hostname SHOULD match both the SNI and Host header.

Previously, the translator grouped listeners by port and created a single Envoy Listener per port. Under each Envoy Listener, it generated ambiguous filter chains without matching criteria, leading Envoy to reject the configuration.

This fix includes a FilterChainMatch with ServerNames whenever a hostname is specified. This enables SNI-based selection of the correct Filter Chain at the TLS layer. Combined with the existing VirtualHost domain matching in the RouteConfiguration, this fulfills the spec requirements for both SNI and Host header validation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #141 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
