### PR TITLE
CI: Support local image building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ default: all
 
 # This must be included after the default target (it defines targets
 # so we cannot have it be first in the Makefile).
+IMAGE_NAME ?= agentic-networking-controller
 include $(CURDIR)/hack/build/Makefile.common.in
 
 .PHONY: help ## Print this help menu.
@@ -35,7 +36,9 @@ help:
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-17s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: all
-all: validate-python vet fmt verify test build  ## Test, verify and build this project.
+# Note: the build target is defined in hack/build/Makefile.common.in.
+# It builds for the local architecture and loads the image into the local docker daemon.
+all: validate-python vet fmt verify test build  ## Test, verify and build this project locally.
 
 PYTHON_FILES := $(shell find . -type f -name "*.py")
 .PHONY: validate-python

--- a/dev/ci/run-e2e.sh
+++ b/dev/ci/run-e2e.sh
@@ -35,11 +35,17 @@ main() {
   kind create cluster --name "${CLUSTER_NAME}" --config dev/ci/kind-config.yaml --wait 5m
 
   header "Building controller image"
-  IMAGE_TAG="us-central1-docker.pkg.dev/k8s-staging-images/agentic-net/agentic-networking-controller:main"
-  docker build . --tag "${IMAGE_TAG}" --label "runnumber=${BUILD_ID:-0}"
+  # These must match the image used in k8s/deploy/deployment.yaml
+  REGISTRY="us-central1-docker.pkg.dev/k8s-staging-images/agentic-net"
+  IMAGE_NAME="agentic-networking-controller"
+  TAG="main"
+
+  # Use the common make rule to build and load the image.
+  # We override TAG to ensure the local image matches the deployment manifest.
+  make build REGISTRY="${REGISTRY}" IMAGE_NAME="${IMAGE_NAME}" TAG="${TAG}" EXTRA_BUILD_OPT="--label runnumber=${BUILD_ID:-0}"
 
   header "Loading controller image into cluster"
-  kind load docker-image "${IMAGE_TAG}" --name "${CLUSTER_NAME}"
+  kind load docker-image "${REGISTRY}/${IMAGE_NAME}:${TAG}" --name "${CLUSTER_NAME}"
 
   header "Installing Gateway API CRDs"
   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml

--- a/hack/build/Makefile.common.in
+++ b/hack/build/Makefile.common.in
@@ -17,11 +17,13 @@
 # shared makefile for all images
 
 # docker image registry, default to upstream
-# TODO: The registry is currently not ready.
-# 			Needs to wait https://github.com/kubernetes-sigs/kube-agentic-networking/issues/41 to be done.
 REGISTRY?=us-central1-docker.pkg.dev/k8s-staging-images/agentic-net
 
 REPO_ROOT?=$(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
+
+# Default tags for local builds
+TAG ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo latest)
+BASE_REF ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo latest)
 
 # Go version to use, respected by images that build go binaries
 GO_VERSION?=$(shell cat $(REPO_ROOT)/.go-version | head -n1)
@@ -31,23 +33,25 @@ PLATFORMS?=linux/amd64,linux/arm64
 OUTPUT?=
 PROGRESS=auto
 EXTRA_BUILD_OPT?=
-build: ensure-buildx
+# build-all will perform a multi-platform build (linux/amd64, linux/arm64) by default.
+# The resulting images are stored in the buildx cache but cannot be loaded into
+# the local docker daemon at the moment.
+# See https://github.com/docker/buildx/issues/59
+build-all: ensure-buildx
 	docker buildx build $(if $(PLATFORMS),--platform=$(PLATFORMS),) $(OUTPUT) --progress=$(PROGRESS) -t $(REGISTRY)/$(IMAGE_NAME):$(TAG) -t $(REGISTRY)/$(IMAGE_NAME):$(BASE_REF) --pull --build-arg GO_VERSION=$(GO_VERSION) $(EXTRA_BUILD_OPT) .
 
-# push the cross built image
+# push performs a multi-platform build and pushes the resulting images to the registry.
 push: OUTPUT=--push
-push: build
+push: build-all
 
