### PR TITLE
docs: Tool discovery proposal (XToolInventory CRD)

### DIFF
--- a/docs/proposals/XXXX-ToolDiscovery.md
+++ b/docs/proposals/XXXX-ToolDiscovery.md
@@ -1,0 +1,437 @@
+# Tool Discovery for KAN
+
+Date: 16th March 2026<br/>
+Authors: @rubambiza, @evaline-ju, @david-martin, @guicassolato<br/>
+Status: Provisional<br/>
+
+> [!CAUTION]
+> This API is in a provisional state. It is subject to change and should not be
+> implemented without first consulting the maintainers of the project.
+
+## Summary
+
+KAN has no mechanism to discover what tools an MCP backend exposes. Operators
+must manually enumerate tool names in `XAccessPolicy` rules, and there is no
+feedback loop when tools are added, removed, or misconfigured on backends.
+
+This proposal adds optional, opt-in tool discovery to KAN: a controller that
+connects to MCP backends, calls `tools/list`, validates the results, and
+surfaces discovered tools in `XBackend.status`. This enables policy validation
+against real backend state, operator visibility via `kubectl`, and a foundation
+for future capabilities like response filtering. Discovery is advisory (i.e.,
+it enhances observability but does not affect policy enforcement). Backends
+without discovery enabled continue to work exactly as they do today.
+
+## Non-Goals
+
+- **`tools/list` response filtering.** Filtering the `tools/list` response
+  based on caller identity (so agents only see tools they're authorized to call)
+  is a natural next step but would require a separate proposal.
+- **Tool prefixing / federation.** Disambiguating tools with the same name
+  across multiple backends (e.g., via prefix namespacing) is out of scope.
+- **Full tool schema storage in CRD status.** Storing `inputSchema` and
+  `outputSchema` in `XBackend.status` risks etcd bloat. Discovery validates
+  schemas but does not persist them.
+
+## Motivation
+
+### The Gap
+
+KAN's `XBackend` CRD is purely a routing target. It knows an MCP server's
+address and port, but nothing about what tools that server exposes:
+
+```go
+type MCPBackend struct {
+    ServiceName *string `json:"serviceName,omitempty"`
+    Hostname    *string `json:"hostname,omitempty"`
+    Port        int32   `json:"port"`
+    Path        string  `json:"path,omitempty"`
+}
+// No status.discoveredTools, no status.tools[].
+```
+
+This creates three concrete problems:
+
+**1. Stale access policies.** `XAccessPolicy` rules require operators to
+manually list tool names. If a backend adds, renames, or removes a tool, the
+policy becomes stale with no warning. The ToolAuthAPI proposal (0008) explicitly
+acknowledges this as a TODO.
+
+**2. No operator visibility.** There is no way to inspect what tools a backend
+exposes without directly calling `tools/list` on the backend. `kubectl get
+xbackend` tells you nothing about the backend's capabilities.
+
+**3. Invalid schemas propagate silently.** When a backend MCP server exposes
+tools with invalid JSON schemas, the problem is invisible until an agent tries
+to use the tools. For example, [Kuadrant/mcp-gateway issue #662](https://github.com/Kuadrant/mcp-gateway/issues/662) documents a case
+where a backend with an invalid `inputSchema` caused an agent to fail with a 400
+error (`"JSON schema is invalid. It must match JSON Schema draft 2020-12"`).
+Without validation at the discovery layer, broken backends silently poison the
+system.
+
+### Personas
+
+**Platform Engineer** — Configures `XBackend` and `XAccessPolicy` resources.
+Needs to know what tools each backend exposes to write correct policies, and
+wants warnings when policies reference tools that don't exist.
+
+**Tool Developer** — Deploys MCP servers behind KAN. Wants confidence that
+newly added or renamed tools are visible to the platform without manual CRD
+updates.
+
+### User Journeys
+
+**CUJ 1: Operator discovers tools on a new backend.**
+The platform engineer creates an `XBackend` pointing at an MCP server. Within
+the sync interval, `kubectl get xbackend my-backend -o yaml` shows
+`status.discoveredTools` populated with the backend's tools. No manual
+enumeration required.
+
+**CUJ 2: Operator writes a valid access policy.**
+The platform engineer writes an `XAccessPolicy` referencing tool names. The
+controller validates the tool names against `XBackend.status.discoveredTools`
+and sets a Warning condition on the policy if any tool name doesn't match.
+
+**CUJ 3: Backend adds a new tool.**
+A tool developer deploys a new version of their MCP server with an additional
+tool. The discovery controller detects the change (via `tools/list_changed`
+notification or the next poll) and updates `XBackend.status`. Existing
+`XAccessPolicy` resources that don't include the new tool are unaffected; the
+operator can add it when ready.
+
+**CUJ 4: Backend exposes an invalid tool.**
+A tool developer deploys an MCP server with a tool whose `inputSchema` is
+invalid JSON Schema. The discovery controller validates the schema, rejects the
+tool, and emits a Warning event on the `XBackend`. The invalid tool does not
+appear in `status.discoveredTools`, preventing it from being referenced in
+policies or reaching agents.
+
+## Context
+
+Three recent developments inform this proposal's design:
+
+**XBackend is in flux.** KAN is actively reconsidering XBackend's shape to
+align with the AI Gateway WG's Backend resource ([gateway-api PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)). [Issue
+#161](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/161) tracks whether to drop `Service` as a target type; [issue #162](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/162) questions
+whether `path` belongs on XBackend or in protocol-specific options. This
+proposal's design is resilient to these changes: it extends `XBackend.status`
+(observed state), not `XBackend.spec`, so it works regardless of how the spec
+evolves.
+
+**MCP 2025-11-25 expanded the tool data model.** The MCP spec now includes
+`title` (human-readable display name), `outputSchema`, `icons`, pagination on
+`tools/list` via cursor, and mandatory JSON Schema 2020-12 validation for
+`inputSchema`. The `tools/list_changed` notification (available since
+2025-03-26) was not incorporated in the original proposal.
+
+**Kuadrant/mcp-gateway validates the approach.** Three developments in the MCP
+Gateway directly inform this proposal: `tools/list_changed` support ([PR #329](https://github.com/Kuadrant/mcp-gateway/pull/329))
+validates the hybrid polling + notification approach; [issue #662](https://github.com/Kuadrant/mcp-gateway/issues/662) (invalid
+schemas breaking downstream agents) motivates schema validation at the discovery
+layer; and the `MCPServerRegistration` CRD's evolution toward richer backend
+metadata ([PR #500](https://github.com/Kuadrant/mcp-gateway/pull/500)) confirms that a count-only status is insufficient for policy
+validation.
+
+## API
+
+### XBackend Status Extension
+
+```go
+type BackendStatus struct {
+    // Conditions describe the current state of the XBackend.
+    // +optional
+    // +listType=map
+    // +listMapKey=type
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+    // DiscoveredTools lists the tools discovered on this backend via
+    // MCP tools/list. Only tools with valid schemas are included.
+    // +optional
+    // +listType=map
+    // +listMapKey=name
+    DiscoveredTools []DiscoveredTool `json:"discoveredTools,omitempty"`
+
+    // LastDiscoveryTime is the timestamp of the last successful
+    // tools/list call to this backend.
+    // +optional
+    LastDiscoveryTime *metav1.Time `json:"lastDiscoveryTime,omitempty"`
+}
+
+type DiscoveredTool struct {
+    // Name is the unique identifier for the tool, as returned by
+    // the MCP server's tools/list response.
+    // +required
+    Name string `json:"name"`
+
+    // Title is the human-readable display name for the tool.
+    // Corresponds to the "title" field in MCP 2025-11-25.
+    // +optional
+    Title string `json:"title,omitempty"`
+
+    // Description is a human-readable description of the tool's
+    // functionality.
+    // +optional
+    Description string `json:"description,omitempty"`
+}
+```
+
+### XBackend Status Conditions
+
+The discovery controller sets the following conditions on `XBackend`:
+
+| Type | Status | Reason | Meaning |
+|------|--------|--------|---------|
+| `ToolsDiscovered` | `True` | `DiscoverySucceeded` | tools/list succeeded, all tools valid |
+| `ToolsDiscovered` | `True` | `PartiallyValid` | tools/list succeeded, but some tools had invalid schemas and were excluded |
+| `ToolsDiscovered` | `False` | `DiscoveryFailed` | tools/list call itself failed (backend unreachable, protocol error) |
+
+### Complete Example
+
+```yaml
+apiVersion: agentic.prototype.x-k8s.io/v0alpha0
+kind: XBackend
+metadata:
+  name: weather-service
+  namespace: default
+  annotations:
+    agentic.prototype.x-k8s.io/enable-discovery: "true"
+spec:
+  mcp:
+    serviceName: weather-mcp
+    port: 8080
+    path: /mcp
+status:
+  conditions:
+    - type: ToolsDiscovered
+      status: "True"
+      reason: DiscoverySucceeded
+      message: "Discovered 2 tools"
+      lastTransitionTime: "2026-03-16T10:30:00Z"
+  discoveredTools:
+    - name: get_forecast
+      title: "Weather Forecast"
+      description: "Get weather forecast for a location"
+    - name: get_alerts
+      title: "Weather Alerts"
+      description: "Get active weather alerts for a region"
+  lastDiscoveryTime: "2026-03-16T10:30:00Z"
+```
+
+An `XAccessPolicy` referencing a non-existent tool receives a Warning:
+
+```yaml
+apiVersion: agentic.prototype.x-k8s.io/v0alpha0
+kind: XAccessPolicy
+metadata:
+  name: agent-weather-access
+  namespace: default
+spec:
+  targetRefs:
+    - group: agentic.prototype.x-k8s.io
+      kind: XBackend
+      name: weather-service
+  rules:
+    - name: allow-forecast
+      source:
+        type: ServiceAccount
+        serviceAccount:
+          name: my-agent
+          namespace: default
+      authorization:
+        type: InlineTools
+        tools:
+          - "get_forecast"
+          - "get_humidity"  # Not discovered on backend
+status:
+  ancestors:
+    - ancestorRef:
+        group: agentic.prototype.x-k8s.io
+        kind: XBackend
+        name: weather-service
+      controllerName: agentic.prototype.x-k8s.io/controller
+      conditions:
+        - type: Accepted
+          status: "True"
+          reason: "Accepted"
+          message: "Policy accepted; unverified tools: get_humidity (not found in discovered tools for XBackend 'weather-service')"
+          lastTransitionTime: "2026-03-16T10:31:00Z"
+```
+
+## Implementation
+
+### Discovery Controller
+
+The discovery logic lives in `pkg/discovery/` within the existing
+`agentic-net-controller` binary as a new reconciler. Discovery is opt-in:
+the controller only processes XBackend resources that carry the
+`agentic.prototype.x-k8s.io/enable-discovery: "true"` annotation. Backends
+without this annotation are ignored, incurring zero overhead. The discovery
+controller can also be disabled entirely via a controller flag
+(`--enable-discovery=false`).
+
+For opted-in backends, it:
+
+1. **Watches** XBackend resources with the discovery annotation.
+2. **Connects** to each backend's MCP endpoint using the `mcp-go` client
+   library (`github.com/mark3labs/mcp-go`).
+3. **Calls** `tools/list`, handling pagination via cursor for backends with
+   many tools.
+4. **Validates** each tool's `inputSchema` against JSON Schema draft 2020-12.
+   Tools with invalid schemas are rejected and logged as Warning events on the
+   XBackend resource.
+5. **Updates** `XBackend.status.discoveredTools[]` with validated tools only.
+6. **Listens** for `tools/list_changed` notifications on backends that declare
+   the `listChanged` capability, triggering immediate re-discovery.
+7. **Falls back to polling** (configurable interval, default 30s) for backends
+   that don't support `list_changed`, and as a periodic consistency check.
+8. **Detects drift** by diffing new vs. old tool sets and emits Kubernetes
+   Events when tools are added, removed, or fail validation.
+
+### AccessPolicy Validation
+
+The existing AccessPolicy reconciler is extended to cross-reference
+`rules[].authorization.tools[]` against `XBackend.status.discoveredTools`:
+
+- If a tool name doesn't match, surface the unverified tool names in the
+  `Accepted` condition's `message` field on the relevant ancestor entry
+  (not rejection — the tool may not be discovered yet). This follows
+  Gateway API convention of using standard condition types rather than
+  introducing domain-specific ones.
+- Validation runs on both AccessPolicy changes and XBackend status changes,
+  so stale policies are detected when a backend removes a tool.
+
+### Phasing
+
+**Phase 1: In-cluster discovery (plain HTTP).** XBackend status extension,
+discovery controller, schema validation, `list_changed` support, drift
+detection. The controller connects to backends using the service name and port
+from `XBackend.spec.mcp` over plain HTTP. This is sufficient for in-cluster
+backends where trust is assumed. In mesh environments (e.g., Istio sidecar on
+the controller pod), mTLS is handled transparently at the infrastructure layer,
+so the plain HTTP implementation covers that case without extra work.
+
+Backends that require authentication for `tools/list` will fail gracefully:
+the XBackend receives a `ToolsDiscovered: False` condition with reason
+`DiscoveryFailed`, and AccessPolicy enforcement continues unaffected. Discovery
+is advisory — it does not gate the data plane. The operator sees an early
+signal that the backend is unreachable to the control plane, but runtime tool
+calls proceed normally as long as the agent's own credentials are valid.
+
+**Phase 2: External backends (TLS and authentication).** Extends the discovery
+controller to connect to backends outside the cluster, requiring TLS and
+potentially a credential reference for `tools/list` calls. The exact mechanism
+(e.g., a `credentialRef` on XBackend) is deferred pending stabilization of the
+Backend spec between KAN and the AI Gateway WG.
+
+**Phase 3: Policy validation.** AccessPolicy cross-referencing against
+discovered tools. When an XBackend has `ToolsDiscovered: False` (discovery
+failed or not yet attempted), any AccessPolicy targeting that backend includes
+a note in the `Accepted` condition message indicating which target backends
+had no discovery data available (e.g., "tools not verified against XBackend
+'weather-service': discovery unavailable"). This ensures operators have
+visibility without blocking policy acceptance.
+
+### Alternative: Separate Discovery Controller
+
+The discovery logic is encapsulated in `pkg/discovery/`, making extraction into
+a standalone `agentic-net-discovery` binary straightforward if the community
+prefers separation of concerns. This pattern, a dedicated controller whose
+sole job is to periodically fetch remote capabilities and cache them in CRD
+status, is used by the kagenti-operator's AgentCard controller, which fetches
+agent capability cards from `/.well-known/agent.json` endpoints and writes them
+to `AgentCard.status`. The benefit is fault isolation: a bug or crash in the
+discovery loop doesn't affect the main proxy management controller. The
+embedded approach is recommended to start because it avoids an additional
+deployment and simplifies RBAC.
+
+## Prior Art
+
+### Kuadrant/mcp-gateway MCPManager
+
+The MCP Gateway's broker connects to upstream MCP servers and calls
+`tools/list` on a reconciliation loop, maintaining an in-memory registry. It
+supports `tools/list_changed` for reactive re-discovery ([PR #329](https://github.com/Kuadrant/mcp-gateway/pull/329)) and prefixes
+tool names for federation. Its `MCPServerRegistration` CRD status stores only a
+tool count — sufficient for the gateway's needs but too minimal for KAN's
+policy validation use case.
+
+- *Pro:* Production-tested discovery loop with list_changed support.
+- *Pro:* Schema validation gap ([issue #662](https://github.com/Kuadrant/mcp-gateway/issues/662)) validates our design choice to
+  validate at the discovery layer.
+- *Con:* CRD status (count only) is insufficient for policy validation.
+- *Con:* In-memory tool registry doesn't surface tools to kubectl or other
+  controllers.
+
+### [kagenti-operator](https://github.com/kagenti/kagenti-operator) AgentCard Controller
+
+The kagenti-operator's AgentCard controller periodically fetches agent
+capability cards from `/.well-known/agent.json` endpoints and caches them in
+`AgentCard.status.card`. It detects drift via SHA-256 hashing and runs as a
+dedicated controller separate from other reconcilers.
+
+- *Pro:* Validates the pattern of fetching remote capabilities into CRD status.
+- *Pro:* Separate controller provides fault isolation.
+- *Con:* Separate deployment adds operational complexity.
+
+## Alternatives Considered
+
+### Discovery in the data plane (Envoy calls tools/list)
+
+Envoy could call `tools/list` at request time instead of a controller caching
+the results. This would always be fresh but adds latency to every `tools/list`
+request, provides no CRD visibility, and makes offline policy validation
+impossible. The controller-side approach also enables schema validation before
+tools reach agents.
+
+### Full tool metadata in XBackend.status
+
+Storing `inputSchema`, `outputSchema`, and other fields would provide a
+complete picture but risks `etcd` bloat. A backend with 150 tools at ~5 KB each
+approaches etcd's ~1.5 MB per-object limit. Name + title + description at
+~200-500 bytes per tool is the right middle ground: enough for policy
+validation and kubectl inspection, without the storage risk.
+
+### Separate ToolRegistry CRD
+
+A dedicated `XToolRegistry` CRD could decouple tool discovery from XBackend.
+This adds CRD surface area without clear benefit at this stage. If etcd size
+becomes a concern, the `pkg/discovery/` package boundary makes migrating to a
+separate CRD a localized change.
+
+## Community Consensus Points
+
+### Phase 1
+
+1. **Is `XBackend.status` the right location?** Given the ongoing XBackend
+   shape discussions ([#161](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/161), [#162](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/162)), should discovery wait? We argue no. Status
+   constitutes observed state that is independent of spec changes.
+2. **MCP client library.** Should KAN depend on `github.com/mark3labs/mcp-go`?
+   It is the most mature Go MCP client.
+3. **Default sync interval.** We propose 30s. Configurable via controller flag.
+
+### Phase 3
+
+4. **Warning vs. rejection.** Should an AccessPolicy referencing a
+   non-existent tool be admitted with a Warning, or rejected? We recommend
+   Warning — the backend may be temporarily unreachable.
+5. **Bi-directional validation.** Should validation trigger on both
+   AccessPolicy changes and XBackend status changes? We recommend both.
+
+## Contributors
+
+This proposal is led by @rubambiza (IBM) with support from @evaline-ju (IBM),
+@david-martin (Red Hat), and @guicassolato (Red Hat). Delivery of Phases 1-2
+would establish a natural ownership scope for `pkg/discovery/`. Phase 2 is
+deferred pending Backend spec stabilization.
+
+## References
+
+- [0008-ToolAuthAPI proposal](./0008-ToolAuthAPI.md) — tool-level authorization, acknowledges discovery as a TODO
+- [KAN issue #161](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/161) — Service targeting on XBackend
+- [KAN issue #162](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/162) — Path on XBackend
+- [KAN PR #182](https://github.com/kubernetes-sigs/kube-agentic-networking/pull/182) — Empty tool list deny-all semantics
+- [gateway-api PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488) — Upstream Backend resource
+- [AI Gateway WG Proposal 10](https://github.com/kubernetes-sigs/wg-ai-gateway/blob/main/proposals/10-egress-gateways.md) — Egress gateways with MCP protocol support
+- [MCP Specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) — Current MCP spec with tool annotations, pagination, schema requirements
+- [Kuadrant/mcp-gateway issue #662](https://github.com/Kuadrant/mcp-gateway/issues/662) — Schema validation gap
+- [Kuadrant/mcp-gateway PR #329](https://github.com/Kuadrant/mcp-gateway/pull/329) — tools/list_changed support

--- a/docs/proposals/XXXX-ToolDiscovery.md
+++ b/docs/proposals/XXXX-ToolDiscovery.md
@@ -32,6 +32,10 @@ without discovery enabled continue to work exactly as they do today.
 - **Full tool schema storage in CRD status.** Storing `inputSchema` and
   `outputSchema` in `XBackend.status` risks etcd bloat. Discovery validates
   schemas but does not persist them.
+- **Agent capability discovery.** Backends that are AI agents (e.g.,
+  exposing capabilities via A2A or similar protocols) use different discovery
+  mechanisms than MCP `tools/list`. This proposal is scoped to MCP tool
+  discovery only; agent capability discovery is a parallel concern.
 
 ## Motivation
 

--- a/docs/proposals/XXXX-ToolDiscovery.md
+++ b/docs/proposals/XXXX-ToolDiscovery.md
@@ -26,8 +26,7 @@ This proposal adds optional, opt-in tool discovery to KAN: a controller that
 connects to MCP backends, calls `tools/list`, validates the results, and
 surfaces discovered tools in a dedicated `XToolInventory` resource (one per
 backend, linked via `backendRef`). This enables policy validation against real
-backend state, operator visibility via `kubectl`, and a foundation for future
-capabilities like response filtering. Discovery is advisory (i.e., it enhances
+backend state and operator visibility via `kubectl`. Discovery is advisory (i.e., it enhances
 observability but does not affect policy enforcement). Backends without
 discovery enabled continue to work exactly as they do today.
 

--- a/docs/proposals/XXXX-ToolDiscovery.md
+++ b/docs/proposals/XXXX-ToolDiscovery.md
@@ -19,8 +19,9 @@ Status: Provisional<br/>
 ## Summary
 
 KAN has no mechanism to discover what tools an MCP backend exposes. Operators
-must manually enumerate tool names in `XAccessPolicy` rules, and there is no
-feedback loop when tools are added, removed, or misconfigured on backends.
+who write `Inline` `XAccessPolicy` rules must manually enumerate tool names,
+and there is no feedback loop when tools are added, removed, or misconfigured
+on backends.
 
 This proposal adds optional, opt-in tool discovery to KAN: a controller that
 connects to MCP backends, calls `tools/list`, validates the results, and
@@ -376,11 +377,21 @@ For each XToolInventory, the controller:
 
 The existing XAccessPolicy reconciler is extended to cross-reference
 `rules[].authorization.mcp.methods[].params[]` against
-`XToolInventory.status.discoveredTools` for the policy's target backend:
+`XToolInventory.status.discoveredTools` for the policy's target backend.
 
-- The reconciler finds the XToolInventory whose `spec.backendRef` matches the
+This validation applies to `Inline` authorization rules, which enumerate tool
+names explicitly via `params[]`. It does not apply to `CEL` authorization
+rules, which can match tools dynamically (e.g.,
+`request.mcp.tool_name.startsWith('verify_')`). A pattern-based CEL rule does
+not reference a fixed tool name to verify, so it is not meaningfully validated
+against a discovered tool list and does not go stale the same way an explicit
+enumeration does.
+
+For Inline rules, the reconciler:
+
+- Finds the XToolInventory whose `spec.backendRef` matches the
   policy's `targetRef`.
-- Tool names in `params[]` (for `tools/call` method entries) are compared
+- Compares tool names in `params[]` (for `tools/call` method entries)
   against `discoveredTools[].name`.
 - If a tool name doesn't match, the unverified tool names are surfaced in the
   `Accepted` condition's `message` field on the relevant ancestor entry

--- a/docs/proposals/XXXX-ToolDiscovery.md
+++ b/docs/proposals/XXXX-ToolDiscovery.md
@@ -8,6 +8,14 @@ Status: Provisional<br/>
 > This API is in a provisional state. It is subject to change and should not be
 > implemented without first consulting the maintainers of the project.
 
+### Revision History
+
+| Date | Change |
+|------|--------|
+| 2026-05-25 | Major revision: replaced `XBackend.status.discoveredTools` with a dedicated `XToolInventory` CRD (1:1 with XBackend via `backendRef`). Updated all examples to `agentic.networking.x-k8s.io/v1alpha1` with method-based matching (`mcp.methods[].params[]`). Changed default poll interval from 30s to 5m. Added hybrid creation model (explicit + annotation-triggered). Motivated by community feedback from @keithmattix and @david-martin. |
+| 2026-04-06 | Added A2A scoping non-goal. |
+| 2026-03-16 | Initial proposal. |
+
 ## Summary
 
 KAN has no mechanism to discover what tools an MCP backend exposes. Operators
@@ -16,11 +24,12 @@ feedback loop when tools are added, removed, or misconfigured on backends.
 
 This proposal adds optional, opt-in tool discovery to KAN: a controller that
 connects to MCP backends, calls `tools/list`, validates the results, and
-surfaces discovered tools in `XBackend.status`. This enables policy validation
-against real backend state, operator visibility via `kubectl`, and a foundation
-for future capabilities like response filtering. Discovery is advisory (i.e.,
-it enhances observability but does not affect policy enforcement). Backends
-without discovery enabled continue to work exactly as they do today.
+surfaces discovered tools in a dedicated `XToolInventory` resource (one per
+backend, linked via `backendRef`). This enables policy validation against real
+backend state, operator visibility via `kubectl`, and a foundation for future
+capabilities like response filtering. Discovery is advisory (i.e., it enhances
+observability but does not affect policy enforcement). Backends without
+discovery enabled continue to work exactly as they do today.
 
 ## Non-Goals
 
@@ -29,9 +38,9 @@ without discovery enabled continue to work exactly as they do today.
   is a natural next step but would require a separate proposal.
 - **Tool prefixing / federation.** Disambiguating tools with the same name
   across multiple backends (e.g., via prefix namespacing) is out of scope.
-- **Full tool schema storage in CRD status.** Storing `inputSchema` and
-  `outputSchema` in `XBackend.status` risks etcd bloat. Discovery validates
-  schemas but does not persist them.
+- **Full tool schema storage.** Storing `inputSchema` and `outputSchema` in
+  `XToolInventory.status` risks etcd bloat. Discovery validates schemas but
+  does not persist them.
 - **Agent capability discovery.** Backends that are AI agents (e.g.,
   exposing capabilities via A2A or similar protocols) use different discovery
   mechanisms than MCP `tools/list`. This proposal is scoped to MCP tool
@@ -51,7 +60,7 @@ type MCPBackend struct {
     Port        int32   `json:"port"`
     Path        string  `json:"path,omitempty"`
 }
-// No status.discoveredTools, no status.tools[].
+// No discoveredTools, no tool metadata.
 ```
 
 This creates three concrete problems:
@@ -62,8 +71,8 @@ policy becomes stale with no warning. The ToolAuthAPI proposal (0008) explicitly
 acknowledges this as a TODO.
 
 **2. No operator visibility.** There is no way to inspect what tools a backend
-exposes without directly calling `tools/list` on the backend. `kubectl get
-xbackend` tells you nothing about the backend's capabilities.
+exposes without directly calling `tools/list` on the backend. `kubectl` tells
+you nothing about the backend's capabilities.
 
 **3. Invalid schemas propagate silently.** When a backend MCP server exposes
 tools with invalid JSON schemas, the problem is invisible until an agent tries
@@ -86,28 +95,31 @@ updates.
 ### User Journeys
 
 **CUJ 1: Operator discovers tools on a new backend.**
-The platform engineer creates an `XBackend` pointing at an MCP server. Within
-the sync interval, `kubectl get xbackend my-backend -o yaml` shows
+The platform engineer creates an `XBackend` pointing at an MCP server and
+either creates an `XToolInventory` with a `backendRef` or annotates the
+XBackend to trigger auto-creation. Within the poll interval,
+`kubectl get xtoolinventory weather-service-tools -o yaml` shows
 `status.discoveredTools` populated with the backend's tools. No manual
 enumeration required.
 
 **CUJ 2: Operator writes a valid access policy.**
-The platform engineer writes an `XAccessPolicy` referencing tool names. The
-controller validates the tool names against `XBackend.status.discoveredTools`
-and sets a Warning condition on the policy if any tool name doesn't match.
+The platform engineer writes an `XAccessPolicy` referencing tool names in
+`mcp.methods[].params[]`. The controller validates the tool names against
+the corresponding `XToolInventory.status.discoveredTools` and sets a Warning
+in the policy's `Accepted` condition message if any tool name doesn't match.
 
 **CUJ 3: Backend adds a new tool.**
 A tool developer deploys a new version of their MCP server with an additional
 tool. The discovery controller detects the change (via `tools/list_changed`
-notification or the next poll) and updates `XBackend.status`. Existing
-`XAccessPolicy` resources that don't include the new tool are unaffected; the
-operator can add it when ready.
+notification or the next poll) and updates the `XToolInventory` status.
+Existing `XAccessPolicy` resources that don't include the new tool are
+unaffected; the operator can add it when ready.
 
 **CUJ 4: Backend exposes an invalid tool.**
 A tool developer deploys an MCP server with a tool whose `inputSchema` is
 invalid JSON Schema. The discovery controller validates the schema, rejects the
-tool, and emits a Warning event on the `XBackend`. The invalid tool does not
-appear in `status.discoveredTools`, preventing it from being referenced in
+tool, and emits a Warning event on the `XToolInventory`. The invalid tool does
+not appear in `status.discoveredTools`, preventing it from being referenced in
 policies or reaching agents.
 
 ## Context
@@ -117,10 +129,12 @@ Three recent developments inform this proposal's design:
 **XBackend is in flux.** KAN is actively reconsidering XBackend's shape to
 align with the AI Gateway WG's Backend resource ([gateway-api PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)). [Issue
 #161](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/161) tracks whether to drop `Service` as a target type; [issue #162](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/162) questions
-whether `path` belongs on XBackend or in protocol-specific options. This
-proposal's design is resilient to these changes: it extends `XBackend.status`
-(observed state), not `XBackend.spec`, so it works regardless of how the spec
-evolves.
+whether `path` belongs on XBackend or in protocol-specific options.
+Additionally, not every backend controller performs discovery — coupling
+discovery data to XBackend.status would force all backend controllers to
+account for fields they don't manage. A separate `XToolInventory` CRD
+decouples discovery lifecycle from backend lifecycle, allowing discovery to
+evolve independently of XBackend's ongoing shape changes.
 
 **MCP 2025-11-25 expanded the tool data model.** The MCP spec now includes
 `title` (human-readable display name), `outputSchema`, `icons`, pagination on
@@ -132,31 +146,60 @@ evolves.
 Gateway directly inform this proposal: `tools/list_changed` support ([PR #329](https://github.com/Kuadrant/mcp-gateway/pull/329))
 validates the hybrid polling + notification approach; [issue #662](https://github.com/Kuadrant/mcp-gateway/issues/662) (invalid
 schemas breaking downstream agents) motivates schema validation at the discovery
-layer; and the `MCPServerRegistration` CRD's evolution toward richer backend
-metadata ([PR #500](https://github.com/Kuadrant/mcp-gateway/pull/500)) confirms that a count-only status is insufficient for policy
-validation.
+layer; and [issue #629](https://github.com/Kuadrant/mcp-gateway/issues/629) (usability issues with reflecting discovery data on
+CRD status) motivates the choice of a dedicated CRD over embedding in
+XBackend.status.
 
 ## API
 
-### XBackend Status Extension
+### XToolInventory CRD
+
+A new `XToolInventory` resource provides a 1:1 mapping to an XBackend,
+containing the discovery configuration (spec) and discovered tool data
+(status). This mirrors patterns like Service → EndpointSlice where observed
+state lives in a companion resource rather than on the original object.
 
 ```go
-type BackendStatus struct {
-    // Conditions describe the current state of the XBackend.
+// XToolInventory represents the discovered tool set for a single MCP backend.
+// +genclient
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+type XToolInventory struct {
+    metav1.TypeMeta   `json:",inline"`
+    metav1.ObjectMeta `json:"metadata,omitempty"`
+
+    Spec   XToolInventorySpec   `json:"spec"`
+    Status XToolInventoryStatus `json:"status,omitempty"`
+}
+
+type XToolInventorySpec struct {
+    // BackendRef identifies the XBackend this inventory is for.
+    // +required
+    BackendRef gwapiv1.LocalObjectReference `json:"backendRef"`
+
+    // PollInterval is the interval between discovery polls for backends
+    // that do not support tools/list_changed notifications.
+    // Defaults to 5 minutes.
+    // +optional
+    PollInterval *metav1.Duration `json:"pollInterval,omitempty"`
+}
+
+type XToolInventoryStatus struct {
+    // Conditions describe the current state of tool discovery.
     // +optional
     // +listType=map
     // +listMapKey=type
     Conditions []metav1.Condition `json:"conditions,omitempty"`
 
-    // DiscoveredTools lists the tools discovered on this backend via
-    // MCP tools/list. Only tools with valid schemas are included.
+    // DiscoveredTools lists the tools discovered on the referenced backend
+    // via MCP tools/list. Only tools with valid schemas are included.
     // +optional
     // +listType=map
     // +listMapKey=name
     DiscoveredTools []DiscoveredTool `json:"discoveredTools,omitempty"`
 
     // LastDiscoveryTime is the timestamp of the last successful
-    // tools/list call to this backend.
+    // tools/list call to the referenced backend.
     // +optional
     LastDiscoveryTime *metav1.Time `json:"lastDiscoveryTime,omitempty"`
 }
@@ -179,34 +222,51 @@ type DiscoveredTool struct {
 }
 ```
 
-### XBackend Status Conditions
+### XToolInventory Conditions
 
-The discovery controller sets the following conditions on `XBackend`:
+The discovery controller sets the following conditions on `XToolInventory`:
 
 | Type | Status | Reason | Meaning |
 |------|--------|--------|---------|
-| `ToolsDiscovered` | `True` | `DiscoverySucceeded` | tools/list succeeded, all tools valid |
-| `ToolsDiscovered` | `True` | `PartiallyValid` | tools/list succeeded, but some tools had invalid schemas and were excluded |
-| `ToolsDiscovered` | `False` | `DiscoveryFailed` | tools/list call itself failed (backend unreachable, protocol error) |
+| `Ready` | `True` | `DiscoverySucceeded` | tools/list succeeded, all tools valid |
+| `Ready` | `True` | `PartiallyValid` | tools/list succeeded, but some tools had invalid schemas and were excluded |
+| `Ready` | `False` | `DiscoveryFailed` | tools/list call itself failed (backend unreachable, protocol error) |
 
 ### Complete Example
 
 ```yaml
-apiVersion: agentic.prototype.x-k8s.io/v0alpha0
+apiVersion: agentic.networking.x-k8s.io/v1alpha1
 kind: XBackend
 metadata:
   name: weather-service
   namespace: default
   annotations:
-    agentic.prototype.x-k8s.io/enable-discovery: "true"
+    agentic.networking.x-k8s.io/enable-discovery: "true"
 spec:
   mcp:
     serviceName: weather-mcp
     port: 8080
     path: /mcp
+---
+apiVersion: agentic.networking.x-k8s.io/v1alpha1
+kind: XToolInventory
+metadata:
+  name: weather-service-tools
+  namespace: default
+  ownerReferences:
+    - apiVersion: agentic.networking.x-k8s.io/v1alpha1
+      kind: XBackend
+      name: weather-service
+      uid: <backend-uid>
+spec:
+  backendRef:
+    group: agentic.networking.x-k8s.io
+    kind: XBackend
+    name: weather-service
+  pollInterval: 5m
 status:
   conditions:
-    - type: ToolsDiscovered
+    - type: Ready
       status: "True"
       reason: DiscoverySucceeded
       message: "Discovered 2 tools"
@@ -224,40 +284,42 @@ status:
 An `XAccessPolicy` referencing a non-existent tool receives a Warning:
 
 ```yaml
-apiVersion: agentic.prototype.x-k8s.io/v0alpha0
+apiVersion: agentic.networking.x-k8s.io/v1alpha1
 kind: XAccessPolicy
 metadata:
   name: agent-weather-access
   namespace: default
 spec:
   targetRefs:
-    - group: agentic.prototype.x-k8s.io
+    - group: agentic.networking.x-k8s.io
       kind: XBackend
       name: weather-service
   rules:
     - name: allow-forecast
       source:
-        type: ServiceAccount
         serviceAccount:
           name: my-agent
           namespace: default
       authorization:
-        type: InlineTools
-        tools:
-          - "get_forecast"
-          - "get_humidity"  # Not discovered on backend
+        type: Inline
+        mcp:
+          methods:
+            - name: tools/call
+              params:
+                - "get_forecast"
+                - "get_humidity"  # Not discovered on backend
 status:
   ancestors:
     - ancestorRef:
-        group: agentic.prototype.x-k8s.io
+        group: agentic.networking.x-k8s.io
         kind: XBackend
         name: weather-service
-      controllerName: agentic.prototype.x-k8s.io/controller
+      controllerName: agentic.networking.x-k8s.io/controller
       conditions:
         - type: Accepted
           status: "True"
           reason: "Accepted"
-          message: "Policy accepted; unverified tools: get_humidity (not found in discovered tools for XBackend 'weather-service')"
+          message: "Policy accepted; unverified tools: get_humidity (not found in XToolInventory 'weather-service-tools')"
           lastTransitionTime: "2026-03-16T10:31:00Z"
 ```
 
@@ -266,57 +328,82 @@ status:
 ### Discovery Controller
 
 The discovery logic lives in `pkg/discovery/` within the existing
-`agentic-net-controller` binary as a new reconciler. Discovery is opt-in:
-the controller only processes XBackend resources that carry the
-`agentic.prototype.x-k8s.io/enable-discovery: "true"` annotation. Backends
-without this annotation are ignored, incurring zero overhead. The discovery
-controller can also be disabled entirely via a controller flag
+`agentic-net-controller` binary as a new reconciler. Discovery is opt-in via
+two mechanisms (a common Kubernetes pattern, analogous to how a Service can
+auto-create an EndpointSlice, but operators can also manage EndpointSlices
+manually):
+
+1. **Explicit creation.** An operator creates an `XToolInventory` with a
+   `backendRef` pointing at an XBackend. The controller reconciles it
+   immediately.
+2. **Annotation-triggered auto-creation.** When an XBackend carries the
+   annotation `agentic.networking.x-k8s.io/enable-discovery: "true"` and no
+   corresponding XToolInventory exists, the controller auto-creates one with
+   an `ownerReference` back to the XBackend (enabling garbage collection on
+   backend deletion).
+
+The discovery controller can be disabled entirely via a controller flag
 (`--enable-discovery=false`).
 
-For opted-in backends, it:
+The discovery controller connects to backends using its own service account
+identity. This is distinct from agent runtime identities — the controller's
+`tools/list` calls are a control-plane operation, while agent `tools/call`
+requests at runtime are data-plane operations subject to XAccessPolicy
+enforcement.
 
-1. **Watches** XBackend resources with the discovery annotation.
-2. **Connects** to each backend's MCP endpoint using the `mcp-go` client
+For each XToolInventory, the controller:
+
+1. **Resolves** the backend address from the referenced XBackend's
+   `spec.mcp.serviceName` and port.
+2. **Connects** to the backend's MCP endpoint using the `mcp-go` client
    library (`github.com/mark3labs/mcp-go`).
 3. **Calls** `tools/list`, handling pagination via cursor for backends with
    many tools.
 4. **Validates** each tool's `inputSchema` against JSON Schema draft 2020-12.
    Tools with invalid schemas are rejected and logged as Warning events on the
-   XBackend resource.
-5. **Updates** `XBackend.status.discoveredTools[]` with validated tools only.
-6. **Listens** for `tools/list_changed` notifications on backends that declare
-   the `listChanged` capability, triggering immediate re-discovery.
-7. **Falls back to polling** (configurable interval, default 30s) for backends
-   that don't support `list_changed`, and as a periodic consistency check.
+   XToolInventory resource.
+5. **Updates** `XToolInventory.status.discoveredTools[]` with validated tools
+   only.
+6. **Maintains a persistent connection** to backends that declare the
+   `listChanged` capability, listening for `tools/list_changed` notifications
+   to trigger immediate re-discovery.
+7. **Falls back to polling** (configurable via `spec.pollInterval`, default 5m)
+   for backends that don't support `list_changed`, and as a periodic
+   consistency check for all backends.
 8. **Detects drift** by diffing new vs. old tool sets and emits Kubernetes
    Events when tools are added, removed, or fail validation.
 
-### AccessPolicy Validation
+### XAccessPolicy Validation
 
-The existing AccessPolicy reconciler is extended to cross-reference
-`rules[].authorization.tools[]` against `XBackend.status.discoveredTools`:
+The existing XAccessPolicy reconciler is extended to cross-reference
+`rules[].authorization.mcp.methods[].params[]` against
+`XToolInventory.status.discoveredTools` for the policy's target backend:
 
-- If a tool name doesn't match, surface the unverified tool names in the
+- The reconciler finds the XToolInventory whose `spec.backendRef` matches the
+  policy's `targetRef`.
+- Tool names in `params[]` (for `tools/call` method entries) are compared
+  against `discoveredTools[].name`.
+- If a tool name doesn't match, the unverified tool names are surfaced in the
   `Accepted` condition's `message` field on the relevant ancestor entry
   (not rejection — the tool may not be discovered yet). This follows
   Gateway API convention of using standard condition types rather than
   introducing domain-specific ones.
-- Validation runs on both AccessPolicy changes and XBackend status changes,
-  so stale policies are detected when a backend removes a tool.
+- Validation runs on both XAccessPolicy changes and XToolInventory status
+  changes, so stale policies are detected when a backend removes a tool.
 
 ### Phasing
 
-**Phase 1: In-cluster discovery (plain HTTP).** XBackend status extension,
-discovery controller, schema validation, `list_changed` support, drift
-detection. The controller connects to backends using the service name and port
-from `XBackend.spec.mcp` over plain HTTP. This is sufficient for in-cluster
-backends where trust is assumed. In mesh environments (e.g., Istio sidecar on
-the controller pod), mTLS is handled transparently at the infrastructure layer,
-so the plain HTTP implementation covers that case without extra work.
+**Phase 1: In-cluster discovery (plain HTTP).** XToolInventory CRD, discovery
+controller, schema validation, `list_changed` support, drift detection. The
+controller connects to backends using the service name and port from
+`XBackend.spec.mcp` over plain HTTP. This is sufficient for in-cluster backends
+where trust is assumed. In mesh environments (e.g., Istio sidecar on the
+controller pod), mTLS is handled transparently at the infrastructure layer, so
+the plain HTTP implementation covers that case without extra work.
 
 Backends that require authentication for `tools/list` will fail gracefully:
-the XBackend receives a `ToolsDiscovered: False` condition with reason
-`DiscoveryFailed`, and AccessPolicy enforcement continues unaffected. Discovery
+the XToolInventory receives a `Ready: False` condition with reason
+`DiscoveryFailed`, and XAccessPolicy enforcement continues unaffected. Discovery
 is advisory — it does not gate the data plane. The operator sees an early
 signal that the backend is unreachable to the control plane, but runtime tool
 calls proceed normally as long as the agent's own credentials are valid.
@@ -324,18 +411,18 @@ calls proceed normally as long as the agent's own credentials are valid.
 **Phase 2: External backends (TLS and authentication).** Extends the discovery
 controller to connect to backends outside the cluster, requiring TLS and
 potentially a credential reference for `tools/list` calls. The exact mechanism
-(e.g., a `credentialRef` on XBackend) is deferred pending stabilization of the
-Backend spec between KAN and the AI Gateway WG.
+(e.g., a `credentialRef` on XToolInventory) is deferred pending stabilization
+of the Backend spec between KAN and the AI Gateway WG.
 
-**Phase 3: Policy validation.** AccessPolicy cross-referencing against
-discovered tools. When an XBackend has `ToolsDiscovered: False` (discovery
-failed or not yet attempted), any AccessPolicy targeting that backend includes
-a note in the `Accepted` condition message indicating which target backends
-had no discovery data available (e.g., "tools not verified against XBackend
-'weather-service': discovery unavailable"). This ensures operators have
-visibility without blocking policy acceptance.
+**Phase 3: Policy validation.** XAccessPolicy cross-referencing against
+discovered tools. When an XToolInventory has `Ready: False` (discovery failed
+or not yet attempted), any XAccessPolicy targeting the corresponding backend
+includes a note in the `Accepted` condition message indicating which target
+backends had no discovery data available (e.g., "tools not verified against
+XBackend 'weather-service': discovery unavailable"). This ensures operators
+have visibility without blocking policy acceptance.
 
-### Alternative: Separate Discovery Controller
+### Alternative: Separate Discovery Controller Binary
 
 The discovery logic is encapsulated in `pkg/discovery/`, making extraction into
 a standalone `agentic-net-discovery` binary straightforward if the community
@@ -365,6 +452,8 @@ policy validation use case.
 - *Con:* CRD status (count only) is insufficient for policy validation.
 - *Con:* In-memory tool registry doesn't surface tools to kubectl or other
   controllers.
+- *Con:* Usability issues with reflecting discovery data directly on CRD status
+  ([issue #629](https://github.com/Kuadrant/mcp-gateway/issues/629)) motivate a dedicated resource.
 
 ### [kagenti-operator](https://github.com/kagenti/kagenti-operator) AgentCard Controller
 
@@ -387,7 +476,7 @@ request, provides no CRD visibility, and makes offline policy validation
 impossible. The controller-side approach also enables schema validation before
 tools reach agents.
 
-### Full tool metadata in XBackend.status
+### Full tool metadata in XToolInventory.status
 
 Storing `inputSchema`, `outputSchema`, and other fields would provide a
 complete picture but risks `etcd` bloat. A backend with 150 tools at ~5 KB each
@@ -395,31 +484,42 @@ approaches etcd's ~1.5 MB per-object limit. Name + title + description at
 ~200-500 bytes per tool is the right middle ground: enough for policy
 validation and kubectl inspection, without the storage risk.
 
-### Separate ToolRegistry CRD
+### Discovery data in XBackend.status
 
-A dedicated `XToolRegistry` CRD could decouple tool discovery from XBackend.
-This adds CRD surface area without clear benefit at this stage. If etcd size
-becomes a concern, the `pkg/discovery/` package boundary makes migrating to a
-separate CRD a localized change.
+The initial version of this proposal placed discovered tools in
+`XBackend.status.discoveredTools`. Community feedback identified issues with
+this approach: not every backend controller performs discovery, so embedding
+discovery fields in XBackend.status forces all backend controllers to account
+for fields they don't manage; XBackend's shape is actively in flux
+([#161](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/161), [#162](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/162)), and coupling discovery to it creates unnecessary
+churn; and practical experience in mcp-gateway ([issue #629](https://github.com/Kuadrant/mcp-gateway/issues/629)) showed usability
+issues with reflecting discovery data on the backend resource's status. A
+dedicated XToolInventory CRD decouples discovery lifecycle from backend
+lifecycle.
 
 ## Community Consensus Points
 
 ### Phase 1
 
-1. **Is `XBackend.status` the right location?** Given the ongoing XBackend
-   shape discussions ([#161](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/161), [#162](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/162)), should discovery wait? We argue no. Status
-   constitutes observed state that is independent of spec changes.
+1. **Is XToolInventory with 1:1 backendRef the right granularity?** One
+   XToolInventory per XBackend is expected to scale well for typical
+   deployments (tens to low hundreds of MCP backends), analogous to
+   HTTPRoute-per-route. The opt-in model (only backends that want discovery get
+   an XToolInventory) naturally bounds the number of objects.
 2. **MCP client library.** Should KAN depend on `github.com/mark3labs/mcp-go`?
    It is the most mature Go MCP client.
-3. **Default sync interval.** We propose 30s. Configurable via controller flag.
+3. **Default poll interval.** We propose 5 minutes. Configurable via
+   `spec.pollInterval` on XToolInventory.
+4. **Hybrid creation model.** Operators can pre-create XToolInventory resources
+   or let the controller auto-create them via annotation. Is this acceptable?
 
 ### Phase 3
 
-4. **Warning vs. rejection.** Should an AccessPolicy referencing a
+5. **Warning vs. rejection.** Should an XAccessPolicy referencing a
    non-existent tool be admitted with a Warning, or rejected? We recommend
    Warning — the backend may be temporarily unreachable.
-5. **Bi-directional validation.** Should validation trigger on both
-   AccessPolicy changes and XBackend status changes? We recommend both.
+6. **Bi-directional validation.** Should validation trigger on both
+   XAccessPolicy changes and XToolInventory status changes? We recommend both.
 
 ## Contributors
 
@@ -438,4 +538,5 @@ deferred pending Backend spec stabilization.
 - [AI Gateway WG Proposal 10](https://github.com/kubernetes-sigs/wg-ai-gateway/blob/main/proposals/10-egress-gateways.md) — Egress gateways with MCP protocol support
 - [MCP Specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) — Current MCP spec with tool annotations, pagination, schema requirements
 - [Kuadrant/mcp-gateway issue #662](https://github.com/Kuadrant/mcp-gateway/issues/662) — Schema validation gap
+- [Kuadrant/mcp-gateway issue #629](https://github.com/Kuadrant/mcp-gateway/issues/629) — Status usability issues motivating dedicated CRD
 - [Kuadrant/mcp-gateway PR #329](https://github.com/Kuadrant/mcp-gateway/pull/329) — tools/list_changed support

--- a/docs/proposals/XXXX-ToolDiscovery.md
+++ b/docs/proposals/XXXX-ToolDiscovery.md
@@ -12,6 +12,7 @@ Status: Provisional<br/>
 
 | Date | Change |
 |------|--------|
+| 2026-07-02 | Added support for the MCP `ttlMs` freshness hint (SEP #2549) as the primary refetch bound, clamped by `spec.maxPollInterval`, with `tools/list_changed` as immediate invalidation. Scoped policy validation to `Inline` rules. Addresses review feedback from @david-martin and @shachartal. |
 | 2026-05-25 | Major revision: replaced `XBackend.status.discoveredTools` with a dedicated `XToolInventory` CRD (1:1 with XBackend via `backendRef`). Updated all examples to `agentic.networking.x-k8s.io/v1alpha1` with method-based matching (`mcp.methods[].params[]`). Changed default poll interval from 30s to 5m. Added hybrid creation model (explicit + annotation-triggered). Motivated by community feedback from @keithmattix and @david-martin. |
 | 2026-04-06 | Added A2A scoping non-goal. |
 | 2026-03-16 | Initial proposal. |
@@ -111,8 +112,8 @@ in the policy's `Accepted` condition message if any tool name doesn't match.
 **CUJ 3: Backend adds a new tool.**
 A tool developer deploys a new version of their MCP server with an additional
 tool. The discovery controller detects the change (via `tools/list_changed`
-notification or the next poll) and updates the `XToolInventory` status.
-Existing `XAccessPolicy` resources that don't include the new tool are
+notification, TTL expiry, or the next poll) and updates the `XToolInventory`
+status. Existing `XAccessPolicy` resources that don't include the new tool are
 unaffected; the operator can add it when ready.
 
 **CUJ 4: Backend exposes an invalid tool.**
@@ -178,10 +179,20 @@ type XToolInventorySpec struct {
     BackendRef gwapiv1.LocalObjectReference `json:"backendRef"`
 
     // PollInterval is the interval between discovery polls for backends
-    // that do not support tools/list_changed notifications.
+    // that do not support tools/list_changed notifications and do not
+    // advertise a ttlMs freshness hint on their tools/list response.
     // Defaults to 5 minutes.
     // +optional
     PollInterval *metav1.Duration `json:"pollInterval,omitempty"`
+
+    // MaxPollInterval bounds how long the controller will honor a
+    // server-advertised ttlMs before re-fetching. It defends against a
+    // misconfigured or malicious server setting an excessively long ttlMs
+    // that would otherwise cause the inventory to serve stale data. The
+    // effective refetch interval is min(server ttlMs, MaxPollInterval).
+    // Defaults to 30 minutes.
+    // +optional
+    MaxPollInterval *metav1.Duration `json:"maxPollInterval,omitempty"`
 }
 
 type XToolInventoryStatus struct {
@@ -202,6 +213,13 @@ type XToolInventoryStatus struct {
     // tools/list call to the referenced backend.
     // +optional
     LastDiscoveryTime *metav1.Time `json:"lastDiscoveryTime,omitempty"`
+
+    // ObservedTTL reflects the ttlMs freshness hint advertised by the
+    // backend on its most recent tools/list response, if any. It is
+    // observed state, not a control knob; the operator bounds it via
+    // spec.maxPollInterval.
+    // +optional
+    ObservedTTL *metav1.Duration `json:"observedTTL,omitempty"`
 }
 
 type DiscoveredTool struct {
@@ -363,13 +381,26 @@ For each XToolInventory, the controller:
    Tools with invalid schemas are rejected and logged as Warning events on the
    XToolInventory resource.
 5. **Updates** `XToolInventory.status.discoveredTools[]` with validated tools
-   only.
+   only, and records any server-advertised `ttlMs` in `status.observedTTL`.
 6. **Maintains a persistent connection** to backends that declare the
    `listChanged` capability, listening for `tools/list_changed` notifications
    to trigger immediate re-discovery.
-7. **Falls back to polling** (configurable via `spec.pollInterval`, default 5m)
-   for backends that don't support `list_changed`, and as a periodic
-   consistency check for all backends.
+7. **Determines the refetch interval** using the freshness signals available,
+   in priority order:
+   - If the backend advertises a `ttlMs` on its `tools/list` response (per the
+     MCP caching hints in [SEP #2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549)),
+     the controller refetches after `min(ttlMs, spec.maxPollInterval)`. The
+     `maxPollInterval` bound guards against a misconfigured or malicious server
+     advertising an excessively long TTL that would defeat the purpose of
+     surfacing fresh data to policy authors.
+   - A `tools/list_changed` notification invalidates the cached result
+     immediately, regardless of the TTL.
+   - For backends that advertise neither, the controller falls back to polling
+     at `spec.pollInterval` (default 5m).
+   Note that the MCP spec frames `ttlMs` as an on-access freshness hint rather
+   than a polling interval; the discovery controller deliberately uses it as a
+   refetch bound, applying jitter and backoff, which is the trade-off this
+   proposal asks the community to accept for a control-plane inventory.
 8. **Detects drift** by diffing new vs. old tool sets and emits Kubernetes
    Events when tools are added, removed, or fail validation.
 
@@ -522,6 +553,13 @@ lifecycle.
    `spec.pollInterval` on XToolInventory.
 4. **Hybrid creation model.** Operators can pre-create XToolInventory resources
    or let the controller auto-create them via annotation. Is this acceptable?
+5. **Freshness signals: TTL vs. notifications.** We propose honoring a
+   server-advertised `ttlMs` ([MCP SEP #2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549))
+   as the primary refetch bound, clamped by `spec.maxPollInterval` to defend
+   against excessively long TTLs, with `tools/list_changed` notifications as an
+   immediate invalidation signal. Is the community comfortable with using
+   `ttlMs` as a refetch bound (rather than the on-access freshness hint the MCP
+   spec describes) for a control-plane inventory?
 
 ### Phase 3
 
@@ -547,6 +585,8 @@ deferred pending Backend spec stabilization.
 - [gateway-api PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488) — Upstream Backend resource
 - [AI Gateway WG Proposal 10](https://github.com/kubernetes-sigs/wg-ai-gateway/blob/main/proposals/10-egress-gateways.md) — Egress gateways with MCP protocol support
 - [MCP Specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) — Current MCP spec with tool annotations, pagination, schema requirements
+- [MCP SEP #2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549) — TTL (`ttlMs`) freshness hints for list results
+- [MCP spec release candidate (2026-07-28)](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) — Release candidate introducing the `ttlMs` caching hints
 - [Kuadrant/mcp-gateway issue #662](https://github.com/Kuadrant/mcp-gateway/issues/662) — Schema validation gap
 - [Kuadrant/mcp-gateway issue #629](https://github.com/Kuadrant/mcp-gateway/issues/629) — Status usability issues motivating dedicated CRD
 - [Kuadrant/mcp-gateway PR #329](https://github.com/Kuadrant/mcp-gateway/pull/329) — tools/list_changed support

--- a/docs/proposals/XXXX-ToolDiscovery.md
+++ b/docs/proposals/XXXX-ToolDiscovery.md
@@ -465,9 +465,13 @@ controller never rejects a policy or cleans up rules based on discovery data
 
 **Phase 2: External backends (TLS and authentication).** Extends the discovery
 controller to connect to backends outside the cluster, requiring TLS and
-potentially a credential reference for `tools/list` calls. The exact mechanism
-(e.g., a `credentialRef` on XToolInventory) is deferred pending stabilization
-of the Backend spec between KAN and the AI Gateway WG.
+potentially a credential reference for `tools/list` calls. The Backend resource
+itself has since landed as Implementable and shipped experimentally in Gateway
+API v1.6.0 ([GEP-4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)),
+with `MCP` as a named `BackendProtocol` value. What remains deferred is
+narrower: the MCP-specific protocol options and the credential mechanism for
+authenticated `tools/list` calls (e.g., a `credentialRef` on XToolInventory),
+which GEP-4488 leaves as future work.
 
 ### Alternative: Separate Discovery Controller Binary
 
@@ -631,7 +635,7 @@ deferred pending Backend spec stabilization.
 - [KAN issue #161](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/161) — Service targeting on XBackend
 - [KAN issue #162](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/162) — Path on XBackend
 - [KAN PR #182](https://github.com/kubernetes-sigs/kube-agentic-networking/pull/182) — Empty tool list deny-all semantics
-- [gateway-api PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488) — Upstream Backend resource
+- [gateway-api GEP-4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488) — Upstream Backend resource (Implementable; shipped experimentally in v1.6.0 with `MCP` as a named `BackendProtocol`)
 - [AI Gateway WG Proposal 10](https://github.com/kubernetes-sigs/wg-ai-gateway/blob/main/proposals/10-egress-gateways.md) — Egress gateways with MCP protocol support
 - [MCP Specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) — Current MCP spec with tool annotations, pagination, schema requirements
 - [MCP SEP #2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549) — TTL (`ttlMs`) freshness hints for list results

--- a/docs/proposals/XXXX-ToolDiscovery.md
+++ b/docs/proposals/XXXX-ToolDiscovery.md
@@ -12,6 +12,7 @@ Status: Provisional<br/>
 
 | Date | Change |
 |------|--------|
+| 2026-07-23 | Collapsed phasing so discovery, drift detection, and XAccessPolicy cross-referencing land together in Phase 1 (external backends become Phase 2). Added "Known Limitation: dynamic and per-caller tools" and "Relationship to MCP Server Cards (SEP-2127)" sections. Addresses review feedback from @david-martin. |
 | 2026-07-02 | Added support for the MCP `ttlMs` freshness hint (SEP #2549) as the primary refetch bound, clamped by `spec.maxPollInterval`, with `tools/list_changed` as immediate invalidation. Scoped policy validation to `Inline` rules. Addresses review feedback from @david-martin and @shachartal. |
 | 2026-05-25 | Major revision: replaced `XBackend.status.discoveredTools` with a dedicated `XToolInventory` CRD (1:1 with XBackend via `backendRef`). Updated all examples to `agentic.networking.x-k8s.io/v1alpha1` with method-based matching (`mcp.methods[].params[]`). Changed default poll interval from 30s to 5m. Added hybrid creation model (explicit + annotation-triggered). Motivated by community feedback from @keithmattix and @david-martin. |
 | 2026-04-06 | Added A2A scoping non-goal. |
@@ -434,9 +435,13 @@ For Inline rules, the reconciler:
 
 ### Phasing
 
-**Phase 1: In-cluster discovery (plain HTTP).** XToolInventory CRD, discovery
-controller, schema validation, `list_changed` support, drift detection. The
-controller connects to backends using the service name and port from
+**Phase 1: In-cluster discovery and policy cross-referencing (plain HTTP).**
+XToolInventory CRD, discovery controller, schema validation, `list_changed`
+support, drift detection, and XAccessPolicy cross-referencing. Visibility,
+drift detection, and policy cross-referencing land together in this phase so
+the community can evaluate the full advisory workflow at once.
+
+The controller connects to backends using the service name and port from
 `XBackend.spec.mcp` over plain HTTP. This is sufficient for in-cluster backends
 where trust is assumed. In mesh environments (e.g., Istio sidecar on the
 controller pod), mTLS is handled transparently at the infrastructure layer, so
@@ -449,19 +454,20 @@ is advisory — it does not gate the data plane. The operator sees an early
 signal that the backend is unreachable to the control plane, but runtime tool
 calls proceed normally as long as the agent's own credentials are valid.
 
+Policy cross-referencing is likewise advisory. When an XToolInventory has
+`Ready: False` (discovery failed or not yet attempted), any XAccessPolicy
+targeting the corresponding backend includes a note in the `Accepted` condition
+message indicating which target backends had no discovery data available (e.g.,
+"tools not verified against XBackend 'weather-service': discovery unavailable").
+This ensures operators have visibility without blocking policy acceptance. The
+controller never rejects a policy or cleans up rules based on discovery data
+(see [Known Limitation: dynamic and per-caller tools](#known-limitation-dynamic-and-per-caller-tools)).
+
 **Phase 2: External backends (TLS and authentication).** Extends the discovery
 controller to connect to backends outside the cluster, requiring TLS and
 potentially a credential reference for `tools/list` calls. The exact mechanism
 (e.g., a `credentialRef` on XToolInventory) is deferred pending stabilization
 of the Backend spec between KAN and the AI Gateway WG.
-
-**Phase 3: Policy validation.** XAccessPolicy cross-referencing against
-discovered tools. When an XToolInventory has `Ready: False` (discovery failed
-or not yet attempted), any XAccessPolicy targeting the corresponding backend
-includes a note in the `Accepted` condition message indicating which target
-backends had no discovery data available (e.g., "tools not verified against
-XBackend 'weather-service': discovery unavailable"). This ensures operators
-have visibility without blocking policy acceptance.
 
 ### Alternative: Separate Discovery Controller Binary
 
@@ -475,6 +481,54 @@ to `AgentCard.status`. The benefit is fault isolation: a bug or crash in the
 discovery loop doesn't affect the main proxy management controller. The
 embedded approach is recommended to start because it avoids an additional
 deployment and simplifies RBAC.
+
+## Known Limitation: dynamic and per-caller tools
+
+The tool set an MCP server exposes can be dynamic. It may vary by authenticated
+user, session, configuration, feature flags, or deployment state. The MCP
+community has grappled with this directly: MCP Server Cards ([SEP-2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127))
+deliberately exclude primitives (tools, resources, prompts) from the static
+card, stating that "clients cannot trust a static manifest for access-control
+or safety decisions; primitives are always validated at runtime via standard
+list operations." The tension around pre-connection primitive visibility is
+discussed further in [modelcontextprotocol issue #540](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/540).
+
+This proposal respects that constraint. The discovery controller connects and
+calls `tools/list` at runtime using a single control-plane identity, so
+XToolInventory captures one "control-plane variant" of the tool set, not the
+per-caller view a specific agent would see. As a result:
+
+- Tools gated on the caller's identity or session may not match what the
+  controller observes, so the drift signal can produce false positives.
+- This is precisely why discovery is advisory and validation is Warning-only
+  (never rejection), and why the controller never automates cleanup or removal
+  of XAccessPolicy rules. The operator's intent is not knowable from discovery
+  data alone; a rule may be intentionally present ahead of a tool being
+  (re)exposed.
+
+XToolInventory is not a substitute for runtime listing with the caller's
+identity, and it is not an access-control source of truth. It is a
+control-plane aid for visibility and policy authoring.
+
+## Relationship to MCP Server Cards (SEP-2127)
+
+XToolInventory and MCP Server Cards are complementary and non-overlapping:
+
+- **MCP Server Cards** are static documents served *without* a connection,
+  answering "where and how do I connect" (transports, protocol versions). They
+  deliberately exclude primitives.
+- **XToolInventory** is a cache of a live `tools/list` result obtained *with* a
+  connection, by the controller's control-plane identity, to support policy
+  authoring and operator visibility.
+
+The two sit on the same side of the line SEP-2127 draws: primitives are
+validated at runtime via standard list operations, never trusted from a static
+manifest. XToolInventory does not attempt to make primitives safely
+advertisable in a static, pre-connection document; that remains an open problem
+the SEP explicitly defers. If anything, SEP-2127 corroborates this proposal's
+design constraint, arriving independently at the same conclusion that motivates
+our advisory-only posture: a manifest of primitives is not a safe basis for
+access-control decisions.
 
 ## Prior Art
 
@@ -540,8 +594,6 @@ lifecycle.
 
 ## Community Consensus Points
 
-### Phase 1
-
 1. **Is XToolInventory with 1:1 backendRef the right granularity?** One
    XToolInventory per XBackend is expected to scale well for typical
    deployments (tens to low hundreds of MCP backends), analogous to
@@ -560,13 +612,10 @@ lifecycle.
    immediate invalidation signal. Is the community comfortable with using
    `ttlMs` as a refetch bound (rather than the on-access freshness hint the MCP
    spec describes) for a control-plane inventory?
-
-### Phase 3
-
-5. **Warning vs. rejection.** Should an XAccessPolicy referencing a
+6. **Warning vs. rejection.** Should an XAccessPolicy referencing a
    non-existent tool be admitted with a Warning, or rejected? We recommend
    Warning — the backend may be temporarily unreachable.
-6. **Bi-directional validation.** Should validation trigger on both
+7. **Bi-directional validation.** Should validation trigger on both
    XAccessPolicy changes and XToolInventory status changes? We recommend both.
 
 ## Contributors

--- a/docs/proposals/XXXX-ToolDiscovery.md
+++ b/docs/proposals/XXXX-ToolDiscovery.md
@@ -12,6 +12,7 @@ Status: Provisional<br/>
 
 | Date | Change |
 |------|--------|
+| 2026-07-23 | Clarified CUJ 2 to attribute policy authoring to a policy author distinct from (though optionally the same as) the platform engineer managing XToolInventory, and noted the policy author need not deploy or reconcile a discovery resource. Addresses review feedback from @LiorLieberman. |
 | 2026-07-23 | Collapsed phasing so discovery, drift detection, and XAccessPolicy cross-referencing land together in Phase 1 (external backends become Phase 2). Added "Known Limitation: dynamic and per-caller tools" and "Relationship to MCP Server Cards (SEP-2127)" sections. Addresses review feedback from @david-martin. |
 | 2026-07-02 | Added support for the MCP `ttlMs` freshness hint (SEP #2549) as the primary refetch bound, clamped by `spec.maxPollInterval`, with `tools/list_changed` as immediate invalidation. Scoped policy validation to `Inline` rules. Addresses review feedback from @david-martin and @shachartal. |
 | 2026-05-25 | Major revision: replaced `XBackend.status.discoveredTools` with a dedicated `XToolInventory` CRD (1:1 with XBackend via `backendRef`). Updated all examples to `agentic.networking.x-k8s.io/v1alpha1` with method-based matching (`mcp.methods[].params[]`). Changed default poll interval from 30s to 5m. Added hybrid creation model (explicit + annotation-triggered). Motivated by community feedback from @keithmattix and @david-martin. |
@@ -104,11 +105,14 @@ XBackend to trigger auto-creation. Within the poll interval,
 `status.discoveredTools` populated with the backend's tools. No manual
 enumeration required.
 
-**CUJ 2: Operator writes a valid access policy.**
-The platform engineer writes an `XAccessPolicy` referencing tool names in
-`mcp.methods[].params[]`. The controller validates the tool names against
-the corresponding `XToolInventory.status.discoveredTools` and sets a Warning
-in the policy's `Accepted` condition message if any tool name doesn't match.
+**CUJ 2: Policy author writes a valid access policy.**
+A policy author writes an `XAccessPolicy` referencing tool names in
+`mcp.methods[].params[]`. This may or may not be the same person who manages
+the XToolInventory; either way, the policy author does not need to create or
+reconcile any discovery resource themselves. They consume the
+already-populated `XToolInventory.status.discoveredTools`. The controller
+validates the tool names against it and sets a Warning in the policy's
+`Accepted` condition message if any tool name doesn't match.
 
 **CUJ 3: Backend adds a new tool.**
 A tool developer deploys a new version of their MCP server with an additional

--- a/docs/proposals/XXXX-ToolDiscovery.md
+++ b/docs/proposals/XXXX-ToolDiscovery.md
@@ -133,7 +133,7 @@ policies or reaching agents.
 Three recent developments inform this proposal's design:
 
 **XBackend is in flux.** KAN is actively reconsidering XBackend's shape to
-align with the AI Gateway WG's Backend resource ([gateway-api PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)). [Issue
+align with the AI Gateway WG's Backend resource ([gateway-api GEP-4894](https://github.com/kubernetes-sigs/gateway-api/blob/main/geps/gep-4894/index.md)). [Issue
 #161](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/161) tracks whether to drop `Service` as a target type; [issue #162](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/162) questions
 whether `path` belongs on XBackend or in protocol-specific options.
 Additionally, not every backend controller performs discovery — coupling
@@ -470,12 +470,12 @@ controller never rejects a policy or cleans up rules based on discovery data
 **Phase 2: External backends (TLS and authentication).** Extends the discovery
 controller to connect to backends outside the cluster, requiring TLS and
 potentially a credential reference for `tools/list` calls. The Backend resource
-itself has since landed as Implementable and shipped experimentally in Gateway
-API v1.6.0 ([GEP-4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)),
+itself has since landed as Experimental in Gateway
+API v1.6.0 ([GEP-4894](https://github.com/kubernetes-sigs/gateway-api/blob/main/geps/gep-4894/index.md)),
 with `MCP` as a named `BackendProtocol` value. What remains deferred is
 narrower: the MCP-specific protocol options and the credential mechanism for
 authenticated `tools/list` calls (e.g., a `credentialRef` on XToolInventory),
-which GEP-4488 leaves as future work.
+which GEP-4894 leaves as future work.
 
 ### Alternative: Separate Discovery Controller Binary
 
@@ -639,7 +639,7 @@ deferred pending Backend spec stabilization.
 - [KAN issue #161](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/161) — Service targeting on XBackend
 - [KAN issue #162](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/162) — Path on XBackend
 - [KAN PR #182](https://github.com/kubernetes-sigs/kube-agentic-networking/pull/182) — Empty tool list deny-all semantics
-- [gateway-api GEP-4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488) — Upstream Backend resource (Implementable; shipped experimentally in v1.6.0 with `MCP` as a named `BackendProtocol`)
+- [gateway-api GEP-4894](https://github.com/kubernetes-sigs/gateway-api/blob/main/geps/gep-4894/index.md) — Upstream Backend resource (Experimental; shipped in v1.6.0 with `MCP` as a named `BackendProtocol`)
 - [AI Gateway WG Proposal 10](https://github.com/kubernetes-sigs/wg-ai-gateway/blob/main/proposals/10-egress-gateways.md) — Egress gateways with MCP protocol support
 - [MCP Specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) — Current MCP spec with tool annotations, pagination, schema requirements
 - [MCP SEP #2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549) — TTL (`ttlMs`) freshness hints for list results


### PR DESCRIPTION
## Summary

- Proposes optional, opt-in tool discovery for KAN: a controller that calls `tools/list` on MCP backends, validates schemas, and surfaces discovered tools in a dedicated `XToolInventory` CRD (1:1 with XBackend via `backendRef`)
- Enables policy validation against real backend state and operator visibility via `kubectl`
- Discovery is advisory (does not affect policy enforcement) and opt-in via hybrid creation model (operator creates XToolInventory explicitly, or controller auto-creates via annotation)

## Key design decisions

- **Separate CRD over XBackend.status**: Decouples discovery lifecycle from backend lifecycle; not every backend controller does discovery; XBackend shape is in flux
- **1:1 mapping**: One XToolInventory per XBackend, analogous to HTTPRoute-per-route
- **Hybrid creation**: Explicit creation or annotation-triggered auto-creation (common pattern: Service → EndpointSlice)
- **Freshness signals**: Honor a server-advertised `ttlMs` ([MCP SEP #2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549)) as the primary refetch bound, clamped by `spec.maxPollInterval` to guard against excessively long TTLs; `tools/list_changed` as immediate invalidation; fall back to `spec.pollInterval` (default 5m) when neither is advertised
- **Validation scoped to Inline rules**: Cross-referencing discovered tools applies to `Inline` authorization (explicit enumeration), not `CEL` (dynamic matching)
- **v1alpha1 alignment**: Examples use `agentic.networking.x-k8s.io/v1alpha1` with method-based matching (`mcp.methods[].params[]`)

## Phasing

- **Phase 1**: In-cluster discovery (plain HTTP), XToolInventory CRD, schema validation, `list_changed` + `ttlMs` freshness handling, drift detection
- **Phase 2**: External backends with TLS/authentication via `credentialRef` on XToolInventory (deferred pending Backend spec stabilization)
- **Phase 3**: XAccessPolicy cross-referencing `params[]` against `XToolInventory.status.discoveredTools`

## Prior discussion

- Initial draft reviewed on fork PR (rubambiza/kube-agentic-networking#1) with feedback from @evaline-ju and @david-martin
- Major revision (2026-05-25) based on community feedback from @keithmattix (separate CRD, egress gateway routing) and @david-martin (v1alpha1 alignment, poll interval, two identities)
- Revision (2026-07-02) adding `ttlMs` freshness handling (SEP #2549) and Inline-scoped validation, based on feedback from @LiorLieberman, @david-martin, and @shachartal

## Community consensus points

- [x] Is XToolInventory with 1:1 backendRef the right granularity?
- [x] MCP client library: `github.com/mark3labs/mcp-go`?
- [x] Hybrid creation model (explicit + annotation-triggered) acceptable?
- [x] Freshness signals: `ttlMs` as a refetch bound (vs. on-access hint) + notifications — acceptable trade-off for a control-plane inventory?
- [x] Warning vs. rejection for unverified tools?

## Test plan

- [ ] Community review of revised API design (XToolInventory CRD)
- [ ] Alignment on consensus points above
- [ ] Validate implementability against current codebase structure