### PR TITLE
Max of 1 ext_authz rule per AccessPolicy

### DIFF
--- a/api/v0alpha0/accesspolicy_types.go
+++ b/api/v0alpha0/accesspolicy_types.go
@@ -40,6 +40,7 @@ type AccessPolicySpec struct {
 	// +kubebuilder:validation:MaxItems=10
 	// +listType=atomic
 	// +kubebuilder:validation:XValidation:rule="self.all(r, self.filter(x, x.name == r.name).size() == 1)",message="AccessRule names must be unique"
+	// +kubebuilder:validation:XValidation:rule="self.filter(r, has(r.authorization) && r.authorization.type == 'ExternalAuth').size() <= 1",message="a maximum of one rule per policy can specify 'ExternalAuth' authorization type"
 	Rules []AccessRule `json:"rules"`
 }
 

--- a/k8s/crds/agentic.prototype.x-k8s.io_xaccesspolicies.yaml
+++ b/k8s/crds/agentic.prototype.x-k8s.io_xaccesspolicies.yaml
@@ -391,6 +391,10 @@ spec:
                 x-kubernetes-validations:
                 - message: AccessRule names must be unique
                   rule: self.all(r, self.filter(x, x.name == r.name).size() == 1)
+                - message: a maximum of one rule per policy can specify 'ExternalAuth'
+                    authorization type
+                  rule: self.filter(r, has(r.authorization) && r.authorization.type
+                    == 'ExternalAuth').size() <= 1
               targetRefs:
                 description: |-
                   TargetRefs specifies the targets of the AccessPolicy.

--- a/pkg/translator/accesspolicy.go
+++ b/pkg/translator/accesspolicy.go
@@ -169,7 +169,7 @@ func (t *Translator) translatesAccessPolicyToRBAC(accessPolicy *agenticv0alpha0.
 						klog.Errorf("Failed to generate unique ID for externalAuth config in AccessPolicy %s/%s: %v", accessPolicy.Namespace, accessPolicy.Name, err)
 						continue
 					}
-					rbacConfig.ShadowRulesStatPrefix = fmt.Sprintf("%s_%s_", externalAuthzShadowRulePrefix, hash)
+					rbacConfig.ShadowRulesStatPrefix = fmt.Sprintf("%s_%s_", externalAuthzShadowRulePrefix, hash) // a maximum of one ExternalAuth rule per policy is allowed, so we can safely set the shadow rule stat prefix at the RBAC config level
 					policy.Permissions = []*rbacconfigv3.Permission{buildTooslCallMethodPermission()}
 					addPolicyToRBACShadowRules(rbacConfig, policyName, policy)
 				}

--- a/tests/cel/accesspolicy_test.go
+++ b/tests/cel/accesspolicy_test.go
@@ -195,6 +195,40 @@ func TestValidateXAccessPolicy(t *testing.T) {
 			},
 			wantErrors: []string{"only one of tools or externalAuth can be specified"},
 		},
+		{
+			desc: "multiple ExternalAuth authorization rules specified",
+			mutate: func(p *v0alpha0.XAccessPolicy) {
+				p.Spec.Rules[0].Authorization = &v0alpha0.AuthorizationRule{
+					Type: v0alpha0.AuthorizationRuleTypeExternalAuth,
+					ExternalAuth: &gwapiv1.HTTPExternalAuthFilter{
+						ExternalAuthProtocol: gwapiv1.HTTPRouteExternalAuthGRPCProtocol,
+						BackendRef: gwapiv1.BackendObjectReference{
+							Name: "ext-auth-svc",
+						},
+					},
+				}
+				// add another rule with ExternalAuth type
+				p.Spec.Rules = append(p.Spec.Rules, v0alpha0.AccessRule{
+					Name: "rule-2",
+					Source: v0alpha0.Source{
+						Type: v0alpha0.AuthorizationSourceTypeServiceAccount,
+						ServiceAccount: &v0alpha0.AuthorizationSourceServiceAccount{
+							Name: "sa-2",
+						},
+					},
+					Authorization: &v0alpha0.AuthorizationRule{
+						Type: v0alpha0.AuthorizationRuleTypeExternalAuth,
+						ExternalAuth: &gwapiv1.HTTPExternalAuthFilter{
+							ExternalAuthProtocol: gwapiv1.HTTPRouteExternalAuthGRPCProtocol,
+							BackendRef: gwapiv1.BackendObjectReference{
+								Name: "ext-auth-svc-2",
+							},
+						},
+					},
+				})
+			},
+			wantErrors: []string{"a maximum of one rule per policy can specify 'ExternalAuth' authorization type"},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Enforces a maximum of one rule of `ExternalAuth` type per AccessPolicy object.

This will fix an issue of the reference implementation that currently makes all ext_authz rules of an AccessPolicy to always trigger the callout to the ext_authz service as it's specified at the last of these rules.

Example:

```yaml
rules:
- name: rule-1
  externalAuth: <ext-authz-config-1>
- name: rule-2
  externalAuth: <ext-authz-config-2> # <=== both rules trigger this config
```

The issue described does not affect ext_authz configs across different AccessPolicy objects / different Backend targets.

The simplest approach to resolve the issue is by changing the API to allow a maximum of 1 ext_authz per policy. Even if other (future) implementations may have a different way to manage the callouts to the ext_authz services compared to the reference implementation, where allowing multiple ext_authz rules is not a problem, it's still easier to remove this constraint in the future than having to impose it afterwards. And for the implementation, based on Envoy RBAC and ext_authz filter configurations, there are also options to support a unconstrained number of ext_authz rules if we want, despite a max of 1 being the recommended approach por now.

**Does this PR introduce a user-facing change?**:

```release-note
Sets a maximum of one rule of `ExternalAuth` type per AccessPolicy object
```