### PR TITLE
Optimize AccessPolicy target lookup using custom indexer

### DIFF
--- a/pkg/controller/accesspolicy.go
+++ b/pkg/controller/accesspolicy.go
@@ -38,6 +38,26 @@ import (
 	"sigs.k8s.io/kube-agentic-networking/pkg/constants"
 )
 
+// AccessPolicyTargetRefIndex is the index name for looking up AccessPolicies by target ref (namespace/name of XBackend).
+const AccessPolicyTargetRefIndex = "targetRef"
+
+// accessPolicyTargetRefIndexFunc indexes AccessPolicies by each XBackend targetRef (namespace/name).
+// Used by the informer cache to support O(1) lookup of policies targeting a given backend.
+func accessPolicyTargetRefIndexFunc(obj interface{}) ([]string, error) {
+	policy, ok := obj.(*agenticv0alpha0.XAccessPolicy)
+	if !ok {
+		return nil, nil
+	}
+	var keys []string
+	for _, targetRef := range policy.Spec.TargetRefs {
+		if !isXBackendTargetRef(targetRef) {
+			continue
+		}
+		keys = append(keys, policy.Namespace+"/"+string(targetRef.Name))
+	}
+	return keys, nil
+}
+
 func (c *Controller) setupAccessPolicyEventHandlers(accessPolicyInformer agenticinformers.XAccessPolicyInformer) error {
 	_, err := accessPolicyInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onAccessPolicyAdd,

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -159,6 +159,15 @@ func (c *Controller) syncBackendFinalizer(ctx context.Context, key string) error
 
 // hasAccessPoliciesTargetingBackend returns true if any XAccessPolicy has a targetRef to the given backend.
 func hasAccessPoliciesTargetingBackend(c *Controller, backend *agenticv0alpha0.XBackend) bool {
+	if c.agentic.accessPolicyIndexer != nil {
+		key := backend.Namespace + "/" + backend.Name
+		objs, err := c.agentic.accessPolicyIndexer.ByIndex(AccessPolicyTargetRefIndex, key)
+		if err != nil {
+			klog.V(4).ErrorS(err, "failed to list XAccessPolicies by targetRef index for XBackend finalizer")
+			return true
+		}
+		return len(objs) > 0
+	}
 	policies, err := c.agentic.accessPolicyLister.XAccessPolicies(backend.Namespace).List(labels.Everything())
 	if err != nil {
 		klog.V(4).ErrorS(err, "failed to list XAccessPolicies for XBackend finalizer")

--- a/pkg/controller/backend_test.go
+++ b/pkg/controller/backend_test.go
@@ -35,10 +35,14 @@ func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
 	backendName := "my-backend"
 
 	t.Run("no policies in namespace", func(t *testing.T) {
-		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+			cache.NamespaceIndex:       cache.MetaNamespaceIndexFunc,
+			AccessPolicyTargetRefIndex: accessPolicyTargetRefIndexFunc,
+		})
 		c := &Controller{
 			agentic: agenticNetResources{
-				accessPolicyLister: agenticlisters.NewXAccessPolicyLister(indexer),
+				accessPolicyLister:  agenticlisters.NewXAccessPolicyLister(indexer),
+				accessPolicyIndexer: indexer,
 			},
 		}
 		backend := &agenticv0alpha0.XBackend{
@@ -50,7 +54,10 @@ func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
 	})
 
 	t.Run("policy targets different backend", func(t *testing.T) {
-		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+			cache.NamespaceIndex:       cache.MetaNamespaceIndexFunc,
+			AccessPolicyTargetRefIndex: accessPolicyTargetRefIndexFunc,
+		})
 		policy := &agenticv0alpha0.XAccessPolicy{
 			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "policy-1"},
 			Spec: agenticv0alpha0.AccessPolicySpec{
@@ -71,7 +78,8 @@ func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
 		}
 		c := &Controller{
 			agentic: agenticNetResources{
-				accessPolicyLister: agenticlisters.NewXAccessPolicyLister(indexer),
+				accessPolicyLister:  agenticlisters.NewXAccessPolicyLister(indexer),
+				accessPolicyIndexer: indexer,
 			},
 		}
 		backend := &agenticv0alpha0.XBackend{
@@ -83,7 +91,10 @@ func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
 	})
 
 	t.Run("policy targets this backend", func(t *testing.T) {
-		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+			cache.NamespaceIndex:       cache.MetaNamespaceIndexFunc,
+			AccessPolicyTargetRefIndex: accessPolicyTargetRefIndexFunc,
+		})
 		policy := &agenticv0alpha0.XAccessPolicy{
 			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "policy-1"},
 			Spec: agenticv0alpha0.AccessPolicySpec{
@@ -104,7 +115,8 @@ func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
 		}
 		c := &Controller{
 			agentic: agenticNetResources{
-				accessPolicyLister: agenticlisters.NewXAccessPolicyLister(indexer),
+				accessPolicyLister:  agenticlisters.NewXAccessPolicyLister(indexer),
+				accessPolicyIndexer: indexer,
 			},
 		}
 		backend := &agenticv0alpha0.XBackend{
@@ -116,7 +128,10 @@ func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
 	})
 
 	t.Run("policy targets this backend by name but wrong group is skipped", func(t *testing.T) {
-		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+			cache.NamespaceIndex:       cache.MetaNamespaceIndexFunc,
+			AccessPolicyTargetRefIndex: accessPolicyTargetRefIndexFunc,
+		})
 		policy := &agenticv0alpha0.XAccessPolicy{
 			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "policy-1"},
 			Spec: agenticv0alpha0.AccessPolicySpec{
@@ -137,7 +152,8 @@ func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
 		}
 		c := &Controller{
 			agentic: agenticNetResources{
-				accessPolicyLister: agenticlisters.NewXAccessPolicyLister(indexer),
+				accessPolicyLister:  agenticlisters.NewXAccessPolicyLister(indexer),
+				accessPolicyIndexer: indexer,
 			},
 		}
 		backend := &agenticv0alpha0.XBackend{
@@ -149,7 +165,10 @@ func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
 	})
 
 	t.Run("multiple targetRefs one matches backend", func(t *testing.T) {
-		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+			cache.NamespaceIndex:       cache.MetaNamespaceIndexFunc,
+			AccessPolicyTargetRefIndex: accessPolicyTargetRefIndexFunc,
+		})
 		policy := &agenticv0alpha0.XAccessPolicy{
 			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "policy-1"},
 			Spec: agenticv0alpha0.AccessPolicySpec{
@@ -177,7 +196,8 @@ func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
 		}
 		c := &Controller{
 			agentic: agenticNetResources{
-				accessPolicyLister: agenticlisters.NewXAccessPolicyLister(indexer),
+				accessPolicyLister:  agenticlisters.NewXAccessPolicyLister(indexer),
+				accessPolicyIndexer: indexer,
 			},
 		}
 		backend := &agenticv0alpha0.XBackend{

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -91,8 +91,9 @@ type agenticNetResources struct {
 	backendLister agenticlisters.XBackendLister
 	backendSynced cache.InformerSynced
 
-	accessPolicyLister agenticlisters.XAccessPolicyLister
-	accessPolicySynced cache.InformerSynced
+	accessPolicyLister  agenticlisters.XAccessPolicyLister
+	accessPolicyIndexer cache.Indexer
+	accessPolicySynced  cache.InformerSynced
 }
 
 // Controller is the controller implementation for Gateway resources
@@ -128,6 +129,11 @@ func New(
 	backendInformer agenticinformers.XBackendInformer,
 	accessPolicyInformer agenticinformers.XAccessPolicyInformer,
 ) (*Controller, error) {
+	apInformer := accessPolicyInformer.Informer()
+	if err := apInformer.AddIndexers(cache.Indexers{AccessPolicyTargetRefIndex: accessPolicyTargetRefIndexFunc}); err != nil {
+		return nil, fmt.Errorf("add AccessPolicy targetRef index: %w", err)
+	}
+
 	c := &Controller{
 		core: coreResources{
 			client:       kubeClientSet,
@@ -151,11 +157,12 @@ func New(
 			referenceGrantSynced: referenceGrantInformer.Informer().HasSynced,
 		},
 		agentic: agenticNetResources{
-			client:             agenticClientSet,
-			backendLister:      backendInformer.Lister(),
-			backendSynced:      backendInformer.Informer().HasSynced,
-			accessPolicyLister: accessPolicyInformer.Lister(),
-			accessPolicySynced: accessPolicyInformer.Informer().HasSynced,
+			client:              agenticClientSet,
+			backendLister:       backendInformer.Lister(),
+			backendSynced:       backendInformer.Informer().HasSynced,
+			accessPolicyLister:  accessPolicyInformer.Lister(),
+			accessPolicyIndexer: apInformer.GetIndexer(),
+			accessPolicySynced:  apInformer.HasSynced,
 		},
 		agenticIdentityTrustDomain: agenticIdentityTrustDomain,
 		envoyImage:                 envoyImage,


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Optimizes AccessPolicy target lookup by moving grouping from the controller into the client-go cache via a custom indexer, addressing the O(N) behavior described in #168. Previously, every evaluation of “does any AccessPolicy target this backend?” listed all AccessPolicies in the namespace and iterated over their TargetRefs (O(N) in the number of policies). With many policies this caused unnecessary CPU and memory use. The cache now maintains the grouping; lookups are a single index query.

**Which issue(s) this PR fixes**:
Fixes #168 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
