### PR TITLE
controller: block Gateway deletion when AccessPolicy targets it

### DIFF
--- a/pkg/constants/controller.go
+++ b/pkg/constants/controller.go
@@ -33,7 +33,7 @@ const (
 
 	// GatewayClassFinalizer is set on GatewayClass; removed when no Gateways use this class.
 	GatewayClassFinalizer = ProjectName + "/gatewayclass-finalizer"
-	// GatewayFinalizer is set on Gateway; removed when no HTTPRoutes reference it and proxy is cleaned up.
+	// GatewayFinalizer is set on Gateway; removed when no HTTPRoutes or AccessPolicies reference it and proxy is cleaned up.
 	GatewayFinalizer = ProjectName + "/gateway-finalizer"
 	// XBackendFinalizer is set on XBackend; removed when no XAccessPolicy targets it and no HTTPRoute references it.
 	XBackendFinalizer = ProjectName + "/xbackend-finalizer"

--- a/pkg/controller/accesspolicy.go
+++ b/pkg/controller/accesspolicy.go
@@ -121,6 +121,7 @@ func (c *Controller) onAccessPolicyDelete(obj interface{}) {
 
 // enqueueGatewaysForAccessPolicy enqueues all Gateways that are affected by the given AccessPolicy.
 // It also enqueues the targeted XBackend for finalizer reconciliation.
+// When an AccessPolicy targets a Gateway, that Gateway is enqueued so its finalizer can be re-evaluated on AccessPolicy delete (avoids deadlock).
 func (c *Controller) enqueueGatewaysForAccessPolicy(policy *agenticv0alpha0.XAccessPolicy) {
 	isAccepted := policy.IsAccepted()
 	isDeleting := policy.DeletionTimestamp != nil
@@ -128,24 +129,14 @@ func (c *Controller) enqueueGatewaysForAccessPolicy(policy *agenticv0alpha0.XAcc
 
 	for _, targetRef := range policy.Spec.TargetRefs {
 		if isGatewayTargetRef(targetRef) {
-			// We only reconcile Gateways/Envoy for accepted policies.
-			if !shouldEnqueueGW {
-				continue
-			}
-			gw, err := c.gateway.gatewayLister.Gateways(policy.Namespace).Get(string(targetRef.Name))
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					// TODO: Set status condition on AccessPolicy to indicate missing Gateway
-					klog.InfoS("AccessPolicy targets a non-existent Gateway", "accesspolicy", klog.KObj(policy), "gateway", types.NamespacedName{Namespace: policy.Namespace, Name: string(targetRef.Name)})
-				} else {
-					runtime.HandleError(fmt.Errorf("failed to get gateway %s/%s targeted by access policy %s: %w", policy.Namespace, targetRef.Name, policy.Name, err))
-				}
-				continue
-			}
-			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(gw)
-			if err == nil {
-				c.gatewayqueue.Add(key)
-			}
+			// Always enqueue targeted Gateways so syncGateway can add/maintain the Gateway finalizer
+			// and re-evaluate hasAccessPoliciesTargetingGateway when this policy changes or is removed.
+			// This matches the "wake parent on dependent delete" pattern from
+			// https://github.com/kubernetes-sigs/kube-agentic-networking/pull/148 (see also #150).
+			// Unlike XBackend→Gateway fan-out, we do not gate on policy acceptance: rejected policies
+			// still block Gateway deletion via hasAccessPoliciesTargetingGateway until removed.
+			gatewayKey := policy.Namespace + "/" + string(targetRef.Name)
+			c.gatewayqueue.Add(gatewayKey)
 			continue
 		}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -346,10 +346,14 @@ func (c *Controller) syncGateway(ctx context.Context, key string) error {
 		return nil
 	}
 
-	// If Gateway is being deleted, block until no HTTPRoutes reference it, then clean up and remove finalizer.
+	// If Gateway is being deleted, block until no HTTPRoutes or AccessPolicies reference it, then clean up and remove finalizer.
 	if gateway.DeletionTimestamp != nil {
 		if hasHTTPRoutesReferencingGateway(c, gateway) {
 			logger.V(4).Info("Gateway has HTTPRoutes still referencing it, blocking deletion")
+			return nil
+		}
+		if hasAccessPoliciesTargetingGateway(c, gateway) {
+			logger.V(4).Info("Gateway has AccessPolicies still targeting it, blocking deletion")
 			return nil
 		}
 		if errDel := envoy.DeleteProxy(ctx, c.core.client, namespace, name); errDel != nil {
@@ -438,6 +442,27 @@ func hasHTTPRoutesReferencingGateway(c *Controller, gw *gatewayv1.Gateway) bool 
 				refNamespace = string(*parentRef.Namespace)
 			}
 			if string(parentRef.Name) == gw.Name && refNamespace == gw.Namespace {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasAccessPoliciesTargetingGateway returns true if any XAccessPolicy has a targetRef to the given Gateway.
+// Used to block Gateway finalizer removal until all targeting AccessPolicies are removed (avoids dangling refs).
+func hasAccessPoliciesTargetingGateway(c *Controller, gw *gatewayv1.Gateway) bool {
+	policies, err := c.agentic.accessPolicyLister.XAccessPolicies(gw.Namespace).List(labels.Everything())
+	if err != nil {
+		klog.V(4).ErrorS(err, "failed to list AccessPolicies for Gateway finalizer")
+		return true // conservatively block
+	}
+	for _, policy := range policies {
+		for _, targetRef := range policy.Spec.TargetRefs {
+			if !isGatewayTargetRef(targetRef) {
+				continue
+			}
+			if string(targetRef.Name) == gw.Name {
 				return true
 			}
 		}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -19,12 +19,14 @@ package controller
 import (
 	"testing"
 
-	"k8s.io/client-go/tools/cache"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewaylisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1"
+
+	agenticv0alpha0 "sigs.k8s.io/kube-agentic-networking/api/v0alpha0"
+	agenticlisters "sigs.k8s.io/kube-agentic-networking/k8s/client/listers/api/v0alpha0"
 )
 
 func TestHasHTTPRoutesReferencingGateway(t *testing.T) {
@@ -214,6 +216,119 @@ func TestHasHTTPRoutesReferencingGateway(t *testing.T) {
 		}
 		if !hasHTTPRoutesReferencingGateway(c, gw) {
 			t.Error("expected true when one parentRef references this gateway")
+		}
+	})
+}
+
+func TestHasAccessPoliciesTargetingGateway(t *testing.T) {
+	gwNamespace := "default"
+	gwName := "my-gateway"
+
+	t.Run("no policies in namespace", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		c := &Controller{
+			agentic: agenticNetResources{
+				accessPolicyLister: agenticlisters.NewXAccessPolicyLister(indexer),
+			},
+		}
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: gwName},
+		}
+		if hasAccessPoliciesTargetingGateway(c, gw) {
+			t.Error("expected false when no AccessPolicies exist in namespace")
+		}
+	})
+
+	t.Run("policy targets different gateway", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		policy := &agenticv0alpha0.XAccessPolicy{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: "policy-1"},
+			Spec: agenticv0alpha0.AccessPolicySpec{
+				TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+					{
+						LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+							Group: gatewayv1.GroupName, Kind: "Gateway", Name: gatewayv1.ObjectName("other-gateway"),
+						},
+					},
+				},
+				Rules: []agenticv0alpha0.AccessRule{{Name: "r1", Source: agenticv0alpha0.Source{Type: agenticv0alpha0.AuthorizationSourceTypeSPIFFE}}},
+			},
+		}
+		if err := indexer.Add(policy); err != nil {
+			t.Fatalf("indexer.Add: %v", err)
+		}
+		c := &Controller{
+			agentic: agenticNetResources{
+				accessPolicyLister: agenticlisters.NewXAccessPolicyLister(indexer),
+			},
+		}
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: gwName},
+		}
+		if hasAccessPoliciesTargetingGateway(c, gw) {
+			t.Error("expected false when policy targets a different gateway")
+		}
+	})
+
+	t.Run("policy targets this gateway", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		policy := &agenticv0alpha0.XAccessPolicy{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: "policy-1"},
+			Spec: agenticv0alpha0.AccessPolicySpec{
+				TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+					{
+						LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+							Group: gatewayv1.GroupName, Kind: "Gateway", Name: gatewayv1.ObjectName(gwName),
+						},
+					},
+				},
+				Rules: []agenticv0alpha0.AccessRule{{Name: "r1", Source: agenticv0alpha0.Source{Type: agenticv0alpha0.AuthorizationSourceTypeSPIFFE}}},
+			},
+		}
+		if err := indexer.Add(policy); err != nil {
+			t.Fatalf("indexer.Add: %v", err)
+		}
+		c := &Controller{
+			agentic: agenticNetResources{
+				accessPolicyLister: agenticlisters.NewXAccessPolicyLister(indexer),
+			},
+		}
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: gwName},
+		}
+		if !hasAccessPoliciesTargetingGateway(c, gw) {
+			t.Error("expected true when policy targets this gateway")
+		}
+	})
+
+	t.Run("policy with XBackend targetRef only", func(t *testing.T) {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		policy := &agenticv0alpha0.XAccessPolicy{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: "policy-1"},
+			Spec: agenticv0alpha0.AccessPolicySpec{
+				TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+					{
+						LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+							Group: agenticv0alpha0.GroupName, Kind: "XBackend", Name: gatewayv1.ObjectName("some-backend"),
+						},
+					},
+				},
+				Rules: []agenticv0alpha0.AccessRule{{Name: "r1", Source: agenticv0alpha0.Source{Type: agenticv0alpha0.AuthorizationSourceTypeSPIFFE}}},
+			},
+		}
+		if err := indexer.Add(policy); err != nil {
+			t.Fatalf("indexer.Add: %v", err)
+		}
+		c := &Controller{
+			agentic: agenticNetResources{
+				accessPolicyLister: agenticlisters.NewXAccessPolicyLister(indexer),
+			},
+		}
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: gwName},
+		}
+		if hasAccessPoliciesTargetingGateway(c, gw) {
+			t.Error("expected false when policy only targets XBackend, not Gateway")
 		}
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Deleting a Gateway that is still referenced by an AccessPolicy can lead to inconsistent state and reconciliation errors.

- **Finalizer protection:** When reconciling a Gateway that is being deleted, the controller now also checks whether any XAccessPolicy in the same namespace has a `targetRef` to this Gateway (group `gateway.networking.k8s.io`, kind `Gateway`). If so, the Gateway’s finalizer is not removed and the Envoy proxy is not deleted until those AccessPolicies are removed.
- **Reconciliation on AccessPolicy delete:** When an AccessPolicy is added, updated, or deleted, the controller enqueues any Gateway referenced by that policy’s `targetRefs`. So when an AccessPolicy that targeted a Gateway is deleted, the Gateway is reconciled and can then remove its finalizer and complete deletion, avoiding the deadlock pattern.

**Which issue(s) this PR fixes**:
Fixes #150 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
