### PR TITLE
Add kan-reference-implementation-approvers as owners of hack and k8s/deploy

### DIFF
--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+# See the OWNERS_ALIASES file at https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/OWNERS_ALIASES for a list of members for each alias.
+
+
+approvers:
+  - kan-reference-implementation-approvers
+
+reviewers:
+  - kan-reference-implementation-approvers

--- a/k8s/deploy/OWNERS
+++ b/k8s/deploy/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+# See the OWNERS_ALIASES file at https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/OWNERS_ALIASES for a list of members for each alias.
+
+
+approvers:
+  - kan-reference-implementation-approvers
+
+reviewers:
+  - kan-reference-implementation-approvers


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind cleanup

**What this PR does / why we need it**:
This allows kan-reference-implementation-approvers to approve changes to the directory `k8s/deploy` and `hack`. 


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