-# quick can be used to do a build that will be imported into the local docker
-# for sanity checking before doing a cross build push
-# cross builds cannot be imported locally at the moment
-# https://github.com/docker/buildx/issues/59
-quick: PLATFORMS=
-quick: OUTPUT=--load
-quick: build
+# build performs a single-platform build for the local architecture and loads the resulting
+# image into the local docker daemon. This is the preferred target for local development.
+build: PLATFORMS=
+build: OUTPUT=--load
+build: build-all
 
 # enable buildx
 ensure-buildx:
 	$(REPO_ROOT)/hack/build/init-buildx.sh
 
-.PHONY: push build quick ensure-buildx
+.PHONY: push build-all build ensure-buildx

--- a/site-src/guides/quickstart/additional-agent-examples/langchain-agent/Makefile
+++ b/site-src/guides/quickstart/additional-agent-examples/langchain-agent/Makefile
@@ -1,1 +1,2 @@
+IMAGE_NAME ?= quickstart-langchain-agent
 include $(CURDIR)/../../../../../hack/build/Makefile.common.in

--- a/site-src/guides/quickstart/additional-agent-examples/langchain-agent/cloudbuild.yaml
+++ b/site-src/guides/quickstart/additional-agent-examples/langchain-agent/cloudbuild.yaml
@@ -14,7 +14,6 @@ steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
     entrypoint: make
     env:
-      - IMAGE_NAME=quickstart-langchain-agent
       - TAG=$_GIT_TAG
       - BASE_REF=$_PULL_BASE_REF
     args:

--- a/site-src/guides/quickstart/additional-agent-examples/openai-agent/Makefile
+++ b/site-src/guides/quickstart/additional-agent-examples/openai-agent/Makefile
@@ -1,1 +1,2 @@
+IMAGE_NAME ?= quickstart-openai-agent
 include $(CURDIR)/../../../../../hack/build/Makefile.common.in

--- a/site-src/guides/quickstart/additional-agent-examples/openai-agent/cloudbuild.yaml
+++ b/site-src/guides/quickstart/additional-agent-examples/openai-agent/cloudbuild.yaml
@@ -14,7 +14,6 @@ steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
     entrypoint: make
     env:
-      - IMAGE_NAME=quickstart-openai-agent
       - TAG=$_GIT_TAG
       - BASE_REF=$_PULL_BASE_REF
     args:

--- a/site-src/guides/quickstart/adk-agent/Makefile
+++ b/site-src/guides/quickstart/adk-agent/Makefile
@@ -1,1 +1,2 @@
+IMAGE_NAME ?= quickstart-adk-agent
 include $(CURDIR)/../../../../hack/build/Makefile.common.in

--- a/site-src/guides/quickstart/adk-agent/cloudbuild.yaml
+++ b/site-src/guides/quickstart/adk-agent/cloudbuild.yaml
@@ -14,7 +14,6 @@ steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
     entrypoint: make
     env:
-      - IMAGE_NAME=quickstart-adk-agent
       - TAG=$_GIT_TAG
       - BASE_REF=$_PULL_BASE_REF
     args: ["-C", "site-src/guides/quickstart/adk-agent", "push"]

--- a/site-src/guides/quickstart/mcpserver/Makefile
+++ b/site-src/guides/quickstart/mcpserver/Makefile
@@ -1,1 +1,2 @@
+IMAGE_NAME ?= quickstart-everything-mcp
 include $(CURDIR)/../../../../hack/build/Makefile.common.in

--- a/site-src/guides/quickstart/mcpserver/cloudbuild.yaml
+++ b/site-src/guides/quickstart/mcpserver/cloudbuild.yaml
@@ -12,7 +12,6 @@ steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
     entrypoint: make
     env:
-      - IMAGE_NAME=quickstart-everything-mcp
       - TAG=$_GIT_TAG
       - BASE_REF=$_PULL_BASE_REF
     args: ["-C", "site-src/guides/quickstart/mcpserver", "push"]


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->

/kind cleanup

**What this PR does / why we need it**:

Refactor the build system to allow `make build` and `make build-all` to function correctly outside of Cloud Build.

Key changes:
- Explicitly set `IMAGE_NAME` in local Makefiles instead of in Cloud Build 
  configuration. This also makes it single source of truth for image name.
- Automatically derive `TAG` and `BASE_REF` from git for local development.
- Update root `all` target to use `build` for automatic local Docker loading.
- Add documentation clarifying the difference between `build-all` (multi-platform) and `build` (local architecture + docker load).
- Update dev/ci/run-e2e.sh to use `make build` for building the test image, 
  standardizing on individual variables (REGISTRY, IMAGE_NAME, TAG).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
