### PR TITLE
Block XBackend deletion when HTTPRoutes still reference it

### DIFF
--- a/pkg/constants/controller.go
+++ b/pkg/constants/controller.go
@@ -35,6 +35,6 @@ const (
 	GatewayClassFinalizer = ProjectName + "/gatewayclass-finalizer"
 	// GatewayFinalizer is set on Gateway; removed when no HTTPRoutes reference it and proxy is cleaned up.
 	GatewayFinalizer = ProjectName + "/gateway-finalizer"
-	// XBackendFinalizer is set on XBackend; removed when no XAccessPolicy targets it.
+	// XBackendFinalizer is set on XBackend; removed when no XAccessPolicy targets it and no HTTPRoute references it.
 	XBackendFinalizer = ProjectName + "/xbackend-finalizer"
 )

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -80,10 +80,40 @@ func (c *Controller) onBackendDelete(obj interface{}) {
 	c.enqueueGatewaysForBackend(backend)
 }
 
-// enqueueBackendForFinalizer enqueues the XBackend for finalizer sync only (add/remove finalizer based on XAccessPolicy targetRefs). It does not enqueue Gateways.
+// enqueueBackendForFinalizer enqueues the XBackend for finalizer sync only (add/remove finalizer based on XAccessPolicy and HTTPRoute references). It does not enqueue Gateways.
 func (c *Controller) enqueueBackendForFinalizer(backend *agenticv0alpha0.XBackend) {
 	key := backend.Namespace + "/" + backend.Name
 	c.backendFinalizerQueue.Add(key)
+}
+
+// enqueueBackendsForHTTPRouteFinalizer enqueues each XBackend referenced by the HTTPRoute's backendRefs for finalizer sync.
+// Call this when an HTTPRoute is added, updated, or deleted so XBackends can re-evaluate and remove their finalizer when no longer referenced.
+func (c *Controller) enqueueBackendsForHTTPRouteFinalizer(route *gatewayv1.HTTPRoute) {
+	seen := make(map[string]struct{})
+	for _, rule := range route.Spec.Rules {
+		for _, ref := range rule.BackendRefs {
+			if !isXBackendRef(ref.BackendRef) {
+				continue
+			}
+			ns := route.Namespace
+			if ref.Namespace != nil {
+				ns = string(*ref.Namespace)
+			}
+			key := ns + "/" + string(ref.Name)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			backend, err := c.agentic.backendLister.XBackends(ns).Get(string(ref.Name))
+			if err != nil {
+				if !apierrors.IsNotFound(err) {
+					runtime.HandleError(fmt.Errorf("failed to get XBackend %s/%s for HTTPRoute finalizer enqueue: %w", ns, ref.Name, err))
+				}
+				continue
+			}
+			c.enqueueBackendForFinalizer(backend)
+		}
+	}
 }
 
 // syncBackendFinalizer manages the XBackend finalizer.
@@ -105,6 +135,10 @@ func (c *Controller) syncBackendFinalizer(ctx context.Context, key string) error
 	if backend.DeletionTimestamp != nil {
 		if hasAccessPoliciesTargetingBackend(c, backend) {
 			klog.V(4).InfoS("XBackend has XAccessPolicies still targeting it, blocking deletion", "backend", klog.KObj(backend))
+			return nil
+		}
+		if hasHTTPRoutesReferencingBackend(c, backend) {
+			klog.V(4).InfoS("XBackend is still referenced by HTTPRoute(s), blocking deletion", "backend", klog.KObj(backend))
 			return nil
 		}
 		if removeFinalizer(&newBackend.ObjectMeta, constants.XBackendFinalizer) {
@@ -138,6 +172,32 @@ func hasAccessPoliciesTargetingBackend(c *Controller, backend *agenticv0alpha0.X
 			}
 			if string(targetRef.Name) == backend.Name {
 				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasHTTPRoutesReferencingBackend returns true if any HTTPRoute has a backendRef to the given XBackend.
+func hasHTTPRoutesReferencingBackend(c *Controller, backend *agenticv0alpha0.XBackend) bool {
+	routes, err := c.gateway.httprouteLister.List(labels.Everything())
+	if err != nil {
+		klog.V(4).ErrorS(err, "failed to list HTTPRoutes for XBackend finalizer")
+		return true
+	}
+	for _, route := range routes {
+		for _, rule := range route.Spec.Rules {
+			for _, ref := range rule.BackendRefs {
+				if !isXBackendRef(ref.BackendRef) {
+					continue
+				}
+				refNamespace := route.Namespace
+				if ref.Namespace != nil {
+					refNamespace = string(*ref.Namespace)
+				}
+				if string(ref.Name) == backend.Name && refNamespace == backend.Namespace {
+					return true
+				}
 			}
 		}
 	}

--- a/pkg/controller/backend_test.go
+++ b/pkg/controller/backend_test.go
@@ -19,11 +19,12 @@ package controller
 import (
 	"testing"
 
-	"k8s.io/client-go/tools/cache"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewaylisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1"
 
 	agenticv0alpha0 "sigs.k8s.io/kube-agentic-networking/api/v0alpha0"
 	agenticlisters "sigs.k8s.io/kube-agentic-networking/k8s/client/listers/api/v0alpha0"
@@ -186,4 +187,79 @@ func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
 			t.Error("expected true when one targetRef matches this backend")
 		}
 	})
+}
+
+func TestHasHTTPRoutesReferencingBackend(t *testing.T) {
+	ns := "default"
+	backendName := "my-backend"
+
+	httpRouteWithBackendRef := func(backendRefName string, xbackend bool) *gatewayv1.HTTPRoute {
+		ref := gatewayv1.BackendRef{
+			BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name: gatewayv1.ObjectName(backendRefName),
+			},
+		}
+		if xbackend {
+			ref.Group = ptr.To(gatewayv1.Group(agenticv0alpha0.GroupName))
+			ref.Kind = ptr.To(gatewayv1.Kind("XBackend"))
+		}
+		return &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "route-1"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Rules: []gatewayv1.HTTPRouteRule{{
+					BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: ref}},
+				}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		routes         []*gatewayv1.HTTPRoute
+		wantReferenced bool
+	}{
+		{
+			name:           "no routes",
+			routes:         nil,
+			wantReferenced: false,
+		},
+		{
+			name:           "route references different XBackend",
+			routes:         []*gatewayv1.HTTPRoute{httpRouteWithBackendRef("other-backend", true)},
+			wantReferenced: false,
+		},
+		{
+			name:           "route references this XBackend",
+			routes:         []*gatewayv1.HTTPRoute{httpRouteWithBackendRef(backendName, true)},
+			wantReferenced: true,
+		},
+		{
+			name:           "route references Service not XBackend is ignored",
+			routes:         []*gatewayv1.HTTPRoute{httpRouteWithBackendRef(backendName, false)},
+			wantReferenced: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, route := range tt.routes {
+				if err := indexer.Add(route); err != nil {
+					t.Fatalf("indexer.Add: %v", err)
+				}
+			}
+			c := &Controller{
+				gateway: gatewayResources{
+					httprouteLister: gatewaylisters.NewHTTPRouteLister(indexer),
+				},
+			}
+			backend := &agenticv0alpha0.XBackend{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: backendName},
+			}
+			got := hasHTTPRoutesReferencingBackend(c, backend)
+			if got != tt.wantReferenced {
+				t.Errorf("hasHTTPRoutesReferencingBackend() = %v, want %v", got, tt.wantReferenced)
+			}
+		})
+	}
 }

