### PR TITLE
docs: Fix stale template content and minor docs inaccuracies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,5 +22,5 @@ If your repo has certain guidelines for contribution, put them here ahead of the
 
 ## Contact Information
 
-- [Slack channel](https://kubernetes.slack.com/messages/sig-network)
+- [Slack channel](https://kubernetes.slack.com/archives/C09P6KS6EQZ) (`#sig-network-agentic-networking`)
 - [Mailing List](https://groups.google.com/a/kubernetes.io/g/sig-network)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,4 +23,4 @@ If your repo has certain guidelines for contribution, put them here ahead of the
 ## Contact Information
 
 - [Slack channel](https://kubernetes.slack.com/archives/C09P6KS6EQZ) (`#sig-network-agentic-networking`)
-- [Mailing List](https://groups.google.com/a/kubernetes.io/g/sig-network)
+- [Mailing List](https://groups.google.com/a/kubernetes.io/g/sig-network) (shared with SIG Network)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,9 @@
 # Release Process
 
-The Kubernetes Template Project is released on an as-needed basis. The process is as follows:
+Kube Agentic Networking is released on an as-needed basis. The process is as follows:
 
 1. An issue is proposing a new release with a changelog since the last release
 1. All [OWNERS](OWNERS) must LGTM this release
 1. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push $VERSION`
 1. The release issue is closed
-1. An announcement email is sent to `dev@kubernetes.io` with the subject `[ANNOUNCE] kubernetes-template-project $VERSION is released`
+1. An announcement email is sent to `dev@kubernetes.io` with the subject `[ANNOUNCE] kube-agentic-networking $VERSION is released`

--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -1,3 +1,4 @@
 # Guides
 
 - [Quickstart](quickstart/README.md)
+- [AI Agents](ai-agents.md)

--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -1,4 +1,5 @@
 # Guides
 
 - [Quickstart](quickstart/README.md)
+- [External Auth Quickstart](external-auth-quickstart/README.md)
 - [AI Agents](ai-agents.md)

--- a/site-src/guides/quickstart/README.md
+++ b/site-src/guides/quickstart/README.md
@@ -57,7 +57,7 @@ Before you begin, ensure you have the following:
 - **[git](https://git-scm.com/downloads)**
 - **[kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)** (Kubernetes in Docker)
 - **[kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)**
-- **[Go](https://go.dev/doc/install)** (1.23+)
+- **[Go](https://go.dev/doc/install)** (1.25+)
 - **[envsubst](https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html)** (typically included with `gettext`)
 
 **Choose one of the following LLM options:**

--- a/site-src/introduction.md
+++ b/site-src/introduction.md
@@ -53,12 +53,12 @@ This subproject aims to deliver the following:
 
 This defines authorization policies for tool access from AI agents running inside a Kubernetes cluster to MCP servers running in the Kubernetes cluster or outside of the Kubernetes cluster.
 
-- [API Proposal](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/a52a78a1665d3f036cdb3208fafbac7a85cddcf1/docs/proposals/0008-ToolAuthAPI.md)
+- [API Proposal](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/docs/proposals/0008-ToolAuthAPI.md)
 
 The API introduces 2 new CRDs:
 
-- [XBackend](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/a52a78a1665d3f036cdb3208fafbac7a85cddcf1/api/v0alpha0/backend_types.go): describes a backend in agentic networking
-- [XAccessPolicy](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/a52a78a1665d3f036cdb3208fafbac7a85cddcf1/api/v0alpha0/accesspolicy_types.go): describes who can access what (the permissions/grants) in relation to the agentic networking backends
+- [XBackend](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/api/v0alpha0/backend_types.go): describes a backend in agentic networking
+- [XAccessPolicy](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/api/v0alpha0/accesspolicy_types.go): describes who can access what (the permissions/grants) in relation to the agentic networking backends
 
 ## Who is working on this project?
 


### PR DESCRIPTION
## Summary

- Fix CONTRIBUTING.md Slack link to point to `#sig-network-agentic-networking` instead of `#sig-network`
- Replace "Kubernetes Template Project" references in RELEASE.md with actual project name
- Update Go prerequisite from 1.23+ to 1.25+ to match `go.mod`
- Replace hardcoded commit SHA with `main` in introduction.md GitHub links
- Add missing `ai-agents.md` link to guides index

Fixes https://github.com/kubernetes-sigs/kube-agentic-networking/issues/212