### PR TITLE
Fix Gateway ObservedGeneration timeouts and support infrastructure labels/annotations

### DIFF
--- a/pkg/constants/envoynames.go
+++ b/pkg/constants/envoynames.go
@@ -38,7 +38,8 @@ const (
 	EnvoyBootstrapMountPath = "/etc/envoy/bootstrap"
 
 	// GatewayNameLabel is the label key used to identify resources associated with a specific Gateway.
-	GatewayNameLabel = ProjectName + "/gateway-name"
+	// This label was formally introduced in https://gateway-api.sigs.k8s.io/geps/gep-1762/#automated-deployments.
+	GatewayNameLabel = "gateway.networking.k8s.io/gateway-name"
 
 	// GatewayRBACFilterNamePrefix is the prefix for Envoy RBAC filters at the gateway level.
 	GatewayRBACFilterNamePrefix = "envoy.filters.http.rbac.gateway_level_"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -400,7 +400,8 @@ func (c *Controller) syncGateway(ctx context.Context, key string) error {
 	rm := envoy.NewResourceManager(c.core.client, gateway, c.envoyImage, c.agenticIdentityTrustDomain)
 	proxyIP, err := rm.EnsureProxyExist(ctx)
 	if err != nil {
-		return err
+		updateErr := updateGatewayStatus(ctx, c, gateway, newGW, nil, err)
+		return errors.Join(err, updateErr)
 	}
 
 	// TODO: Add support for IPv6?
@@ -418,25 +419,18 @@ func (c *Controller) syncGateway(ctx context.Context, key string) error {
 	// Translate Gateway to xDS resources (includes only current HTTPRoutes/XAccessPolicies; stale rules are omitted).
 	resources, listenerStatuses, httpRouteStatuses, _, err := c.translator.TranslateGatewayToXDS(ctx, gateway)
 	if err != nil {
-		// TODO: Update Gateway status with the error.
-		return fmt.Errorf("failed to translate gateway to xDS resources: %w", err)
+		updateErr := updateGatewayStatus(ctx, c, gateway, newGW, nil, fmt.Errorf("failed to translate gateway to xDS resources: %w", err))
+		return errors.Join(err, updateErr)
 	}
 
 	logger.Info("Translated gateway to xDS resources")
 
 	newGW.Status.Listeners = listenerStatuses
 	// Update the xDS server with the new resources.
-	err = c.xdsServer.UpdateXDSServer(ctx, rm.NodeID(), resources)
-
-	setGatewayConditions(newGW, listenerStatuses, err)
-
-	if !reflect.DeepEqual(gateway.Status, newGW.Status) {
-		if err := c.updateGatewayStatus(ctx, newGW.Namespace, newGW.Name, &newGW.Status); err != nil {
-			return fmt.Errorf("failed to update gateway status: %w", err)
-		}
-		logger.Info("Updated gateway status")
-	}
-	return c.updateHTTPRouteStatuses(ctx, httpRouteStatuses)
+	xdsErr := c.xdsServer.UpdateXDSServer(ctx, rm.NodeID(), resources)
+	updateGatewayStatusErr := updateGatewayStatus(ctx, c, gateway, newGW, listenerStatuses, xdsErr)
+	updateHTTPRouteStatusErr := c.updateHTTPRouteStatuses(ctx, httpRouteStatuses)
+	return errors.Join(xdsErr, updateGatewayStatusErr, updateHTTPRouteStatusErr)
 }
 
 func (c *Controller) updateGatewayRemoveFinalizer(ctx context.Context, namespace, name string) error {
@@ -455,6 +449,23 @@ func (c *Controller) updateGatewayRemoveFinalizer(ctx context.Context, namespace
 		_, err = c.gateway.client.GatewayV1().Gateways(namespace).Update(ctx, u, metav1.UpdateOptions{})
 		return err
 	})
+}
+
+// updateGatewayStatus updates the Gateway status in the API server if it has changed.
+// Note: this function modifies newGW.
+func updateGatewayStatus(ctx context.Context, c *Controller, gateway *gatewayv1.Gateway, newGW *gatewayv1.Gateway, listenerStatuses []gatewayv1.ListenerStatus, syncErr error) error {
+	setGatewayConditions(newGW, listenerStatuses, syncErr)
+
+	if reflect.DeepEqual(gateway.Status, newGW.Status) {
+		return nil
+	}
+
+	if _, statusErr := c.gateway.client.GatewayV1().Gateways(newGW.Namespace).UpdateStatus(ctx, newGW, metav1.UpdateOptions{}); statusErr != nil {
+		klog.FromContext(ctx).Error(statusErr, "failed to update gateway status")
+		return fmt.Errorf("failed to update gateway status: %w", statusErr)
+	}
+	klog.FromContext(ctx).Info("Updated gateway status")
+	return nil
 }
 
 // ensureGatewayFinalizer adds the controller finalizer via the API when missing.
@@ -490,22 +501,6 @@ func (c *Controller) ensureGatewayFinalizer(ctx context.Context, namespace, name
 	}
 	nowHas := sets.New(fresh.Finalizers...).Has(constants.GatewayFinalizer)
 	return !hadFinalizer && nowHas, nil
-}
-
-func (c *Controller) updateGatewayStatus(ctx context.Context, namespace, name string, desired *gatewayv1.GatewayStatus) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest, err := c.gateway.gatewayLister.Gateways(namespace).Get(name)
-		if err != nil {
-			return err
-		}
-		if reflect.DeepEqual(latest.Status, *desired) {
-			return nil
-		}
-		u := latest.DeepCopy()
-		u.Status = *desired.DeepCopy()
-		_, err = c.gateway.client.GatewayV1().Gateways(namespace).UpdateStatus(ctx, u, metav1.UpdateOptions{})
-		return err
-	})
 }
 
 // hasHTTPRoutesReferencingGateway returns true if any HTTPRoute has a ParentRef to the given Gateway.

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,16 +17,25 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 	gatewaylisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1"
 
 	agenticv0alpha0 "sigs.k8s.io/kube-agentic-networking/api/v0alpha0"
 	agenticlisters "sigs.k8s.io/kube-agentic-networking/k8s/client/listers/api/v0alpha0"
