### PR TITLE
small fix to the openai agent

### DIFF
--- a/site-src/guides/quickstart/additional-agent-examples/openai-agent/deployment.yaml
+++ b/site-src/guides/quickstart/additional-agent-examples/openai-agent/deployment.yaml
@@ -73,7 +73,7 @@ spec:
               # This is the address of the Envoy sidecar
               value: "127.0.0.1:10001"
             - name: HF_MODEL
-              value: "deepseek-ai/DeepSeek-R1-0528"
+              value: "huggingface/deepseek-ai/DeepSeek-R1-0528"
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/site-src/guides/quickstart/additional-agent-examples/openai-agent/main.py
+++ b/site-src/guides/quickstart/additional-agent-examples/openai-agent/main.py
@@ -26,7 +26,7 @@ if not envoy_service:
     raise ValueError("the ENVOY_SERVICE environment variable is missing.")
 
 DEEPWIKI_URL = f"http://{envoy_service}/remote/mcp"
-EVERYTHINGMCP_URL = f"http://{envoy_service}/local/mcp",
+EVERYTHINGMCP_URL = f"http://{envoy_service}/local/mcp"
 
 HF_TOKEN = os.getenv("HF_TOKEN")
 if not HF_TOKEN:
@@ -40,7 +40,7 @@ client = AsyncOpenAI(
     base_url="https://router.huggingface.co/v1",
     api_key=HF_TOKEN
 )
-MODEL_NAME = "deepseek-ai/DeepSeek-R1-0528"
+MODEL_NAME = hf_model.removeprefix("huggingface/")
 
 logging.basicConfig(
     level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(name)s - %(message)s"


### PR DESCRIPTION


**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

* prefix  the HF_MODEL Env  with "huggingface/" to match other agents deployment spec. users will use the same command to switch models.

* remove an extra comma in the python string

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
