### PR TITLE
fix: makefile import

### DIFF
--- a/site-src/guides/quickstart/additional-agent-examples/langchain-agent/Makefile
+++ b/site-src/guides/quickstart/additional-agent-examples/langchain-agent/Makefile
@@ -1,1 +1,1 @@
-include $(CURDIR)/../../../hack/build/Makefile.common.in
+include $(CURDIR)/../../../../../hack/build/Makefile.common.in

--- a/site-src/guides/quickstart/additional-agent-examples/openai-agent/Makefile
+++ b/site-src/guides/quickstart/additional-agent-examples/openai-agent/Makefile
@@ -1,1 +1,1 @@
-include $(CURDIR)/../../../hack/build/Makefile.common.in
+include $(CURDIR)/../../../../../hack/build/Makefile.common.in

--- a/site-src/guides/quickstart/adk-agent/Makefile
+++ b/site-src/guides/quickstart/adk-agent/Makefile
@@ -1,1 +1,1 @@
-include $(CURDIR)/../../hack/build/Makefile.common.in
+include $(CURDIR)/../../../../hack/build/Makefile.common.in

--- a/site-src/guides/quickstart/mcpserver/Makefile
+++ b/site-src/guides/quickstart/mcpserver/Makefile
@@ -1,1 +1,1 @@
-include $(CURDIR)/../../hack/build/Makefile.common.in
+include $(CURDIR)/../../../../hack/build/Makefile.common.in


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->

/kind bug

**What this PR does / why we need it**:

The move of the quickstart folder in #152 resulted in an incorrect Makefile import path, and also caused [those prow jobs](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/k8s-staging-agentic-net.yaml) to not run for those quickstart images


This PR fixes import path for the common makefile.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE.
```
