### PR TITLE
Add local_reply_config to convert 403 reponse to MCP compatible response

### DIFF
--- a/pkg/translator/listener.go
+++ b/pkg/translator/listener.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	accesslogv3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	ext_authzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
@@ -37,6 +38,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -190,6 +192,58 @@ func (t *Translator) translateListenerToFilterChain(lis gatewayv1.Listener, rout
 	return filterChain, nil
 }
 
+// buildLocalReplyConfig constructs the local reply configuration for 403 responses
+func buildLocalReplyConfig() *hcm.LocalReplyConfig {
+	return &hcm.LocalReplyConfig{
+		Mappers: []*hcm.ResponseMapper{
+			{
+				Filter: &accesslogv3.AccessLogFilter{
+					FilterSpecifier: &accesslogv3.AccessLogFilter_StatusCodeFilter{
+						StatusCodeFilter: &accesslogv3.StatusCodeFilter{
+							Comparison: &accesslogv3.ComparisonFilter{
+								Op: accesslogv3.ComparisonFilter_EQ,
+								Value: &corev3.RuntimeUInt32{
+									DefaultValue: 403,
+									RuntimeKey:   "custom_403",
+								},
+							},
+						},
+					},
+				},
+				// Change the status code to 200 so the MCP client processes the JSON-RPC error natively.
+				StatusCode: wrapperspb.UInt32(200),
+				// Override the body format to JSON-RPC 2.0.
+				BodyFormatOverride: &corev3.SubstitutionFormatString{
+					Format: &corev3.SubstitutionFormatString_JsonFormat{
+						JsonFormat: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"jsonrpc": structpb.NewStringValue("2.0"),
+								"id":      structpb.NewStringValue("%DYNAMIC_METADATA(mcp_proxy:id)%"),
+								"result": structpb.NewStructValue(&structpb.Struct{
+									Fields: map[string]*structpb.Value{
+										"isError": structpb.NewBoolValue(true),
+										"content": structpb.NewListValue(&structpb.ListValue{
+											Values: []*structpb.Value{
+												structpb.NewStructValue(&structpb.Struct{
+													Fields: map[string]*structpb.Value{
+														"type": structpb.NewStringValue("text"),
+														"text": structpb.NewStringValue("Access to this tool is forbidden (403)."),
+													},
+												}),
+											},
+										}),
+									},
+								}),
+							},
+						},
+					},
+					ContentType: "application/json",
+				},
+			},
+		},
+	}
+}
+
 func buildHTTPFilterChain(lis gatewayv1.Listener, routeName string, accessPolicyLister agenticlisters.XAccessPolicyLister) (*listener.FilterChain, error) {
 	httpFilters, err := buildHTTPFilters(accessPolicyLister)
 	if err != nil {
@@ -197,7 +251,8 @@ func buildHTTPFilterChain(lis gatewayv1.Listener, routeName string, accessPolicy
 	}
 
 	hcmConfig := &hcm.HttpConnectionManager{
-		StatPrefix: string(lis.Name),
+		StatPrefix:       string(lis.Name),
+		LocalReplyConfig: buildLocalReplyConfig(),
 		RouteSpecifier: &hcm.HttpConnectionManager_Rds{
 			Rds: &hcm.Rds{
 				ConfigSource: &corev3.ConfigSource{

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -33,6 +34,27 @@ const (
 	agentKeyPath  = "/run/agent-identity-mtls/credential-bundle.pem"
 	agentCAPath   = "/run/agent-identity-mtls/cluster.local.trust-bundle.pem"
 )
+
+type mcpResponse struct {
+	StatusCode int      `json:"status"`
+	Body       respBody `json:"body"`
+}
+
+type respBody struct {
+	JSONRPC string     `json:"jsonrpc"`
+	ID      int        `json:"id"`
+	Result  *mcpResult `json:"result,omitempty"`
+}
+
+type mcpResult struct {
+	IsError bool         `json:"isError"`
+	Content []mcpContent `json:"content"`
+}
+
+type mcpContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
 
 func TestControllerE2E(t *testing.T) {
 	// 1. Initial Setup
@@ -126,10 +148,45 @@ func TestControllerE2E(t *testing.T) {
 	// 5. Test Phase 1: get-sum allowed, echo denied
 	t.Log("Verifying initial policy (get-sum: OK, echo: DENY)...")
 
-	// get-sum should be 200
-	assertToolCall(t, mcpSessionID, gatewayIP, "get-sum", `{"a":2,"b":3}`, 200)
-	// echo should be 403
-	assertToolCall(t, mcpSessionID, gatewayIP, "echo", `{"message":"hello"}`, 403)
+	// get-sum should be successful.
+	assertToolCall(t, "1", mcpSessionID, gatewayIP, "get-sum", `{"a":2,"b":3}`,
+		mcpResponse{
+			StatusCode: 200,
+			Body: respBody{
+				JSONRPC: "2.0",
+				ID:      1,
+				Result: &mcpResult{
+					IsError: false,
+					Content: []mcpContent{
+						{
+							Type: "text",
+							Text: "The sum of 2 and 3 is 5.",
+						},
+					},
+				},
+			},
+		},
+	)
+
+	// echo should be unsuccessful.
+	assertToolCall(t, "2", mcpSessionID, gatewayIP, "echo", `{"message":"hello"}`,
+		mcpResponse{
+			StatusCode: 200,
+			Body: respBody{
+				JSONRPC: "2.0",
+				ID:      2,
+				Result: &mcpResult{
+					IsError: true,
+					Content: []mcpContent{
+						{
+							Type: "text",
+							Text: "Access to this tool is forbidden (403).",
+						},
+					},
+				},
+			},
+		},
+	)
 
 	// 6. Update Policy
 	t.Log("Updating XAccessPolicy (swap permissions)...")
@@ -142,10 +199,45 @@ func TestControllerE2E(t *testing.T) {
 	// 7. Test Phase 2: get-sum denied, echo allowed
 	t.Log("Verifying updated policy (get-sum: DENY, echo: OK)...")
 
-	// get-sum should now be 403
-	assertToolCall(t, mcpSessionID, gatewayIP, "get-sum", `{"a":2,"b":3}`, 403)
-	// echo should now be 200
-	assertToolCall(t, mcpSessionID, gatewayIP, "echo", `{"message":"hello"}`, 200)
+	// get-sum should now be unsuccessful.
+	assertToolCall(t, "3", mcpSessionID, gatewayIP, "get-sum", `{"a":2,"b":3}`,
+		mcpResponse{
+			StatusCode: 200,
+			Body: respBody{
+				JSONRPC: "2.0",
+				ID:      3,
+				Result: &mcpResult{
+					IsError: true,
+					Content: []mcpContent{
+						{
+							Type: "text",
+							Text: "Access to this tool is forbidden (403).",
+						},
+					},
+				},
+			},
+		},
+	)
+
+	// echo should now be successful.
+	assertToolCall(t, "4", mcpSessionID, gatewayIP, "echo", `{"message":"hello"}`,
+		mcpResponse{
+			StatusCode: 200,
+			Body: respBody{
+				JSONRPC: "2.0",
+				ID:      4,
+				Result: &mcpResult{
+					IsError: false,
+					Content: []mcpContent{
+						{
+							Type: "text",
+							Text: "Echo: hello",
+						},
+					},
+				},
+			},
+		},
+	)
 
 	t.Log("E2E Test Passed!")
 }
@@ -183,12 +275,11 @@ func retry(attempts int, sleep time.Duration, f func() error) error {
 	}
 	return fmt.Errorf("after %d attempts", attempts)
 }
-
-func assertToolCall(t *testing.T, sessionID, gatewayAddr, toolName, toolArgs string, expectedStatus int) {
-	data := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"%s","arguments":%s}}`, toolName, toolArgs)
+func assertToolCall(t *testing.T, requestID, sessionID, gatewayAddr, toolName, toolArgs string, expected mcpResponse) {
+	data := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"method":"tools/call","params":{"name":"%s","arguments":%s}}`, requestID, toolName, toolArgs)
 
 	out := runKubectlOutput(t, "exec", "e2e-tester", "-n", "e2e-test-ns", "--",
-		"curl", "-ks", "-o", "/dev/null", "-w", "%{http_code}",
+		"curl", "-ks", "-w", "\n%{http_code}",
 		"--cert", agentCertPath,
 		"--key", agentKeyPath,
 		"--cacert", agentCAPath,
@@ -199,14 +290,57 @@ func assertToolCall(t *testing.T, sessionID, gatewayAddr, toolName, toolArgs str
 		"--data-raw", data,
 		fmt.Sprintf("https://%s:10001/mcp", gatewayAddr))
 
-	gotStatus, err := strconv.Atoi(strings.TrimSpace(out))
-	if err != nil {
-		t.Fatalf("Failed to parse HTTP status code from curl output %q: %v", out, err)
+	out = strings.TrimSpace(out)
+	lines := strings.Split(out, "\n")
+	if len(lines) == 0 {
+		t.Fatalf("empty response from gateway")
 	}
 
-	if gotStatus != expectedStatus {
-		t.Errorf("Tool call %s: expected status %d, got %d", toolName, expectedStatus, gotStatus)
-	} else {
-		t.Logf("Tool call %s: got expected status %d", toolName, gotStatus)
+	// Check HTTP status code
+	codeStr := strings.TrimSpace(lines[len(lines)-1])
+	code, err := strconv.Atoi(codeStr)
+	if err != nil {
+		t.Fatalf("failed to parse HTTP status code from response: %q", codeStr)
+	}
+	if expected.StatusCode != 0 && code != expected.StatusCode {
+		t.Fatalf("unexpected HTTP status code: got %d, want %d\n", code, expected.StatusCode)
+	}
+	// An example mcp response body: {"id":1,"jsonrpc":"2.0","result":{"content":[{"text":"Access to this tool is forbidden (403).","type":"text"}],"isError":true}}
+	// Check HTTP body
+	body := strings.TrimSpace(strings.Join(lines[:len(lines)-1], "\n"))
+	var resp respBody
+	idx := strings.Index(body, "{")
+	if idx == -1 {
+		t.Fatalf("failed to find JSON payload in response\nbody: %s", body)
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(body[idx:])), &resp); err != nil {
+		t.Fatalf("failed to parse JSON response: %v\nbody: %s", err, body)
+	}
+
+	if expected.Body.JSONRPC != "" && resp.JSONRPC != expected.Body.JSONRPC {
+		t.Fatalf("jsonrpc mismatch: got %q, want %q\nJSON payload: %s", resp.JSONRPC, expected.Body.JSONRPC, body)
+	}
+
+	if requestID != "" && strconv.Itoa(resp.ID) != requestID {
+		t.Fatalf("id mismatch: got %q, want %q\nbody: %s", strconv.Itoa(resp.ID), requestID, body)
+	}
+
+	if resp.Result == nil || len(resp.Result.Content) == 0 {
+		t.Fatalf("response contains no result\nbody: %s", body)
+	}
+	isError := resp.Result.IsError
+	message := resp.Result.Content[0].Text
+	tp := resp.Result.Content[0].Type
+	expectedIsError := expected.Body.Result.IsError
+	expectedMessage := expected.Body.Result.Content[0].Text
+	expectedType := expected.Body.Result.Content[0].Type
+	if expectedIsError != isError {
+		t.Fatalf("isError mismatch: got %v, want %v\nbody: %s", isError, expectedIsError, body)
+	}
+	if expectedMessage != "" && message != expectedMessage {
+		t.Fatalf("message mismatch: expected %q to be in %q\nbody: %s", expectedMessage, message, body)
+	}
+	if expectedType != "" && tp != expectedType {
+		t.Fatalf("type mismatch: got %q, want %q\nbody: %s", tp, expectedType, body)
 	}
 }


### PR DESCRIPTION


**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
* The PR improves user experience when trying to use a restricted MCP tool. Instead of hanging there, the agents display 403 message to users.
* Improved e2e test to check more fields in the response.

Fixes #64


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