+	"sigs.k8s.io/kube-agentic-networking/pkg/constants"
 )
 
 func TestHasHTTPRoutesReferencingGateway(t *testing.T) {
@@ -341,4 +350,92 @@ func ptrGatewayNamespace(ns string) *gatewayv1.Namespace {
 func ptrGatewayKind(kind string) *gatewayv1.Kind {
 	k := gatewayv1.Kind(kind)
 	return &k
+}
+
+type fakeQueue struct {
+	workqueue.TypedRateLimitingInterface[string]
+	addedAfter string
+	delay      time.Duration
+}
+
+func (q *fakeQueue) AddAfter(item string, duration time.Duration) {
+	q.addedAfter = item
+	q.delay = duration
+}
+
+func (q *fakeQueue) Len() int {
+	if q.addedAfter != "" {
+		return 1
+	}
+	return 0
+}
+
+func TestSyncGateway_EnsureProxyExistError(t *testing.T) {
+	gwNamespace := "default"
+	gwName := "my-gateway"
+	gwcName := "my-class"
+
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: gwNamespace, Name: gwName, Finalizers: []string{constants.GatewayFinalizer}},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(gwcName),
+		},
+	}
+
+	gwc := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: gwcName},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: constants.ControllerName,
+		},
+	}
+
+	gwIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	if err := gwIndexer.Add(gw); err != nil {
+		t.Fatalf("gwIndexer.Add() = %v, want nil", err)
+	}
+
+	gwcIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if err := gwcIndexer.Add(gwc); err != nil {
+		t.Fatalf("gwcIndexer.Add() = %v, want nil", err)
+	}
+
+	fakeK8sClient := fake.NewClientset()
+	// Force error on SA creation
+	fakeK8sClient.PrependReactor("create", "serviceaccounts", func(_ k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("forced error")
+	})
+
+	fakeGwClient := gatewayfake.NewClientset(gw)
+
+	queue := &fakeQueue{}
+
+	c := &Controller{
+		gateway: gatewayResources{
+			gatewayLister:      gatewaylisters.NewGatewayLister(gwIndexer),
+			gatewayClassLister: gatewaylisters.NewGatewayClassLister(gwcIndexer),
+			client:             fakeGwClient,
+		},
+		core: coreResources{
+			client: fakeK8sClient,
+		},
+		gatewayqueue: queue,
+	}
+
+	err := c.syncGateway(context.Background(), gwNamespace+"/"+gwName)
+	if err == nil {
+		t.Fatal("syncGateway() = nil, want error")
+	}
+
+	// Verify status was updated with error!
+	actions := fakeGwClient.Actions()
+	foundUpdateStatus := false
+	for _, action := range actions {
+		if action.GetVerb() == "update" && action.GetSubresource() == "status" {
+			foundUpdateStatus = true
+			break
+		}
+	}
+	if !foundUpdateStatus {
+		t.Error("foundUpdateStatus = false, want true")
+	}
 }

