### PR TITLE
update envoy filter to not override MCP server 403 response

### DIFF
--- a/pkg/translator/listener.go
+++ b/pkg/translator/listener.go
@@ -25,6 +25,7 @@ import (
 	accesslogv3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	ext_authzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	mcpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/mcp/v3"
 	rbacv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
@@ -204,20 +205,52 @@ func buildLocalReplyConfig() *hcm.LocalReplyConfig {
 	return &hcm.LocalReplyConfig{
 		Mappers: []*hcm.ResponseMapper{
 			{
+				// Use an access-log style filter to identify the responses we want to remap.
+				// The AND filter ensures both conditions must hold:
+				// 1) Status code equals the runtime-configurable value (default 403).
+				// 2) The "WWW-Authenticate" header is NOT present so we don't catch
+				//    upstream authentication failures (which include that header).
 				Filter: &accesslogv3.AccessLogFilter{
-					FilterSpecifier: &accesslogv3.AccessLogFilter_StatusCodeFilter{
-						StatusCodeFilter: &accesslogv3.StatusCodeFilter{
-							Comparison: &accesslogv3.ComparisonFilter{
-								Op: accesslogv3.ComparisonFilter_EQ,
-								Value: &corev3.RuntimeUInt32{
-									DefaultValue: 403,
-									RuntimeKey:   "custom_403",
+					FilterSpecifier: &accesslogv3.AccessLogFilter_AndFilter{
+						AndFilter: &accesslogv3.AndFilter{
+							Filters: []*accesslogv3.AccessLogFilter{
+								{
+									FilterSpecifier: &accesslogv3.AccessLogFilter_StatusCodeFilter{
+										StatusCodeFilter: &accesslogv3.StatusCodeFilter{
+											Comparison: &accesslogv3.ComparisonFilter{
+												Op: accesslogv3.ComparisonFilter_EQ,
+												Value: &corev3.RuntimeUInt32{
+													DefaultValue: 403,
+												},
+											},
+										},
+									},
+								},
+								// MCP servers typically return 403 with a "WWW-Authenticate" header when
+								// the client fails to authenticate. We only want to remap our custom 403s,
+								// so require that header to be absent.
+								// https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#protected-resource-metadata-discovery-requirements
+								{
+									FilterSpecifier: &accesslogv3.AccessLogFilter_HeaderFilter{
+										HeaderFilter: &accesslogv3.HeaderFilter{
+											Header: &routev3.HeaderMatcher{
+												Name:                 "WWW-Authenticate",
+												HeaderMatchSpecifier: &routev3.HeaderMatcher_PresentMatch{PresentMatch: false},
+											},
+										},
+									},
 								},
 							},
 						},
 					},
 				},
-				// Change the status code to 200 so the MCP client processes the JSON-RPC error natively.
+				// TODO: https://github.com/kubernetes-sigs/kube-agentic-networking/issues/169
+				// NOTE: Temporary workaround: Agent SDKs incorrectly treat a 403 in a way that
+				// prevents proper client-side error handling. To remain compatible until all SDKs
+				// are fixed, set the HTTP status code to 200 and encode a JSON-RPC error body.
+				// See the linked SDK improvement below for context.
+				// https://github.com/modelcontextprotocol/python-sdk/commit/2fe56e56de2aff8fcb964ff7e26e7c6df4d14653
+				// Change the HTTP status code back to 403 when the commit above is released in all Agent SDKs.
 				StatusCode: wrapperspb.UInt32(200),
 				// Override the body format to JSON-RPC 2.0.
 				BodyFormatOverride: &corev3.SubstitutionFormatString{
@@ -226,19 +259,10 @@ func buildLocalReplyConfig() *hcm.LocalReplyConfig {
 							Fields: map[string]*structpb.Value{
 								"jsonrpc": structpb.NewStringValue("2.0"),
 								"id":      structpb.NewStringValue("%DYNAMIC_METADATA(mcp_proxy:id)%"),
-								"result": structpb.NewStructValue(&structpb.Struct{
+								"error": structpb.NewStructValue(&structpb.Struct{
 									Fields: map[string]*structpb.Value{
-										"isError": structpb.NewBoolValue(true),
-										"content": structpb.NewListValue(&structpb.ListValue{
-											Values: []*structpb.Value{
-												structpb.NewStructValue(&structpb.Struct{
-													Fields: map[string]*structpb.Value{
-														"type": structpb.NewStringValue("text"),
-														"text": structpb.NewStringValue("Access to this tool is forbidden (403)."),
-													},
-												}),
-											},
-										}),
+										"code":    structpb.NewNumberValue(403),
+										"message": structpb.NewStringValue("Access to this tool is forbidden."),
 									},
 								}),
 							},

--- a/site-src/guides/quickstart/README.md
+++ b/site-src/guides/quickstart/README.md
@@ -44,7 +44,7 @@ graph TD
 
     Decision -- "Yes" --> LocalMCP
     Decision -- "Yes" --> RemoteMCP(Remote MCP Server)
-    Decision -- "No" --> Forbidden(Response: 403 Forbidden)
+    Decision -- "No" --> Forbidden["Response: Access to this tool is forbidden.<br/><br/><i>* Returns HTTP 200 with JSON-RPC error<br/>* Temporary workaround for ongoing MCP SDK improvements, <a href='https://github.com/kubernetes-sigs/kube-agentic-networking/issues/169'>see issue #169</a></i>"]
 
     style User fill:#f9f,stroke:#333,stroke-width:2px
     style RemoteMCP fill:#f9f,stroke:#333,stroke-width:2px

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -40,10 +40,16 @@ type mcpResponse struct {
 	Body       respBody `json:"body"`
 }
 
+type mcpError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
 type respBody struct {
 	JSONRPC string     `json:"jsonrpc"`
 	ID      int        `json:"id"`
 	Result  *mcpResult `json:"result,omitempty"`
+	Error   *mcpError  `json:"error,omitempty"`
 }
 
 type mcpResult struct {
@@ -174,15 +180,9 @@ func TestControllerE2E(t *testing.T) {
 			StatusCode: 200,
 			Body: respBody{
 				JSONRPC: "2.0",
-				ID:      2,
-				Result: &mcpResult{
-					IsError: true,
-					Content: []mcpContent{
-						{
-							Type: "text",
-							Text: "Access to this tool is forbidden (403).",
-						},
-					},
+				Error: &mcpError{
+					Code:    403,
+					Message: "Access to this tool is forbidden.",
 				},
 			},
 		},
@@ -206,14 +206,9 @@ func TestControllerE2E(t *testing.T) {
 			Body: respBody{
 				JSONRPC: "2.0",
 				ID:      3,
-				Result: &mcpResult{
-					IsError: true,
-					Content: []mcpContent{
-						{
-							Type: "text",
-							Text: "Access to this tool is forbidden (403).",
-						},
-					},
+				Error: &mcpError{
+					Code:    403,
+					Message: "Access to this tool is forbidden.",
 				},
 			},
 		},
@@ -225,7 +220,6 @@ func TestControllerE2E(t *testing.T) {
 			StatusCode: 200,
 			Body: respBody{
 				JSONRPC: "2.0",
-				ID:      4,
 				Result: &mcpResult{
 					IsError: false,
 					Content: []mcpContent{
@@ -325,22 +319,34 @@ func assertToolCall(t *testing.T, requestID, sessionID, gatewayAddr, toolName, t
 		t.Fatalf("id mismatch: got %q, want %q\nbody: %s", strconv.Itoa(resp.ID), requestID, body)
 	}
 
-	if resp.Result == nil || len(resp.Result.Content) == 0 {
-		t.Fatalf("response contains no result\nbody: %s", body)
-	}
-	isError := resp.Result.IsError
-	message := resp.Result.Content[0].Text
-	tp := resp.Result.Content[0].Type
-	expectedIsError := expected.Body.Result.IsError
-	expectedMessage := expected.Body.Result.Content[0].Text
-	expectedType := expected.Body.Result.Content[0].Type
-	if expectedIsError != isError {
-		t.Fatalf("isError mismatch: got %v, want %v\nbody: %s", isError, expectedIsError, body)
-	}
-	if expectedMessage != "" && message != expectedMessage {
-		t.Fatalf("message mismatch: expected %q to be in %q\nbody: %s", expectedMessage, message, body)
-	}
-	if expectedType != "" && tp != expectedType {
-		t.Fatalf("type mismatch: got %q, want %q\nbody: %s", tp, expectedType, body)
+	if expected.Body.Error != nil {
+		if resp.Error == nil {
+			t.Fatalf("expected error but got nil\nbody: %s", body)
+		}
+		if resp.Error.Code != expected.Body.Error.Code {
+			t.Fatalf("error code mismatch: got %d, want %d\nbody: %s", resp.Error.Code, expected.Body.Error.Code, body)
+		}
+		if expected.Body.Error.Message != "" && resp.Error.Message != expected.Body.Error.Message {
+			t.Fatalf("error message mismatch: got %q, want %q\nbody: %s", resp.Error.Message, expected.Body.Error.Message, body)
+		}
+	} else {
+		if resp.Result == nil || len(resp.Result.Content) == 0 {
+			t.Fatalf("response contains no result\nbody: %s", body)
+		}
+		isError := resp.Result.IsError
+		message := resp.Result.Content[0].Text
+		tp := resp.Result.Content[0].Type
+		expectedIsError := expected.Body.Result.IsError
+		expectedMessage := expected.Body.Result.Content[0].Text
+		expectedType := expected.Body.Result.Content[0].Type
+		if expectedIsError != isError {
+			t.Fatalf("isError mismatch: got %v, want %v\nbody: %s", isError, expectedIsError, body)
+		}
+		if expectedMessage != "" && message != expectedMessage {
+			t.Fatalf("message mismatch: expected %q to be in %q\nbody: %s", expectedMessage, message, body)
+		}
+		if expectedType != "" && tp != expectedType {
+			t.Fatalf("type mismatch: got %q, want %q\nbody: %s", tp, expectedType, body)
+		}
 	}
 }


### PR DESCRIPTION


**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
* Skip response override for real MCP server auth response.
* Use protocal errors instead of tool errors for envoy 403s. as @chuangw6  pointed out https://modelcontextprotocol.io/specification/draft/server/tools#error-handling
* Add comment to change transport level status code after  https://github.com/modelcontextprotocol/python-sdk/commit/2fe56e56de2aff8fcb964ff7e26e7c6df4d14653 is released.

Ref #64 #169

I've created #169 so that we don't forget to pick it up in the future.

**Does this PR introduce a user-facing change?**:

```release-note
None
```
