### PR TITLE
Fix the issue where `make api-ref-docs` was generating an empty reference page

### DIFF
--- a/hack/mkdocs/generate.sh
+++ b/hack/mkdocs/generate.sh
@@ -34,18 +34,7 @@ declare -a arr=(
     "main"
 )
 
-# Create a temporary directory for the script.
-# This directory will be cleaned up automatically on script exit.
-SCRIPT_TMP_DIR=$(mktemp -d)
-trap 'rm -rf "${SCRIPT_TMP_DIR}"' EXIT
-
 for i in "${arr[@]}"; do
-    tmpdir=$(mktemp -d --tmpdir="${SCRIPT_TMP_DIR}")
-
-    # Use the current api directory instead of fetching from remote,
-    # which is required for CI (Prow) to verify PR changes correctly.
-    cp -r api ${tmpdir}/api
-
     # Start removing any "release-" prefix from docpath
     docpath=${i#"release-"}
     # If the release is "main" simply remove it
@@ -53,7 +42,7 @@ for i in "${arr[@]}"; do
 	mkdir -p "${PWD}/site-src/reference/${docpath}"
 
     ${GOBIN}/crd-ref-docs \
-        --source-path=${tmpdir}/api \
+        --source-path=api \
         --config=crd-ref-docs.yaml \
         --renderer=markdown \
         --output-path=${PWD}/site-src/reference/${docpath}/spec.md

--- a/hack/verify-api-docs.sh
+++ b/hack/verify-api-docs.sh
@@ -22,6 +22,11 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 make -C "$SCRIPT_ROOT" api-ref-docs
 
+if ! grep -q "Resource Types" "${SCRIPT_ROOT}/site-src/reference/spec.md"; then
+	echo "Error: Generated API reference appears to be empty or broken (missing 'Resource Types')."
+	exit 1
+fi
+
 if git status -s "${SCRIPT_ROOT}/site-src/reference" 2>&1 | grep -E -q '^\s?[MADRCU\?]'
 then
 	echo "Uncommitted changes or new files in generated API reference documentation (site-src/reference):"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind bug

**What this PR does / why we need it**:
Modify `hack/mkdocs/generate.sh` to use the local api directory directly instead of copying it to a temporary directory outside the project root. This allows `crd-ref-docs` to correctly resolve Go packages.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #226

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
