### PR TITLE
Support for raw HTTP external authorization servers

### DIFF
--- a/pkg/translator/listener.go
+++ b/pkg/translator/listener.go
@@ -451,15 +451,26 @@ func buildExtAuthzFilters(accessPolicyLister agenticlisters.XAccessPolicyLister)
 					if port := backendRef.Port; port != nil {
 						uri = fmt.Sprintf("%s:%d", uri, *port)
 					}
-					extAuthzProto.Services = &ext_authzv3.ExtAuthz_HttpService{
+					httpService := &ext_authzv3.ExtAuthz_HttpService{
 						HttpService: &ext_authzv3.HttpService{
 							ServerUri: &corev3.HttpUri{
-								Uri:     uri,
+								Uri: uri,
+								HttpUpstreamType: &corev3.HttpUri_Cluster{
+									Cluster: clusterName,
+								},
 								Timeout: durationpb.New(uriTimeout),
 							},
 							PathPrefix: config.Path,
 						},
 					}
+					if len(config.AllowedResponseHeaders) > 0 {
+						httpService.HttpService.AuthorizationResponse = &ext_authzv3.AuthorizationResponse{
+							AllowedUpstreamHeaders: &matcherv3.ListStringMatcher{
+								Patterns: toEnvoyExactStringMatchers(config.AllowedResponseHeaders),
+							},
+						}
+					}
+					extAuthzProto.Services = httpService
 					if len(config.AllowedRequestHeaders) > 0 {
 						extAuthzProto.AllowedHeaders = &matcherv3.ListStringMatcher{
 							Patterns: toEnvoyExactStringMatchers(config.AllowedRequestHeaders),

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -607,6 +607,8 @@ func buildExtAuthzBackendClusters(accessPolicyLister agenticlisters.XAccessPolic
 				cluster.TypedExtensionProtocolOptions = map[string]*anypb.Any{
 					string(opts.ProtoReflect().Descriptor().FullName()): optsAny,
 				}
+			case gatewayv1.HTTPRouteExternalAuthHTTPProtocol:
+				// HTTP/1.1 is the default protocol, no special configuration needed
 			}
 			clusters[clusterName] = cluster
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds support for raw HTTP external authorization servers.

E.g.:

```yaml
apiVersion: agentic.prototype.x-k8s.io/v0alpha0
kind: XAccessPolicy
spec:
  rules:
  - authorization:
      type: ExternalAuth
      externalAuth:
        backendRef:
          kind: Service
          name: my-ext-auth-svc
          namespace: my-ext-auth-ns
          port: 5000
        protocol: HTTP
        http: # all fields are optional
          path: /auth
          allowedHeaders:
          - mcp-session-id
          allowedResponseHeaders:
          - x-user-id
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Support for raw HTTP external authorization servers added to the XAccessPolicy
```