--- a/pkg/controller/httproute.go
+++ b/pkg/controller/httproute.go
@@ -48,6 +48,7 @@ func (c *Controller) onHTTPRouteAdd(obj interface{}) {
 	route := obj.(*gatewayv1.HTTPRoute)
 	klog.V(4).InfoS("Adding HTTPRoute", "httproute", klog.KObj(route))
 	c.enqueueGatewaysForHTTPRoute(route.Spec.ParentRefs, route.Namespace)
+	c.enqueueBackendsForHTTPRouteFinalizer(route)
 }
 
 func (c *Controller) onHTTPRouteUpdate(old, newObj interface{}) {
@@ -56,6 +57,8 @@ func (c *Controller) onHTTPRouteUpdate(old, newObj interface{}) {
 	if newRoute.Generation != oldRoute.Generation || newRoute.DeletionTimestamp != oldRoute.DeletionTimestamp || !reflect.DeepEqual(newRoute.Annotations, oldRoute.Annotations) {
 		klog.V(4).InfoS("Updating HTTPRoute", "httproute", klog.KObj(oldRoute))
 		c.enqueueGatewaysForHTTPRoute(append(oldRoute.Spec.ParentRefs, newRoute.Spec.ParentRefs...), newRoute.Namespace)
+		c.enqueueBackendsForHTTPRouteFinalizer(oldRoute)
+		c.enqueueBackendsForHTTPRouteFinalizer(newRoute)
 	}
 }
 
@@ -75,6 +78,7 @@ func (c *Controller) onHTTPRouteDelete(obj interface{}) {
 	}
 	klog.V(4).InfoS("Deleting HTTPRoute", "httproute", klog.KObj(route))
 	c.enqueueGatewaysForHTTPRoute(route.Spec.ParentRefs, route.Namespace)
+	c.enqueueBackendsForHTTPRouteFinalizer(route)
 }
 
 // enqueueGatewaysForHTTPRoute enqueues Gateways so they are reconciled; when an HTTPRoute


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The XBackend finalizer previously only considered XAccessPolicy targetRefs. An XBackend could be deleted while HTTPRoutes still had a backendRef to it, leaving routes pointing at a non-existent backend. An XBackend cannot be deleted until every HTTPRoute that references it has been updated or removed, preventing out-of-order deletion and broken route refs.

#### Changes
- **syncBackendFinalizer**: When an XBackend has a deletion timestamp, the finalizer is only removed if no XAccessPolicy targets it **and** no HTTPRoute references it. Added a check using **hasHTTPRoutesReferencingBackend** before removing the finalizer.
- **hasHTTPRoutesReferencingBackend**: Returns true if any HTTPRoute has a `backendRef` to this XBackend (same namespace/name; only XBackend refs via `isXBackendRef`). On HTTPRoute lister error we return true so we do not allow deletion.
- **Tests**: `TestHasHTTPRoutesReferencingBackend` with cases: no routes, route references another XBackend, route references this XBackend, route references Service (same name) is ignored.

**Which issue(s) this PR fixes**:
Fixes #149 

```release-note
NONE
```