--- a/pkg/infra/envoy/proxy.go
+++ b/pkg/infra/envoy/proxy.go
@@ -21,14 +21,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
@@ -95,6 +93,7 @@ func (r *ResourceManager) NodeID() string {
 	return r.nodeID
 }
 
+// ensureSA ensures that the ServiceAccount for the Envoy proxy exists.
 func (r *ResourceManager) ensureSA(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
 
@@ -102,6 +101,7 @@ func (r *ResourceManager) ensureSA(ctx context.Context) error {
 	_, err := r.client.CoreV1().ServiceAccounts(sa.Namespace).Get(ctx, sa.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			logger.Info("Creating Envoy proxy serviceaccount", "name", sa.Name, "namespace", sa.Namespace)
 			_, err = r.client.CoreV1().ServiceAccounts(sa.Namespace).Create(ctx, sa, metav1.CreateOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to create envoy serviceaccount: %w", err)
@@ -114,6 +114,7 @@ func (r *ResourceManager) ensureSA(ctx context.Context) error {
 	return nil
 }
 
+// ensureConfigMap ensures that the ConfigMap for the Envoy proxy exists.
 func (r *ResourceManager) ensureConfigMap(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
 	cm, err := r.renderConfigMap()
@@ -124,6 +125,7 @@ func (r *ResourceManager) ensureConfigMap(ctx context.Context) error {
 	_, err = r.client.CoreV1().ConfigMaps(cm.Namespace).Get(ctx, cm.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			logger.Info("Creating Envoy bootstrap configmap", "name", cm.Name, "namespace", cm.Namespace)
 			_, err = r.client.CoreV1().ConfigMaps(cm.Namespace).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to create envoy configmap: %w", err)
@@ -137,14 +139,16 @@ func (r *ResourceManager) ensureConfigMap(ctx context.Context) error {
 	return nil
 }
 
+// ensureDeployment ensures that the Envoy deployment exists and is available.
 func (r *ResourceManager) ensureDeployment(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
 
 	deployment := r.renderDeployment()
-	_, err := r.client.AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+	dep, err := r.client.AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			_, err = r.client.AppsV1().Deployments(deployment.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
+			logger.Info("Creating Envoy proxy deployment", "name", deployment.Name, "namespace", deployment.Namespace)
+			dep, err = r.client.AppsV1().Deployments(deployment.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to create envoy deployment: %w", err)
 			}
@@ -153,19 +157,26 @@ func (r *ResourceManager) ensureDeployment(ctx context.Context) error {
 		}
 	}
 
-	if err := waitForDeploymentAvailable(ctx, r.client, deployment.Namespace, deployment.Name); err != nil {
-		return err
+	// If the Deployment was just created, we will highly likely immediately fail
+	// here and return.
+	for _, cond := range dep.Status.Conditions {
+		if cond.Type == appsv1.DeploymentAvailable && cond.Status == corev1.ConditionTrue {
+			logger.Info("Envoy proxy deployment is ready!")
+			return nil
+		}
 	}
-	logger.Info("Envoy proxy deployment is ready!")
-	return nil
+
+	return fmt.Errorf("envoy deployment %s is not available yet", deployment.Name)
 }
 
+// ensureService ensures that the Service for the Envoy proxy exists and has a ClusterIP assigned.
 func (r *ResourceManager) ensureService(ctx context.Context) (string, error) {
 	logger := klog.FromContext(ctx)
 	service := r.renderService()
 	svc, err := r.client.CoreV1().Services(service.Namespace).Get(ctx, service.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			logger.Info("Creating Envoy proxy service", "name", service.Name, "namespace", service.Namespace)
 			svc, err = r.client.CoreV1().Services(service.Namespace).Create(ctx, service, metav1.CreateOptions{})
 			if err != nil {
 				return "", fmt.Errorf("failed to create envoy service: %w", err)
@@ -175,12 +186,6 @@ func (r *ResourceManager) ensureService(ctx context.Context) (string, error) {
 		}
 	}
 
-	if errWait := waitForServiceReady(ctx, r.client, service.Namespace, service.Name); errWait != nil {
-		return "", errWait
-	}
-	logger.Info("Envoy proxy service is ready!")
-
-	// Refresh the service object to get the assigned ClusterIP if it was just created.
 	if svc.Spec.ClusterIP == "" {
 		svc, err = r.client.CoreV1().Services(service.Namespace).Get(ctx, service.Name, metav1.GetOptions{})
 		if err != nil {
@@ -188,47 +193,12 @@ func (r *ResourceManager) ensureService(ctx context.Context) (string, error) {
 		}
 	}
 
+	if svc.Spec.ClusterIP == "" {
+		return "", fmt.Errorf("envoy service %s is not ready yet", service.Name)
+	}
+
+	logger.Info("Envoy proxy service is ready!")
 	return svc.Spec.ClusterIP, nil
-}
-
-func waitForServiceReady(ctx context.Context, client kubernetes.Interface, namespace, name string) error {
-	logger := klog.FromContext(ctx)
-	logger.Info("Waiting for envoy service to be ready...")
-	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
-		svc, err := client.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		if svc.Spec.ClusterIP != "" {
-			return true, nil
-		}
-		return false, nil
-	})
-	if err != nil {
-		return fmt.Errorf("waiting for envoy service %s to be ready: %w", name, err)
-	}
-	return nil
-}
-
-func waitForDeploymentAvailable(ctx context.Context, client kubernetes.Interface, namespace, name string) error {
-	logger := klog.FromContext(ctx)
-	logger.Info("Waiting for envoy deployment to be available...")
-	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
-		dep, err := client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		for _, cond := range dep.Status.Conditions {
-			if cond.Type == appsv1.DeploymentAvailable && cond.Status == corev1.ConditionTrue {
-				return true, nil
-			}
-		}
-		return false, nil
-	})
-	if err != nil {
-		return fmt.Errorf("waiting for envoy deployment %s to be available: %w", name, err)
-	}
-	return nil
 }
 
 func DeleteProxy(ctx context.Context, client kubernetes.Interface, namespace, name string) error {

--- a/pkg/infra/envoy/proxy_test.go
+++ b/pkg/infra/envoy/proxy_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envoy
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestEnsureDeployment(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gw",
+			Namespace: "test-ns",
+		},
+	}
+	nodeID := proxyName(gw.Namespace, gw.Name)
+
+	t.Run("deployment not found, creates and returns error (not ready)", func(t *testing.T) {
+		client := fake.NewClientset()
+		rm := NewResourceManager(client, gw, "envoy-image", "cluster.local")
+
+		err := rm.ensureDeployment(context.Background())
+		if err == nil {
+			t.Fatal("expected error as deployment is not available yet")
+		}
+
+		// Verify deployment was created
+		_, err = client.AppsV1().Deployments("test-ns").Get(context.Background(), nodeID, metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("failed to get created deployment: %v", err)
+		}
+	})
+
+	t.Run("deployment exists but not available, returns error", func(t *testing.T) {
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeID,
+				Namespace: "test-ns",
+			},
+			Status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentAvailable,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			},
+		}
+		client := fake.NewClientset(dep)
+		rm := NewResourceManager(client, gw, "envoy-image", "cluster.local")
+
+		err := rm.ensureDeployment(context.Background())
+		if err == nil {
+			t.Fatal("expected error as deployment is not available")
+		}
+	})
+
+	t.Run("deployment exists and available, returns nil", func(t *testing.T) {
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeID,
+				Namespace: "test-ns",
+			},
+			Status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentAvailable,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		}
+		client := fake.NewClientset(dep)
+		rm := NewResourceManager(client, gw, "envoy-image", "cluster.local")
+
+		err := rm.ensureDeployment(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestEnsureService(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gw",
+			Namespace: "test-ns",
+		},
+	}
+	nodeID := proxyName(gw.Namespace, gw.Name)
+
+	t.Run("service not found, creates and returns error (no ClusterIP)", func(t *testing.T) {
+		client := fake.NewClientset()
+		rm := NewResourceManager(client, gw, "envoy-image", "cluster.local")
+
+		_, err := rm.ensureService(context.Background())
+		if err == nil {
+			t.Fatal("expected error as service has no ClusterIP")
+		}
+
+		// Verify service was created
+		_, err = client.CoreV1().Services("test-ns").Get(context.Background(), nodeID, metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("failed to get created service: %v", err)
+		}
+	})
+
+	t.Run("service exists but no ClusterIP, returns error", func(t *testing.T) {
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeID,
+				Namespace: "test-ns",
+			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: "",
+			},
+		}
+		client := fake.NewClientset(svc)
+		rm := NewResourceManager(client, gw, "envoy-image", "cluster.local")
+
+		_, err := rm.ensureService(context.Background())
+		if err == nil {
+			t.Fatal("expected error as service has no ClusterIP")
+		}
+	})
+
+	t.Run("service exists and has ClusterIP, returns IP", func(t *testing.T) {
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeID,
+				Namespace: "test-ns",
+			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: "10.0.0.1",
+			},
+		}
+		client := fake.NewClientset(svc)
+		rm := NewResourceManager(client, gw, "envoy-image", "cluster.local")
+
+		ip, err := rm.ensureService(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ip != "10.0.0.1" {
+			t.Errorf("ensureService() = %s, want %s", ip, "10.0.0.1")
+		}
+	})
+}

