### PR TITLE
fix: passing args from `ExternalAuth` quickstart to main quickstart

### DIFF
--- a/site-src/guides/external-auth-quickstart/run-external-auth-quickstart.sh
+++ b/site-src/guides/external-auth-quickstart/run-external-auth-quickstart.sh
@@ -112,7 +112,7 @@ info "All prerequisites satisfied."
 
 run_base_quickstart() {
   info "Part 1: Running base quickstart setup..."
-  bash "${SCRIPT_ROOT}/site-src/guides/quickstart/run-quickstart.sh" "${QUICKSTART_ARGS[@]}"
+  bash "${SCRIPT_ROOT}/site-src/guides/quickstart/run-quickstart.sh" "${QUICKSTART_ARGS[@]+"${QUICKSTART_ARGS[@]}"}"
 }
 
 # --- Phase 2: Deploy External Authorization Service ---


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Changes the ExternalAuth quickstart script to safely expand the `QUICKSTART_ARGS` variable and thus avoid failing with "QUICKSTART_ARGS[@]: unbound variable" when no optional arguments are specified in the command.

**Which issue(s) this PR fixes**:

The ExternalAuth quickstart script fails when no optional arguments are specified in the command.

```
❯ bash site-src/guides/external-auth-quickstart/run-external-auth-quickstart.sh
[INFO] Checking prerequisites...
[INFO] All prerequisites satisfied.
[INFO] Part 1: Running base quickstart setup...
site-src/guides/external-auth-quickstart/run-external-auth-quickstart.sh: line 115: QUICKSTART_ARGS[@]: unbound variable
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```