### PR TITLE
controller: fix resource cleanup deadlocks during deletion

### DIFF
--- a/pkg/controller/accesspolicy.go
+++ b/pkg/controller/accesspolicy.go
@@ -73,8 +73,8 @@ func (c *Controller) onAccessPolicyDelete(obj interface{}) {
 	c.enqueueGatewaysForAccessPolicy(policy)
 }
 
-// enqueueGatewaysForAccessPolicy enqueues Gateways so they are reconciled; when an
-// XAccessPolicy is deleted this ensures stale policy rules are removed from Envoy/xDS config.
+// enqueueGatewaysForAccessPolicy enqueues Gateways so they are reconciled.
+// It also enqueues the targeted XBackend for finalizer reconciliation.
 func (c *Controller) enqueueGatewaysForAccessPolicy(policy *agenticv0alpha0.XAccessPolicy) {
 	for _, targetRef := range policy.Spec.TargetRefs {
 		if !isXBackendTargetRef(targetRef) {
@@ -94,6 +94,7 @@ func (c *Controller) enqueueGatewaysForAccessPolicy(policy *agenticv0alpha0.XAcc
 			continue
 		}
 		c.enqueueGatewaysForBackend(backend)
+		c.enqueueBackendForFinalizer(backend)
 	}
 }
 

--- a/pkg/controller/gateway.go
+++ b/pkg/controller/gateway.go
@@ -69,11 +69,28 @@ func (c *Controller) onGatewayUpdate(old, new interface{}) {
 }
 
 func (c *Controller) onGatewayDelete(obj interface{}) {
+	gw, ok := obj.(*gatewayv1.Gateway)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			runtime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		gw, ok = tombstone.Obj.(*gatewayv1.Gateway)
+		if !ok {
+			runtime.HandleError(fmt.Errorf("tombstone contained object that is not a Gateway %#v", obj))
+			return
+		}
+	}
+
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err == nil {
 		c.gatewayqueue.Add(key)
 	}
 	klog.V(4).InfoS("Gateway deleted", "gateway", key)
+
+	// Trigger GatewayClass sync to allow it to remove finalizer if it was waiting on this Gateway.
+	c.syncGatewayClass(string(gw.Spec.GatewayClassName))
 }
 
 func (c *Controller) updateGatewayStatus(ctx context.Context, gateway *gatewayv1.Gateway, ip string) error {


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->

/kind bug

**What this PR does / why we need it**:

***Problem:***
During deletion, resources like XBackend and GatewayClass would hang in a 'Terminating' state indefinitely. This occurred because the controller ignored parent resources when their child dependencies (XAccessPolicy or Gateway) were deleted. As a result, the parent's finalizer was never re-evaluated, leading to deadlocks and timeouts during resource deletion.

***Fix:***
Modified the event handlers to proactively trigger reconciliation for parent resources whenever a child resource is deleted. Specifically,
- Enqueue XBackends when an associated XAccessPolicy is deleted.
- Sync GatewayClasses when an associated Gateway is deleted.

This "wakes up" the parent resources so they
can successfully remove their finalizers once their dependencies are cleared.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