--- a/pkg/infra/envoy/resourcerender.go
+++ b/pkg/infra/envoy/resourcerender.go
@@ -108,6 +108,30 @@ func generateSdsConfig(tmpl, sdsConfigName, trustDomain string) (string, error) 
 	return buff.String(), nil
 }
 
+// getLabels creates a map of labels for resources associated with the Gateway.
+// It includes the standard Gateway name label and converts any custom labels
+// from the Gateway Infrastructure to plain strings, as required by Kubernetes ObjectMeta.
+func getLabels(gwName string, infraLabels map[gatewayv1.LabelKey]gatewayv1.LabelValue) map[string]string {
+	labels := map[string]string{
+		constants.GatewayNameLabel: gwName,
+	}
+	for k, v := range infraLabels {
+		labels[string(k)] = string(v)
+	}
+	return labels
+}
+
+// getAnnotations converts the Gateway Infrastructure annotations map to a standard map[string]string
+// required by Kubernetes ObjectMeta. This conversion is necessary because Gateway API uses distinct
+// types for annotation keys and values, which are not directly assignable to plain strings in Go maps.
+func getAnnotations(infraAnnotations map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue) map[string]string {
+	annotations := map[string]string{}
+	for k, v := range infraAnnotations {
+		annotations[string(k)] = string(v)
+	}
+	return annotations
+}
+
 // renderConfigMap creates a ConfigMap for envoy bootstrap config and SDS configs.
 func (r *ResourceManager) renderConfigMap() (*corev1.ConfigMap, error) {
 	bootstrap, err := generateEnvoyBootstrapConfig(types.NamespacedName{
@@ -144,13 +168,18 @@ func (r *ResourceManager) renderConfigMap() (*corev1.ConfigMap, error) {
 
 func (r *ResourceManager) renderDeployment() *appsv1.Deployment {
 	replicas := int32(1)
+	var infraAnnotations map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue
+	var infraLabels map[gatewayv1.LabelKey]gatewayv1.LabelValue
+	if r.gw.Spec.Infrastructure != nil {
+		infraAnnotations = r.gw.Spec.Infrastructure.Annotations
+		infraLabels = r.gw.Spec.Infrastructure.Labels
+	}
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.nodeID,
-			Namespace: r.namespace,
-			Labels: map[string]string{
-				constants.GatewayNameLabel: r.gw.Name,
-			},
+			Name:            r.nodeID,
+			Namespace:       r.namespace,
+			Labels:          getLabels(r.gw.Name, infraLabels),
+			Annotations:     getAnnotations(infraAnnotations),
 			OwnerReferences: ownerRef(r.gw),
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -162,10 +191,12 @@ func (r *ResourceManager) renderDeployment() *appsv1.Deployment {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app":                      r.nodeID,
-						constants.GatewayNameLabel: r.gw.Name,
-					},
+					Labels: func() map[string]string {
+						l := getLabels(r.gw.Name, infraLabels)
+						l["app"] = r.nodeID
+						return l
+					}(),
+					Annotations: getAnnotations(infraAnnotations),
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: r.nodeID,
@@ -294,13 +325,18 @@ func (r *ResourceManager) renderService() *corev1.Service {
 		return ports[i].Port < ports[j].Port
 	})
 
+	var infraAnnotations map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue
+	var infraLabels map[gatewayv1.LabelKey]gatewayv1.LabelValue
+	if r.gw.Spec.Infrastructure != nil {
+		infraAnnotations = r.gw.Spec.Infrastructure.Annotations
+		infraLabels = r.gw.Spec.Infrastructure.Labels
+	}
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.nodeID,
-			Namespace: r.namespace,
-			Labels: map[string]string{
-				constants.GatewayNameLabel: r.gw.Name,
-			},
+			Name:            r.nodeID,
+			Namespace:       r.namespace,
+			Labels:          getLabels(r.gw.Name, infraLabels),
+			Annotations:     getAnnotations(infraAnnotations),
 			OwnerReferences: ownerRef(r.gw),
 		},
 		Spec: corev1.ServiceSpec{
@@ -314,13 +350,18 @@ func (r *ResourceManager) renderService() *corev1.Service {
 }
 
 func (r *ResourceManager) renderServiceAccount() *corev1.ServiceAccount {
+	var infraAnnotations map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue
+	var infraLabels map[gatewayv1.LabelKey]gatewayv1.LabelValue
+	if r.gw.Spec.Infrastructure != nil {
+		infraAnnotations = r.gw.Spec.Infrastructure.Annotations
+		infraLabels = r.gw.Spec.Infrastructure.Labels
+	}
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.nodeID,
-			Namespace: r.namespace,
-			Labels: map[string]string{
-				constants.GatewayNameLabel: r.gw.Name,
-			},
+			Name:            r.nodeID,
+			Namespace:       r.namespace,
+			Labels:          getLabels(r.gw.Name, infraLabels),
+			Annotations:     getAnnotations(infraAnnotations),
 			OwnerReferences: ownerRef(r.gw),
 		},
 	}

--- a/pkg/infra/envoy/resourcerender_test.go
+++ b/pkg/infra/envoy/resourcerender_test.go
@@ -267,3 +267,139 @@ func TestRenderServiceAccount(t *testing.T) {
 		t.Errorf("ServiceAccount missing gateway name label: got %s, want %s", sa.Labels[constants.GatewayNameLabel], gw.Name)
 	}
 }
+
+func TestRenderWithInfrastructureLabelsAndAnnotations(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gw",
+			Namespace: "test-ns",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			Infrastructure: &gatewayv1.GatewayInfrastructure{
+				Labels: map[gatewayv1.LabelKey]gatewayv1.LabelValue{
+					"custom-label": "custom-value",
+				},
+				Annotations: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+					"custom-annotation": "custom-value",
+				},
+			},
+		},
+	}
+	rm := NewResourceManager(nil, gw, "envoy-image", "cluster.local")
+
+	// Test Deployment
+	dep := rm.renderDeployment()
+	if dep.Labels["custom-label"] != "custom-value" {
+		t.Errorf("Deployment missing custom label")
+	}
+	if dep.Annotations["custom-annotation"] != "custom-value" {
+		t.Errorf("Deployment missing custom annotation")
+	}
+	if dep.Spec.Template.Labels["custom-label"] != "custom-value" {
+		t.Errorf("Pod template missing custom label")
+	}
+	if dep.Spec.Template.Annotations["custom-annotation"] != "custom-value" {
+		t.Errorf("Pod template missing custom annotation")
+	}
+
+	// Test Service
+	svc := rm.renderService()
+	if svc.Labels["custom-label"] != "custom-value" {
+		t.Errorf("Service missing custom label")
+	}
+	if svc.Annotations["custom-annotation"] != "custom-value" {
+		t.Errorf("Service missing custom annotation")
+	}
+
+	// Test ServiceAccount
+	sa := rm.renderServiceAccount()
+	if sa.Labels["custom-label"] != "custom-value" {
+		t.Errorf("ServiceAccount missing custom label")
+	}
+	if sa.Annotations["custom-annotation"] != "custom-value" {
+		t.Errorf("ServiceAccount missing custom annotation")
+	}
+}
+
+func TestGetLabels(t *testing.T) {
+	testCases := []struct {
+		name        string
+		gwName      string
+		infraLabels map[gatewayv1.LabelKey]gatewayv1.LabelValue
+		expected    map[string]string
+	}{
+		{
+			name:   "basic",
+			gwName: "test-gw",
+			infraLabels: map[gatewayv1.LabelKey]gatewayv1.LabelValue{
+				"custom-label": "custom-value",
+			},
+			expected: map[string]string{
+				constants.GatewayNameLabel: "test-gw",
+				"custom-label":             "custom-value",
+			},
+		},
+		{
+			name:        "empty infra labels",
+			gwName:      "test-gw",
+			infraLabels: nil,
+			expected: map[string]string{
+				constants.GatewayNameLabel: "test-gw",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getLabels(tc.gwName, tc.infraLabels)
+			if len(result) != len(tc.expected) {
+				t.Fatalf("expected %d labels, got %d", len(tc.expected), len(result))
+			}
+			for k, v := range tc.expected {
+				if result[k] != v {
+					t.Errorf("label mismatch for key %s: got %s, want %s", k, result[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestGetAnnotations(t *testing.T) {
+	testCases := []struct {
+		name             string
+		infraAnnotations map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue
+		expected         map[string]string
+	}{
+		{
+			name: "basic",
+			infraAnnotations: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+				"custom-annotation": "custom-value",
+			},
+			expected: map[string]string{
+				"custom-annotation": "custom-value",
+			},
+		},
+		{
+			name:             "empty infra annotations",
+			infraAnnotations: nil,
+			expected:         map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getAnnotations(tc.infraAnnotations)
+			if result == nil {
+				t.Errorf("getAnnotations() = nil, want non-nil map")
+			}
+			if len(result) != len(tc.expected) {
+				t.Fatalf("len(getAnnotations()) = %d, want %d", len(result), len(tc.expected))
+			}
+			for k, v := range tc.expected {
+				if result[k] != v {
+					t.Errorf("getAnnotations()[%s] = %s, want %s", k, result[k], v)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind bug

**What this PR does / why we need it**:
    
This commit addresses the following issues:
    
    1. Fixes an issue where the syncGateway reconciliation loop was bypassed
       during proxy provisioning (EnsureProxyExist) or xDS translation
       failures. This ensures the Gateway's ObservedGeneration correctly
       updates its status to Programmed: False instead of skipping the
       update entirely.
    
    2. Implements propagation of Gateway Spec.Infrastructure Labels and
       Annotations down to the generated Envoy proxy Deployments, Pods,
       Services, and ServiceAccounts.
    
    3. Refactors error handling in syncGateway to collect and merge errors
       from status updates and use standard rate-limiting backoff on proxy
       creation failures.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
