### PR TITLE
feat: Add translation logic to support custom TLS and frontendValidation in Gateway

### DIFF
--- a/cmd/agentic-net-controller/main.go
+++ b/cmd/agentic-net-controller/main.go
@@ -125,6 +125,7 @@ func main() {
 		sharedKubeInformers.Core().V1().Namespaces(),
 		sharedKubeInformers.Core().V1().Services(),
 		sharedKubeInformers.Core().V1().Secrets(),
+		sharedKubeInformers.Core().V1().ConfigMaps(),
 		sharedGwInformers.Gateway().V1().GatewayClasses(),
 		sharedGwInformers.Gateway().V1().Gateways(),
 		sharedGwInformers.Gateway().V1().HTTPRoutes(),

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -76,6 +76,9 @@ type coreResources struct {
 
 	secretLister corev1listers.SecretLister
 	secretSynced cache.InformerSynced
+
+	configMapLister corev1listers.ConfigMapLister
+	configMapSynced cache.InformerSynced
 }
 
 type gatewayResources struct {
@@ -132,6 +135,7 @@ func New(
 	namespaceInformer corev1informers.NamespaceInformer,
 	serviceInformer corev1informers.ServiceInformer,
 	secretInformer corev1informers.SecretInformer,
+	configMapInformer corev1informers.ConfigMapInformer,
 	gatewayClassInformer gatewayinformers.GatewayClassInformer,
 	gatewayInformer gatewayinformers.GatewayInformer,
 	httprouteInformer gatewayinformers.HTTPRouteInformer,
@@ -154,13 +158,15 @@ func New(
 
 	c := &Controller{
 		core: coreResources{
-			client:       kubeClientSet,
-			nsLister:     namespaceInformer.Lister(),
-			nsSynced:     namespaceInformer.Informer().HasSynced,
-			svcLister:    serviceInformer.Lister(),
-			svcSynced:    serviceInformer.Informer().HasSynced,
-			secretLister: secretInformer.Lister(),
-			secretSynced: secretInformer.Informer().HasSynced,
+			client:          kubeClientSet,
+			nsLister:        namespaceInformer.Lister(),
+			nsSynced:        namespaceInformer.Informer().HasSynced,
+			svcLister:       serviceInformer.Lister(),
+			svcSynced:       serviceInformer.Informer().HasSynced,
+			secretLister:    secretInformer.Lister(),
+			secretSynced:    secretInformer.Informer().HasSynced,
+			configMapLister: configMapInformer.Lister(),
+			configMapSynced: configMapInformer.Informer().HasSynced,
 		},
 		gateway: gatewayResources{
 			client:               gwClientSet,
@@ -203,6 +209,7 @@ func New(
 		namespaceInformer.Lister(),
 		serviceInformer.Lister(),
 		secretInformer.Lister(),
+		configMapInformer.Lister(),
 		gatewayInformer.Lister(),
 		httprouteInformer.Lister(),
 		referenceGrantInformer.Lister(),
@@ -255,6 +262,7 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 		c.core.nsSynced,
 		c.core.svcSynced,
 		c.core.secretSynced,
+		c.core.configMapSynced,
 		c.gateway.gatewayClassSynced,
 		c.gateway.gatewaySynced,
 		c.gateway.httprouteSynced,

--- a/pkg/translator/common_test.go
+++ b/pkg/translator/common_test.go
@@ -26,8 +26,11 @@ import (
 	agenticv0alpha0 "sigs.k8s.io/kube-agentic-networking/api/v0alpha0"
 )
 
-func newTestGateway(name, ns string) *gatewayv1.Gateway {
-	return &gatewayv1.Gateway{
+// Suppress linter as ns always receives the same value: "quickstart-ns"
+//
+//nolint:unparam
+func newTestGateway(name, ns string, certRefs []gatewayv1.SecretObjectReference, frontendConfig *gatewayv1.FrontendTLSConfig) *gatewayv1.Gateway {
+	gw := &gatewayv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 		Spec: gatewayv1.GatewaySpec{
 			GatewayClassName: "cloud-provider-kind",
@@ -41,8 +44,22 @@ func newTestGateway(name, ns string) *gatewayv1.Gateway {
 			}},
 		},
 	}
+	if len(certRefs) > 0 {
+		gw.Spec.Listeners[0].TLS = &gatewayv1.ListenerTLSConfig{
+			CertificateRefs: certRefs,
+		}
+	}
+	if frontendConfig != nil {
+		gw.Spec.TLS = &gatewayv1.GatewayTLSConfig{
+			Frontend: frontendConfig,
+		}
+	}
+	return gw
 }
 
+// Suppress linter as ns always receives the same value: "quickstart-ns"
+//
+//nolint:unparam
 func newTestBackend(name, ns string) *agenticv0alpha0.XBackend {
 	return &agenticv0alpha0.XBackend{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
@@ -123,6 +140,10 @@ func newTestAccessPolicy(name, ns, targetName, targetKind, principal string) *ag
 	}
 }
 
+// Suppress linter as ns always receives the same value: "quickstart-ns"
+// Suppress linter as port always receives 3001
+//
+//nolint:unparam
 func newTestService(name, ns string, port int32) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},

--- a/pkg/translator/listener.go
+++ b/pkg/translator/listener.go
@@ -19,6 +19,7 @@ package translator
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"time"
 
@@ -40,6 +41,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -163,64 +165,156 @@ func (t *Translator) validateCertificateRefs(gateway *gatewayv1.Gateway, listene
 	}
 
 	for _, ref := range listener.TLS.CertificateRefs {
-		group := ""
-		if ref.Group != nil {
-			group = string(*ref.Group)
+		if cond := t.validateCertificateRef(gateway, ref); cond != nil {
+			return cond
 		}
-		kind := "Secret"
-		if ref.Kind != nil {
-			kind = string(*ref.Kind)
-		}
+	}
 
-		if (group != "" && group != "core") || kind != "Secret" {
-			return &metav1.Condition{
-				Type:               string(gatewayv1.ListenerConditionResolvedRefs),
-				Status:             metav1.ConditionFalse,
-				Reason:             string(gatewayv1.ListenerReasonInvalidCertificateRef),
-				Message:            fmt.Sprintf("Unsupported certificate reference group %q kind %q. Only core/Secret is supported.", group, kind),
-				ObservedGeneration: gateway.Generation,
-			}
-		}
+	return nil
+}
 
-		ns := gateway.Namespace
-		if ref.Namespace != nil {
-			ns = string(*ref.Namespace)
-		}
+func (t *Translator) validateCertificateRef(gateway *gatewayv1.Gateway, ref gatewayv1.SecretObjectReference) *metav1.Condition {
+	group := ""
+	if ref.Group != nil {
+		group = string(*ref.Group)
+	}
+	kind := "Secret"
+	if ref.Kind != nil {
+		kind = string(*ref.Kind)
+	}
 
-		// Check if secret exists
-		_, err := t.secretLister.Secrets(ns).Get(string(ref.Name))
-		if err != nil {
-			reason := string(gatewayv1.ListenerReasonInvalidCertificateRef)
-			message := fmt.Sprintf("Failed to get Secret %s/%s: %v", ns, ref.Name, err)
-			if apierrors.IsNotFound(err) {
-				message = fmt.Sprintf("Secret %s/%s not found", ns, ref.Name)
-			}
-			return &metav1.Condition{
-				Type:               string(gatewayv1.ListenerConditionResolvedRefs),
-				Status:             metav1.ConditionFalse,
-				Reason:             reason,
-				Message:            message,
-				ObservedGeneration: gateway.Generation,
-			}
+	if (group != "" && group != "core") || kind != "Secret" {
+		return &metav1.Condition{
+			Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(gatewayv1.ListenerReasonInvalidCertificateRef),
+			Message:            fmt.Sprintf("Unsupported certificate reference group %q kind %q. Only core/Secret is supported.", group, kind),
+			ObservedGeneration: gateway.Generation,
 		}
+	}
 
-		// Check if cross-namespace reference is allowed by ReferenceGrant
-		if ns == gateway.Namespace {
-			continue
+	ns := gateway.Namespace
+	if ref.Namespace != nil {
+		ns = string(*ref.Namespace)
+	}
+
+	// Check if secret exists
+	secret, err := t.secretLister.Secrets(ns).Get(string(ref.Name))
+	if err != nil {
+		reason := string(gatewayv1.ListenerReasonInvalidCertificateRef)
+		message := fmt.Sprintf("Failed to get Secret %s/%s: %v", ns, ref.Name, err)
+		if apierrors.IsNotFound(err) {
+			message = fmt.Sprintf("Secret %s/%s not found", ns, ref.Name)
 		}
+		return &metav1.Condition{
+			Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+			Status:             metav1.ConditionFalse,
+			Reason:             reason,
+			Message:            message,
+			ObservedGeneration: gateway.Generation,
+		}
+	}
 
-		if !AllowedByReferenceGrant(
-			gateway.Namespace, "gateway.networking.k8s.io", "Gateway",
-			ns, "", "Secret", string(ref.Name),
-			t.referenceGrantLister,
-		) {
-			return &metav1.Condition{
-				Type:               string(gatewayv1.ListenerConditionResolvedRefs),
-				Status:             metav1.ConditionFalse,
-				Reason:             string(gatewayv1.ListenerReasonRefNotPermitted),
-				Message:            fmt.Sprintf("Reference to Secret %s/%s not permitted by ReferenceGrant", ns, ref.Name),
-				ObservedGeneration: gateway.Generation,
-			}
+	certBytes, hasCert := secret.Data[corev1.TLSCertKey]
+	keyBytes, hasKey := secret.Data[corev1.TLSPrivateKeyKey]
+	if !hasCert || !hasKey {
+		return &metav1.Condition{
+			Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(gatewayv1.ListenerReasonInvalidCertificateRef),
+			Message:            fmt.Sprintf("Secret %s/%s missing keys %s or %s", ns, ref.Name, corev1.TLSCertKey, corev1.TLSPrivateKeyKey),
+			ObservedGeneration: gateway.Generation,
+		}
+	}
+
+	block, _ := pem.Decode(certBytes)
+	if block == nil {
+		return &metav1.Condition{
+			Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(gatewayv1.ListenerReasonInvalidCertificateRef),
+			Message:            fmt.Sprintf("Secret %s/%s contains invalid PEM data in %s", ns, ref.Name, corev1.TLSCertKey),
+			ObservedGeneration: gateway.Generation,
+		}
+	}
+
+	// Basic validation that the private key is also present and decodeable
+	if block, _ := pem.Decode(keyBytes); block == nil {
+		return &metav1.Condition{
+			Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(gatewayv1.ListenerReasonInvalidCertificateRef),
+			Message:            fmt.Sprintf("Secret %s/%s contains invalid PEM data in %s", ns, ref.Name, corev1.TLSPrivateKeyKey),
+			ObservedGeneration: gateway.Generation,
+		}
+	}
+
+	// Check if cross-namespace reference is allowed by ReferenceGrant
+	if ns != gateway.Namespace && !AllowedByReferenceGrant(
+		gateway.Namespace, "gateway.networking.k8s.io", "Gateway",
+		ns, "", "Secret", string(ref.Name),
+		t.referenceGrantLister,
+	) {
+		return &metav1.Condition{
+			Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(gatewayv1.ListenerReasonRefNotPermitted),
+			Message:            fmt.Sprintf("Reference to Secret %s/%s not permitted by ReferenceGrant", ns, ref.Name),
+			ObservedGeneration: gateway.Generation,
+		}
+	}
+
+	return nil
+}
+
+func (t *Translator) validateCACertificateRef(gateway *gatewayv1.Gateway, caRef gatewayv1.ObjectReference) *metav1.Condition {
+	ns := gateway.Namespace
+	if caRef.Namespace != nil {
+		ns = string(*caRef.Namespace)
+	}
+	configMapName := string(caRef.Name)
+
+	group := string(caRef.Group)
+	kind := string(caRef.Kind)
+	if (group != "" && group != "core") || kind != "ConfigMap" {
+		return &metav1.Condition{
+			Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(gatewayv1.ListenerReasonInvalidCACertificateKind),
+			Message:            fmt.Sprintf("Unsupported CA certificate reference group %q kind %q. Only ConfigMap is supported.", group, kind),
+			ObservedGeneration: gateway.Generation,
+		}
+	}
+
+	if ns != gateway.Namespace && !AllowedByReferenceGrant(gateway.Namespace, gatewayv1.GroupName, "Gateway", ns, "", "ConfigMap", configMapName, t.referenceGrantLister) {
+		return &metav1.Condition{
+			Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(gatewayv1.ListenerReasonRefNotPermitted),
+			Message:            fmt.Sprintf("Reference to ConfigMap %s/%s not permitted by ReferenceGrant", ns, configMapName),
+			ObservedGeneration: gateway.Generation,
+		}
+	}
+
+	cm, err := t.configMapLister.ConfigMaps(ns).Get(configMapName)
+	if err != nil {
+		return &metav1.Condition{
+			Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(gatewayv1.ListenerReasonInvalidCACertificateRef),
+			Message:            fmt.Sprintf("Failed to get configmap %s: %v", configMapName, err),
+			ObservedGeneration: gateway.Generation,
+		}
+	}
+
+	_, hasCA := cm.Data[corev1.ServiceAccountRootCAKey]
+	if !hasCA {
+		return &metav1.Condition{
+			Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(gatewayv1.ListenerReasonInvalidCACertificateRef),
+			Message:            fmt.Sprintf("ConfigMap %s missing key %s", configMapName, corev1.ServiceAccountRootCAKey),
+			ObservedGeneration: gateway.Generation,
 		}
 	}
 
@@ -253,7 +347,7 @@ func (t *Translator) translateListenerToFilterChain(lis gatewayv1.Listener, rout
 			filterChain.FilterChainMatch.ServerNames = []string{string(*lis.Hostname)}
 		}
 
-		tlsContext, err := buildDownstreamTLSContext()
+		tlsContext, err := buildDownstreamTLSContext(lis, gateway)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build TLS context for listener %s: %w", lis.Name, err)
 		}
@@ -675,39 +769,71 @@ func buildRouterFilter() (*hcm.HttpFilter, error) {
 	}, nil
 }
 
-// TODO: We may want to optimize this in the future by supporting both listener's TLS config and the shared TLS context.
-// https://github.com/kubernetes-sigs/kube-agentic-networking/issues/94
-func buildDownstreamTLSContext() (*anypb.Any, error) {
-	tlsContext := &tlsv3.DownstreamTlsContext{
-		CommonTlsContext: &tlsv3.CommonTlsContext{
-			TlsCertificateSdsSecretConfigs: []*tlsv3.SdsSecretConfig{
-				{
-					Name: constants.SpiffeIdentitySdsConfigName,
-					SdsConfig: &corev3.ConfigSource{
-						ResourceApiVersion: corev3.ApiVersion_V3,
-						ConfigSourceSpecifier: &corev3.ConfigSource_PathConfigSource{
-							PathConfigSource: &corev3.PathConfigSource{
-								Path: fmt.Sprintf("%s/%s", constants.EnvoySdsMountPath, constants.SpiffeIdentitySdsFileName),
-							},
-						},
-					},
-				},
+func newAdsSdsSecretConfig(secretName string) *tlsv3.SdsSecretConfig {
+	return &tlsv3.SdsSecretConfig{
+		Name: secretName,
+		SdsConfig: &corev3.ConfigSource{
+			ResourceApiVersion: corev3.ApiVersion_V3,
+			ConfigSourceSpecifier: &corev3.ConfigSource_Ads{
+				Ads: &corev3.AggregatedConfigSource{},
 			},
-			ValidationContextType: &tlsv3.CommonTlsContext_ValidationContextSdsSecretConfig{
-				ValidationContextSdsSecretConfig: &tlsv3.SdsSecretConfig{
-					Name: constants.SpiffeTrustSdsConfigName,
-					SdsConfig: &corev3.ConfigSource{
-						ResourceApiVersion: corev3.ApiVersion_V3,
-						ConfigSourceSpecifier: &corev3.ConfigSource_PathConfigSource{
-							PathConfigSource: &corev3.PathConfigSource{
-								Path: fmt.Sprintf("%s/%s", constants.EnvoySdsMountPath, constants.SpiffeTrustSdsFileName),
-							},
-						},
-					},
+		},
+	}
+}
+
+func newPathSdsSecretConfig(name, filename string) *tlsv3.SdsSecretConfig {
+	return &tlsv3.SdsSecretConfig{
+		Name: name,
+		SdsConfig: &corev3.ConfigSource{
+			ResourceApiVersion: corev3.ApiVersion_V3,
+			ConfigSourceSpecifier: &corev3.ConfigSource_PathConfigSource{
+				PathConfigSource: &corev3.PathConfigSource{
+					Path: fmt.Sprintf("%s/%s", constants.EnvoySdsMountPath, filename),
 				},
 			},
 		},
+	}
+}
+
+// buildDownstreamTLSContext configures TLS for the downstream (client-to-gateway) connection.
+func buildDownstreamTLSContext(lis gatewayv1.Listener, gateway *gatewayv1.Gateway) (*anypb.Any, error) {
+	certRef, caRef, hasMultipleCerts, hasMultipleCAs := extractCertificateRefs(gateway, lis)
+	if certRef != nil && hasMultipleCerts {
+		klog.Warningf("Gateway %s/%s, listener %s has multiple certificateRefs, only the first one will be used and the rest will be ignored", gateway.Namespace, gateway.Name, lis.Name)
+	}
+	if caRef != nil && hasMultipleCAs {
+		klog.Warningf("Gateway %s/%s, listener %s has multiple CACertificateRefs, only the first one will be used and the rest will be ignored", gateway.Namespace, gateway.Name, lis.Name)
+	}
+
+	tlsContext := &tlsv3.DownstreamTlsContext{
+		CommonTlsContext:         &tlsv3.CommonTlsContext{},
 		RequireClientCertificate: wrapperspb.Bool(true),
+	}
+
+	commonTLS := tlsContext.GetCommonTlsContext()
+
+	// 1. Server Certificate
+	var serverSecretName string
+	if certRef != nil {
+		serverSecretName = fmt.Sprintf("%s-%s", gateway.Namespace, certRef.Name)
+		commonTLS.TlsCertificateSdsSecretConfigs = []*tlsv3.SdsSecretConfig{
+			newAdsSdsSecretConfig(serverSecretName),
+		}
+	} else {
+		commonTLS.TlsCertificateSdsSecretConfigs = []*tlsv3.SdsSecretConfig{
+			newPathSdsSecretConfig(constants.SpiffeIdentitySdsConfigName, constants.SpiffeIdentitySdsFileName),
+		}
+	}
+
+	// 2. Client Validation
+	if caRef != nil {
+		commonTLS.ValidationContextType = &tlsv3.CommonTlsContext_ValidationContextSdsSecretConfig{
+			ValidationContextSdsSecretConfig: newAdsSdsSecretConfig(fmt.Sprintf("%s-%s", gateway.Namespace, caRef.Name)),
+		}
+	} else {
+		commonTLS.ValidationContextType = &tlsv3.CommonTlsContext_ValidationContextSdsSecretConfig{
+			ValidationContextSdsSecretConfig: newPathSdsSecretConfig(constants.SpiffeTrustSdsConfigName, constants.SpiffeTrustSdsFileName),
+		}
 	}
 
 	anyObj, err := anypb.New(tlsContext)

--- a/pkg/translator/listener_test.go
+++ b/pkg/translator/listener_test.go
@@ -40,34 +40,183 @@ import (
 )
 
 func TestBuildDownstreamTLSContext(t *testing.T) {
-	anyContext, err := buildDownstreamTLSContext()
-	if err != nil {
-		t.Fatalf("failed to build downstream TLS context: %v", err)
+	tests := []struct {
+		name                 string
+		listener             gatewayv1.Listener
+		gateway              *gatewayv1.Gateway
+		expectedCertSDSName  string
+		expectedTrustSDSName string
+	}{
+		{
+			name:                 "Default SPIFFE configs",
+			listener:             gatewayv1.Listener{},
+			gateway:              &gatewayv1.Gateway{},
+			expectedCertSDSName:  constants.SpiffeIdentitySdsConfigName,
+			expectedTrustSDSName: constants.SpiffeTrustSdsConfigName,
+		},
+		{
+			name: "Custom per-port CA trust not matching the Listener port",
+			listener: gatewayv1.Listener{
+				Port: 8443,
+			},
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					TLS: &gatewayv1.GatewayTLSConfig{
+						Frontend: &gatewayv1.FrontendTLSConfig{
+							PerPort: []gatewayv1.TLSPortConfig{
+								{
+									Port: 8444,
+									TLS: gatewayv1.TLSConfig{
+										Validation: &gatewayv1.FrontendTLSValidation{
+											CACertificateRefs: []gatewayv1.ObjectReference{
+												{
+													Name: "my-port-ca",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCertSDSName:  constants.SpiffeIdentitySdsConfigName,
+			expectedTrustSDSName: constants.SpiffeTrustSdsConfigName,
+		},
+		{
+			name: "Custom per-port CA trust matching Listener port",
+			listener: gatewayv1.Listener{
+				Port: 8443,
+			},
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					TLS: &gatewayv1.GatewayTLSConfig{
+						Frontend: &gatewayv1.FrontendTLSConfig{
+							PerPort: []gatewayv1.TLSPortConfig{
+								{
+									Port: 8443,
+									TLS: gatewayv1.TLSConfig{
+										Validation: &gatewayv1.FrontendTLSValidation{
+											CACertificateRefs: []gatewayv1.ObjectReference{
+												{
+													Name: "my-port-ca",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCertSDSName:  constants.SpiffeIdentitySdsConfigName,
+			expectedTrustSDSName: "test-ns-my-port-ca",
+		},
+		{
+			name: "Custom default CA client validation without cert",
+			listener: gatewayv1.Listener{
+				Port: 8443,
+			},
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					TLS: &gatewayv1.GatewayTLSConfig{
+						Frontend: &gatewayv1.FrontendTLSConfig{
+							Default: gatewayv1.TLSConfig{
+								Validation: &gatewayv1.FrontendTLSValidation{
+									CACertificateRefs: []gatewayv1.ObjectReference{
+										{
+											Name: "my-port-ca",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCertSDSName:  constants.SpiffeIdentitySdsConfigName,
+			expectedTrustSDSName: "test-ns-my-port-ca",
+		},
+		{
+			name: "Custom cert with default CA trust",
+			listener: gatewayv1.Listener{
+				Port: 8443,
+				TLS: &gatewayv1.ListenerTLSConfig{
+					CertificateRefs: []gatewayv1.SecretObjectReference{
+						{
+							Name: "my-cert",
+						},
+					},
+				},
+			},
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					TLS: &gatewayv1.GatewayTLSConfig{
+						Frontend: &gatewayv1.FrontendTLSConfig{
+							Default: gatewayv1.TLSConfig{
+								Validation: &gatewayv1.FrontendTLSValidation{
+									CACertificateRefs: []gatewayv1.ObjectReference{
+										{
+											Name: "my-port-ca",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCertSDSName:  "test-ns-my-cert",
+			expectedTrustSDSName: "test-ns-my-port-ca",
+		},
 	}
 
-	if anyContext == nil {
-		t.Fatal("expected non-nil TLS context")
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			anyContext, err := buildDownstreamTLSContext(tt.listener, tt.gateway)
+			if err != nil {
+				t.Fatalf("failed to build downstream TLS context: %v", err)
+			}
 
-	tlsContext := &tlsv3.DownstreamTlsContext{}
-	if err := anyContext.UnmarshalTo(tlsContext); err != nil {
-		t.Fatalf("failed to unmarshal any to DownstreamTlsContext: %v", err)
-	}
+			if anyContext == nil {
+				t.Fatal("expected non-nil TLS context")
+			}
 
-	// Verify mTLS requirement
-	if tlsContext.GetRequireClientCertificate() == nil || !tlsContext.GetRequireClientCertificate().GetValue() {
-		t.Errorf("RequireClientCertificate should be true for mTLS")
-	}
+			tlsContext := &tlsv3.DownstreamTlsContext{}
+			if err := anyContext.UnmarshalTo(tlsContext); err != nil {
+				t.Fatalf("failed to unmarshal any to DownstreamTlsContext: %v", err)
+			}
 
-	// Verify SDS Config Names
-	common := tlsContext.GetCommonTlsContext()
-	if len(common.GetTlsCertificateSdsSecretConfigs()) != 1 || common.GetTlsCertificateSdsSecretConfigs()[0].GetName() != constants.SpiffeIdentitySdsConfigName {
-		t.Errorf("Identity SDS secret config name mismatch")
-	}
+			// Verify mTLS requirement
+			if tlsContext.GetRequireClientCertificate() == nil || !tlsContext.GetRequireClientCertificate().GetValue() {
+				t.Errorf("RequireClientCertificate should be true for mTLS")
+			}
 
-	validation := common.GetValidationContextSdsSecretConfig()
-	if validation == nil || validation.GetName() != constants.SpiffeTrustSdsConfigName {
-		t.Errorf("Trust SDS secret config name mismatch")
+			// Verify SDS Config Names
+			common := tlsContext.GetCommonTlsContext()
+			if len(common.GetTlsCertificateSdsSecretConfigs()) != 1 || common.GetTlsCertificateSdsSecretConfigs()[0].GetName() != tt.expectedCertSDSName {
+				t.Errorf("Identity SDS secret config name mismatch: got %s, want %s", common.GetTlsCertificateSdsSecretConfigs()[0].GetName(), tt.expectedCertSDSName)
+			}
+
+			validation := common.GetValidationContextSdsSecretConfig()
+			if validation == nil || validation.GetName() != tt.expectedTrustSDSName {
+				t.Errorf("Trust SDS secret config name mismatch: got %s, want %s", validation.GetName(), tt.expectedTrustSDSName)
+			}
+		})
 	}
 }
 
@@ -383,6 +532,10 @@ func TestValidateListeners(t *testing.T) {
 			secrets: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: ns},
+					Data: map[string][]byte{
+						corev1.TLSCertKey:       []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"),
+						corev1.TLSPrivateKeyKey: []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIB\n-----END RSA PRIVATE KEY-----\n"),
+					},
 				},
 			},
 			expectedConditions: map[gatewayv1.SectionName][]metav1.Condition{
@@ -481,6 +634,10 @@ func TestValidateListeners(t *testing.T) {
 			secrets: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Name: "other-secret", Namespace: "other-ns"},
+					Data: map[string][]byte{
+						corev1.TLSCertKey:       []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"),
+						corev1.TLSPrivateKeyKey: []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIB\n-----END RSA PRIVATE KEY-----\n"),
+					},
 				},
 			},
 			referenceGrants: []runtime.Object{
@@ -538,6 +695,10 @@ func TestValidateListeners(t *testing.T) {
 			secrets: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Name: "other-secret", Namespace: "other-ns"},
+					Data: map[string][]byte{
+						corev1.TLSCertKey:       []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"),
+						corev1.TLSPrivateKeyKey: []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIB\n-----END RSA PRIVATE KEY-----\n"),
+					},
 				},
 			},
 			expectedConditions: map[gatewayv1.SectionName][]metav1.Condition{
@@ -591,6 +752,366 @@ func TestValidateListeners(t *testing.T) {
 					if !found {
 						t.Errorf("Listener %s: expected condition %s not found", listenerName, expCond.Type)
 					}
+				}
+			}
+		})
+	}
+}
+
+func TestValidateCertificateRef(t *testing.T) {
+	ns := "test-ns"
+	gwName := "test-gw"
+
+	tests := []struct {
+		name            string
+		ref             gatewayv1.SecretObjectReference
+		secrets         []runtime.Object
+		referenceGrants []runtime.Object
+		expectedStatus  metav1.ConditionStatus
+		expectedReason  string
+	}{
+		{
+			name: "Valid Secret in same namespace",
+			ref: gatewayv1.SecretObjectReference{
+				Name: "my-secret",
+			},
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: ns},
+					Data: map[string][]byte{
+						corev1.TLSCertKey:       []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"),
+						corev1.TLSPrivateKeyKey: []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIB\n-----END RSA PRIVATE KEY-----\n"),
+					},
+				},
+			},
+			expectedStatus: metav1.ConditionTrue,
+		},
+		{
+			name: "Unsupported Group",
+			ref: gatewayv1.SecretObjectReference{
+				Group: ptr.To(gatewayv1.Group("custom.group")),
+				Name:  "my-secret",
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: string(gatewayv1.ListenerReasonInvalidCertificateRef),
+		},
+		{
+			name: "Unsupported Kind",
+			ref: gatewayv1.SecretObjectReference{
+				Kind: ptr.To(gatewayv1.Kind("ConfigMap")),
+				Name: "my-secret",
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: string(gatewayv1.ListenerReasonInvalidCertificateRef),
+		},
+		{
+			name: "Secret not found",
+			ref: gatewayv1.SecretObjectReference{
+				Name: "missing-secret",
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: string(gatewayv1.ListenerReasonInvalidCertificateRef),
+		},
+		{
+			name: "Secret missing data",
+			ref: gatewayv1.SecretObjectReference{
+				Name: "empty-secret",
+			},
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "empty-secret", Namespace: ns},
+					Data:       map[string][]byte{},
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: string(gatewayv1.ListenerReasonInvalidCertificateRef),
+		},
+		{
+			name: "Secret invalid PEM",
+			ref: gatewayv1.SecretObjectReference{
+				Name: "invalid-pem",
+			},
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "invalid-pem", Namespace: ns},
+					Data: map[string][]byte{
+						corev1.TLSCertKey: []byte("not-pem"),
+					},
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: string(gatewayv1.ListenerReasonInvalidCertificateRef),
+		},
+		{
+			name: "Secret invalid private key PEM",
+			ref: gatewayv1.SecretObjectReference{
+				Name: "invalid-key-pem",
+			},
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "invalid-key-pem", Namespace: ns},
+					Data: map[string][]byte{
+						corev1.TLSCertKey:       []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"),
+						corev1.TLSPrivateKeyKey: []byte("not-pem"),
+					},
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: string(gatewayv1.ListenerReasonInvalidCertificateRef),
+		},
+		{
+			name: "Cross-Namespace allowed by ReferenceGrant",
+			ref: gatewayv1.SecretObjectReference{
+				Namespace: ptr.To(gatewayv1.Namespace("other-ns")),
+				Name:      "other-secret",
+			},
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "other-secret", Namespace: "other-ns"},
+					Data: map[string][]byte{
+						corev1.TLSCertKey:       []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"),
+						corev1.TLSPrivateKeyKey: []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIB\n-----END RSA PRIVATE KEY-----\n"),
+					},
+				},
+			},
+			referenceGrants: []runtime.Object{
+				&gatewayv1beta1.ReferenceGrant{
+					ObjectMeta: metav1.ObjectMeta{Name: "grant", Namespace: "other-ns"},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Group:     gatewayv1.GroupName,
+								Kind:      "Gateway",
+								Namespace: gatewayv1.Namespace(ns),
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "",
+								Kind:  "Secret",
+								Name:  ptr.To(gatewayv1.ObjectName("other-secret")),
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: metav1.ConditionTrue,
+		},
+		{
+			name: "Cross-Namespace denied by missing ReferenceGrant",
+			ref: gatewayv1.SecretObjectReference{
+				Namespace: ptr.To(gatewayv1.Namespace("other-ns")),
+				Name:      "other-secret",
+			},
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "other-secret", Namespace: "other-ns"},
+					Data: map[string][]byte{
+						corev1.TLSCertKey:       []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"),
+						corev1.TLSPrivateKeyKey: []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIB\n-----END RSA PRIVATE KEY-----\n"),
+					},
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: string(gatewayv1.ListenerReasonRefNotPermitted),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := k8sfake.NewClientset(tt.secrets...)
+			k8sInformerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+			for _, s := range tt.secrets {
+				_ = k8sInformerFactory.Core().V1().Secrets().Informer().GetIndexer().Add(s)
+			}
+
+			gwClient := gatewayclient.NewClientset(tt.referenceGrants...)
+			gwInformerFactory := gatewayinformers.NewSharedInformerFactory(gwClient, 0)
+			for _, rg := range tt.referenceGrants {
+				_ = gwInformerFactory.Gateway().V1beta1().ReferenceGrants().Informer().GetIndexer().Add(rg)
+			}
+
+			translator := &Translator{
+				secretLister:         k8sInformerFactory.Core().V1().Secrets().Lister(),
+				referenceGrantLister: gwInformerFactory.Gateway().V1beta1().ReferenceGrants().Lister(),
+			}
+			gw := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns}}
+
+			cond := translator.validateCertificateRef(gw, tt.ref)
+
+			if tt.expectedStatus == metav1.ConditionTrue {
+				if cond != nil {
+					t.Errorf("Expected nil condition for successful validation, got %v", cond)
+				}
+			} else {
+				if cond == nil {
+					t.Fatal("Expected non-nil condition for failed validation")
+				}
+				if cond.Status != tt.expectedStatus {
+					t.Errorf("Expected status %v, got %v", tt.expectedStatus, cond.Status)
+				}
+				if cond.Reason != tt.expectedReason {
+					t.Errorf("Expected reason %v, got %v", tt.expectedReason, cond.Reason)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateCACertificateRef(t *testing.T) {
+	ns := "test-ns"
+	gwName := "test-gw"
+
+	tests := []struct {
+		name            string
+		caRef           gatewayv1.ObjectReference
+		configMaps      []runtime.Object
+		referenceGrants []runtime.Object
+		expectedStatus  metav1.ConditionStatus
+		expectedReason  string
+	}{
+		{
+			name: "Valid ConfigMap in same namespace",
+			caRef: gatewayv1.ObjectReference{
+				Name: "my-ca",
+				Kind: "ConfigMap",
+			},
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: ns},
+					Data: map[string]string{
+						corev1.ServiceAccountRootCAKey: "ca-data",
+					},
+				},
+			},
+			expectedStatus: metav1.ConditionTrue,
+		},
+		{
+			name: "Invalid Kind",
+			caRef: gatewayv1.ObjectReference{
+				Name: "my-ca",
+				Kind: "Secret",
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: string(gatewayv1.ListenerReasonInvalidCACertificateKind),
+		},
+		{
+			name: "Missing ConfigMap",
+			caRef: gatewayv1.ObjectReference{
+				Name: "missing-ca",
+				Kind: "ConfigMap",
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: string(gatewayv1.ListenerReasonInvalidCACertificateRef),
+		},
+		{
+			name: "ConfigMap missing CA key",
+			caRef: gatewayv1.ObjectReference{
+				Name: "empty-ca",
+				Kind: "ConfigMap",
+			},
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "empty-ca", Namespace: ns},
+					Data:       map[string]string{},
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: string(gatewayv1.ListenerReasonInvalidCACertificateRef),
+		},
+		{
+			name: "Cross-Namespace allowed by ReferenceGrant",
+			caRef: gatewayv1.ObjectReference{
+				Namespace: ptr.To(gatewayv1.Namespace("other-ns")),
+				Name:      "other-ca",
+				Kind:      "ConfigMap",
+			},
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "other-ca", Namespace: "other-ns"},
+					Data: map[string]string{
+						corev1.ServiceAccountRootCAKey: "ca-data",
+					},
+				},
+			},
+			referenceGrants: []runtime.Object{
+				&gatewayv1beta1.ReferenceGrant{
+					ObjectMeta: metav1.ObjectMeta{Name: "grant", Namespace: "other-ns"},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Group:     gatewayv1.GroupName,
+								Kind:      "Gateway",
+								Namespace: gatewayv1.Namespace(ns),
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "",
+								Kind:  "ConfigMap",
+								Name:  ptr.To(gatewayv1.ObjectName("other-ca")),
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: metav1.ConditionTrue,
+		},
+		{
+			name: "Cross-Namespace denied by missing ReferenceGrant",
+			caRef: gatewayv1.ObjectReference{
+				Namespace: ptr.To(gatewayv1.Namespace("other-ns")),
+				Name:      "other-ca",
+				Kind:      "ConfigMap",
+			},
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "other-ca", Namespace: "other-ns"},
+					Data: map[string]string{
+						corev1.ServiceAccountRootCAKey: "ca-data",
+					},
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: string(gatewayv1.ListenerReasonRefNotPermitted),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := k8sfake.NewClientset(tt.configMaps...)
+			k8sInformerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+			for _, cm := range tt.configMaps {
+				_ = k8sInformerFactory.Core().V1().ConfigMaps().Informer().GetIndexer().Add(cm)
+			}
+
+			gwClient := gatewayclient.NewClientset(tt.referenceGrants...)
+			gwInformerFactory := gatewayinformers.NewSharedInformerFactory(gwClient, 0)
+			for _, rg := range tt.referenceGrants {
+				_ = gwInformerFactory.Gateway().V1beta1().ReferenceGrants().Informer().GetIndexer().Add(rg)
+			}
+
+			translator := &Translator{
+				configMapLister:      k8sInformerFactory.Core().V1().ConfigMaps().Lister(),
+				referenceGrantLister: gwInformerFactory.Gateway().V1beta1().ReferenceGrants().Lister(),
+			}
+			gw := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns}}
+
+			cond := translator.validateCACertificateRef(gw, tt.caRef)
+
+			if tt.expectedStatus == metav1.ConditionTrue {
+				if cond != nil {
+					t.Errorf("Expected nil condition for successful validation, got %v", cond)
+				}
+			} else {
+				if cond == nil {
+					t.Fatal("Expected non-nil condition for failed validation")
+				}
+				if cond.Status != tt.expectedStatus {
+					t.Errorf("Expected status %v, got %v", tt.expectedStatus, cond.Status)
+				}
+				if cond.Reason != tt.expectedReason {
+					t.Errorf("Expected reason %v, got %v", tt.expectedReason, cond.Reason)
 				}
 			}
 		})

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -25,6 +25,7 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	httpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	envoyproxytypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
@@ -39,6 +40,7 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 
+	corev1 "k8s.io/api/core/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 	gatewaylisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1"
@@ -71,6 +73,7 @@ type Translator struct {
 	namespaceLister            corev1listers.NamespaceLister
 	serviceLister              corev1listers.ServiceLister
 	secretLister               corev1listers.SecretLister
+	configMapLister            corev1listers.ConfigMapLister
 	gatewayLister              gatewaylisters.GatewayLister
 	httprouteLister            gatewaylisters.HTTPRouteLister
 	referenceGrantLister       gatewaylistersv1beta1.ReferenceGrantLister // optional, for Service ref cross-namespace validation
@@ -85,6 +88,7 @@ func New(
 	namespaceLister corev1listers.NamespaceLister,
 	serviceLister corev1listers.ServiceLister,
 	secretLister corev1listers.SecretLister,
+	configMapLister corev1listers.ConfigMapLister,
 	gatewayLister gatewaylisters.GatewayLister,
 	httpRouteLister gatewaylisters.HTTPRouteLister,
 	referenceGrantLister gatewaylistersv1beta1.ReferenceGrantLister,
@@ -98,6 +102,7 @@ func New(
 		namespaceLister,
 		serviceLister,
 		secretLister,
+		configMapLister,
 		gatewayLister,
 		httpRouteLister,
 		referenceGrantLister,
@@ -131,37 +136,14 @@ func (t *Translator) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 	map[types.NamespacedName][]gatewayv1.RouteParentStatus, // GRPCRoutes
 	error,
 ) {
-	httpRouteStatuses := make(map[types.NamespacedName][]gatewayv1.RouteParentStatus)
-	routesByListener := make(map[gatewayv1.SectionName][]*gatewayv1.HTTPRoute)
-
-	// 1. List HTTPRoutes referencing this Gateway
-	allHTTPRoutesForGateway := t.getHTTPRoutesForGateway(gateway)
-	// 2. Validate each HTTPRoute and group accepted ones by listener
-	for _, httpRoute := range allHTTPRoutesForGateway {
-		key := types.NamespacedName{Name: httpRoute.Name, Namespace: httpRoute.Namespace}
-		parentStatuses, acceptingListeners := t.validateHTTPRoute(gateway, httpRoute)
-
-		// Store the definitive status for the route.
-		if len(parentStatuses) > 0 {
-			httpRouteStatuses[key] = parentStatuses
-		}
-		// If the route was accepted, associate it with the listeners that accepted it.
-		if len(acceptingListeners) > 0 {
-			// Associate the accepted route with the listeners that will handle it.
-			// Use a set to prevent adding a route multiple times to the same listener.
-			processedListeners := make(map[gatewayv1.SectionName]bool)
-			for _, listener := range acceptingListeners {
-				if _, ok := processedListeners[listener.Name]; !ok {
-					routesByListener[listener.Name] = append(routesByListener[listener.Name], httpRoute)
-					processedListeners[listener.Name] = true
-				}
-			}
-		}
-	}
+	routesByListener, httpRouteStatuses := t.HTTPRoutesAndStatuses(gateway)
 
 	// Start building Envoy config using only the pre-validated and accepted routes
 	envoyRoutes := []envoyproxytypes.Resource{}
 	allListenerStatuses := make(map[gatewayv1.SectionName]gatewayv1.ListenerStatus)
+
+	envoySecrets := []envoyproxytypes.Resource{}
+	seenSecrets := make(map[string]bool)
 
 	// 3. Build Envoy Clusters for any external auth configs referenced by AccessPolicies
 	envoyClusters := buildExtAuthzBackendClusters(t.accessPolicyLister)
@@ -223,6 +205,15 @@ func (t *Translator) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 					Message:            "All references resolved",
 					ObservedGeneration: gateway.Generation,
 				})
+			}
+
+			// secret extraction
+			if listener.Protocol == gatewayv1.HTTPSProtocolType {
+				certValid, caValid := t.processHTTPSListenerSecrets(gateway, listener, &listenerStatus, &envoySecrets, seenSecrets)
+				if !certValid || !caValid {
+					allListenerStatuses[listener.Name] = listenerStatus
+					continue
+				}
 			}
 
 			//nolint:exhaustive // Other protocols such as GRPCRoutes are currently not supported
@@ -379,8 +370,213 @@ func (t *Translator) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 			resourcev3.ListenerType: finalEnvoyListeners,
 			resourcev3.RouteType:    envoyRoutes,
 			resourcev3.ClusterType:  clustersSlice,
+			resourcev3.SecretType:   envoySecrets,
 		}, orderedStatuses,
 		httpRouteStatuses, nil, nil
+}
+
+func (t *Translator) HTTPRoutesAndStatuses(gateway *gatewayv1.Gateway) (
+	map[gatewayv1.SectionName][]*gatewayv1.HTTPRoute,
+	map[types.NamespacedName][]gatewayv1.RouteParentStatus,
+) {
+	httpRouteStatuses := make(map[types.NamespacedName][]gatewayv1.RouteParentStatus)
+	routesByListener := make(map[gatewayv1.SectionName][]*gatewayv1.HTTPRoute)
+
+	allHTTPRoutesForGateway := t.getHTTPRoutesForGateway(gateway)
+	for _, httpRoute := range allHTTPRoutesForGateway {
+		key := types.NamespacedName{Name: httpRoute.Name, Namespace: httpRoute.Namespace}
+		parentStatuses, acceptingListeners := t.validateHTTPRoute(gateway, httpRoute)
+
+		if len(parentStatuses) > 0 {
+			httpRouteStatuses[key] = parentStatuses
+		}
+		if len(acceptingListeners) > 0 {
+			processedListeners := make(map[gatewayv1.SectionName]bool)
+			for _, listener := range acceptingListeners {
+				if _, ok := processedListeners[listener.Name]; !ok {
+					routesByListener[listener.Name] = append(routesByListener[listener.Name], httpRoute)
+					processedListeners[listener.Name] = true
+				}
+			}
+		}
+	}
+	return routesByListener, httpRouteStatuses
+}
+
+// extractCertificateRefs extract certificate references from gateway and listener
+// It always returns the first certificate reference and ca reference, and whether there are multiple certificate references and ca references.
+// we do not support multiple certificate references and ca references for now.
+func extractCertificateRefs(gateway *gatewayv1.Gateway, lis gatewayv1.Listener) (*gatewayv1.SecretObjectReference, *gatewayv1.ObjectReference, bool, bool) {
+	var certRef *gatewayv1.SecretObjectReference
+	var caRef *gatewayv1.ObjectReference
+	var hasMultipleCerts bool
+	var hasMultipleCAs bool
+
+	if lis.TLS != nil && len(lis.TLS.CertificateRefs) > 0 {
+		certRef = &lis.TLS.CertificateRefs[0]
+		if len(lis.TLS.CertificateRefs) > 1 {
+			hasMultipleCerts = true
+		}
+	}
+
+	if gateway.Spec.TLS != nil && gateway.Spec.TLS.Frontend != nil {
+		var matchedPort bool
+		for _, p := range gateway.Spec.TLS.Frontend.PerPort {
+			if p.Port == lis.Port {
+				if p.TLS.Validation != nil && len(p.TLS.Validation.CACertificateRefs) > 0 {
+					caRef = &p.TLS.Validation.CACertificateRefs[0]
+					if len(p.TLS.Validation.CACertificateRefs) > 1 {
+						hasMultipleCAs = true
+					}
+				}
+				matchedPort = true
+				break
+			}
+		}
+		if !matchedPort && gateway.Spec.TLS.Frontend.Default.Validation != nil && len(gateway.Spec.TLS.Frontend.Default.Validation.CACertificateRefs) > 0 {
+			caRef = &gateway.Spec.TLS.Frontend.Default.Validation.CACertificateRefs[0]
+			if len(gateway.Spec.TLS.Frontend.Default.Validation.CACertificateRefs) > 1 {
+				hasMultipleCAs = true
+			}
+		}
+	}
+	return certRef, caRef, hasMultipleCerts, hasMultipleCAs
+}
+
+func (t *Translator) processHTTPSListenerSecrets(
+	gateway *gatewayv1.Gateway,
+	listener gatewayv1.Listener,
+	listenerStatus *gatewayv1.ListenerStatus,
+	envoySecrets *[]envoyproxytypes.Resource,
+	seenSecrets map[string]bool,
+) (bool, bool) {
+	certRef, caRef, _, _ := extractCertificateRefs(gateway, listener)
+
+	certValid := t.resolveCertificate(gateway, certRef, listenerStatus, envoySecrets, seenSecrets)
+	caValid := t.resolveCACertificate(gateway, caRef, listenerStatus, envoySecrets, seenSecrets)
+
+	if certValid && caValid && certRef != nil && caRef == nil {
+		meta.SetStatusCondition(&listenerStatus.Conditions, metav1.Condition{
+			Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(gatewayv1.ListenerReasonResolvedRefs),
+			Message:            "Gateway is set with CertificateRefs, but recommend to set CACertificateRefs too for mTLS",
+			ObservedGeneration: gateway.Generation,
+		})
+	}
+
+	if !certValid || !caValid {
+		meta.SetStatusCondition(&listenerStatus.Conditions, metav1.Condition{
+			Type:               string(gatewayv1.ListenerConditionAccepted),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(gatewayv1.ListenerReasonNoValidCACertificate),
+			Message:            "Invalid certificate or CA certificate configuration",
+			ObservedGeneration: gateway.Generation,
+		})
+		meta.SetStatusCondition(&listenerStatus.Conditions, metav1.Condition{
+			Type:               string(gatewayv1.ListenerConditionProgrammed),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(gatewayv1.ListenerReasonInvalid),
+			Message:            "Invalid certificate or CA certificate configuration",
+			ObservedGeneration: gateway.Generation,
+		})
+	}
+
+	return certValid, caValid
+}
+
+func (t *Translator) resolveCertificate(
+	gateway *gatewayv1.Gateway,
+	certRef *gatewayv1.SecretObjectReference,
+	listenerStatus *gatewayv1.ListenerStatus,
+	envoySecrets *[]envoyproxytypes.Resource,
+	seenSecrets map[string]bool,
+) bool {
+	if certRef == nil {
+		return true
+	}
+
+	// 1. Validate the reference and secret data using validateCertificateRef
+	if cond := t.validateCertificateRef(gateway, *certRef); cond != nil {
+		meta.SetStatusCondition(&listenerStatus.Conditions, *cond)
+		return false
+	}
+
+	// 2. Resolve the secret
+	ns := gateway.Namespace
+	if certRef.Namespace != nil {
+		ns = string(*certRef.Namespace)
+	}
+	secretName := string(certRef.Name)
+	sdsName := fmt.Sprintf("%s-%s", ns, secretName)
+
+	secret, _ := t.secretLister.Secrets(ns).Get(secretName)
+	certBytes := secret.Data[corev1.TLSCertKey]
+	keyBytes := secret.Data[corev1.TLSPrivateKeyKey]
+
+	if !seenSecrets[sdsName] {
+		envoySecret := &tlsv3.Secret{
+			Name: sdsName,
+			Type: &tlsv3.Secret_TlsCertificate{
+				TlsCertificate: &tlsv3.TlsCertificate{
+					CertificateChain: &corev3.DataSource{
+						Specifier: &corev3.DataSource_InlineBytes{InlineBytes: certBytes},
+					},
+					PrivateKey: &corev3.DataSource{
+						Specifier: &corev3.DataSource_InlineBytes{InlineBytes: keyBytes},
+					},
+				},
+			},
+		}
+		*envoySecrets = append(*envoySecrets, envoySecret)
+		seenSecrets[sdsName] = true
+	}
+	return true
+}
+
+func (t *Translator) resolveCACertificate(
+	gateway *gatewayv1.Gateway,
+	caRef *gatewayv1.ObjectReference,
+	listenerStatus *gatewayv1.ListenerStatus,
+	envoySecrets *[]envoyproxytypes.Resource,
+	seenSecrets map[string]bool,
+) bool {
+	if caRef == nil {
+		return true
+	}
+	// 1. Validate the reference and ConfigMap data using validateCACertificateRef
+	if cond := t.validateCACertificateRef(gateway, *caRef); cond != nil {
+		meta.SetStatusCondition(&listenerStatus.Conditions, *cond)
+		return false
+	}
+
+	// 2. Resolve the CA certificate
+	ns := gateway.Namespace
+	if caRef.Namespace != nil {
+		ns = string(*caRef.Namespace)
+	}
+	configMapName := string(caRef.Name)
+	sdsName := fmt.Sprintf("%s-%s", ns, configMapName)
+
+	cm, _ := t.configMapLister.ConfigMaps(ns).Get(configMapName)
+	caStr := cm.Data[corev1.ServiceAccountRootCAKey]
+
+	if !seenSecrets[sdsName] {
+		envoySecret := &tlsv3.Secret{
+			Name: sdsName,
+			Type: &tlsv3.Secret_ValidationContext{
+				ValidationContext: &tlsv3.CertificateValidationContext{
+					TrustedCa: &corev3.DataSource{
+						Specifier: &corev3.DataSource_InlineBytes{InlineBytes: []byte(caStr)},
+					},
+				},
+			},
+		}
+		*envoySecrets = append(*envoySecrets, envoySecret)
+		seenSecrets[sdsName] = true
+	}
+
+	return true
 }
 
 func getSupportedKinds(listener gatewayv1.Listener) ([]gatewayv1.RouteGroupKind, bool) {

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -56,6 +56,8 @@ type expectedResult struct {
 	routes []expectedRoute
 	// clusters is the list of expected Envoy Cluster names.
 	clusters []string
+	// secrets is the list of expected Envoy Secret names.
+	secrets []string
 }
 
 type expectedListener struct {
@@ -71,6 +73,10 @@ type expectedListener struct {
 	conditions []metav1.Condition
 	// attachedRoutes is the expected number of attached routes.
 	attachedRoutes int32
+	// expectedIdentitySDS is the expected name of the identity SDS secret config.
+	expectedIdentitySDS string
+	// expectedTrustSDS is the expected name of the trust SDS secret config.
+	expectedTrustSDS string
 }
 
 type expectedRoute struct {
@@ -91,17 +97,19 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 	trustDomain := "cluster.local"
 
 	tests := []struct {
-		name     string
-		gw       *gatewayv1.Gateway
-		backend  *agenticv0alpha0.XBackend
-		routes   []*gatewayv1.HTTPRoute
-		policies []*agenticv0alpha0.XAccessPolicy
-		mcpSvc   *corev1.Service
-		expected expectedResult
+		name       string
+		gw         *gatewayv1.Gateway
+		backend    *agenticv0alpha0.XBackend
+		routes     []*gatewayv1.HTTPRoute
+		policies   []*agenticv0alpha0.XAccessPolicy
+		mcpSvc     *corev1.Service
+		secrets    []runtime.Object
+		configMaps []runtime.Object
+		expected   expectedResult
 	}{
 		{
 			name:    "Basic mTLS and RBAC Translation",
-			gw:      newTestGateway("agentic-net-gateway", ns),
+			gw:      newTestGateway("agentic-net-gateway", ns, nil, nil),
 			backend: newTestBackend("local-mcp-backend", ns),
 			routes: []*gatewayv1.HTTPRoute{
 				newTestHTTPRoute("httproute-local-mcp", ns, "agentic-net-gateway", "local-mcp-backend"),
@@ -113,9 +121,11 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 			expected: expectedResult{
 				listeners: []expectedListener{
 					{
-						envoyName:          "listener-10001",
-						k8sName:            "https-listener",
-						maxBackendPolicies: 1,
+						envoyName:           "listener-10001",
+						k8sName:             "https-listener",
+						maxBackendPolicies:  1,
+						expectedIdentitySDS: constants.SpiffeIdentitySdsConfigName,
+						expectedTrustSDS:    constants.SpiffeTrustSdsConfigName,
 						conditions: []metav1.Condition{
 							{
 								Type:   string(gatewayv1.ListenerConditionProgrammed),
@@ -161,7 +171,7 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 		},
 		{
 			name:    "Multiple Policies Targeting Gateway and Backend",
-			gw:      newTestGateway("multi-policy-gw", ns),
+			gw:      newTestGateway("multi-policy-gw", ns, nil, nil),
 			backend: newTestBackend("multi-policy-backend", ns),
 			routes: []*gatewayv1.HTTPRoute{
 				newTestHTTPRoute("multi-policy-route", ns, "multi-policy-gw", "multi-policy-backend"),
@@ -177,10 +187,12 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 			expected: expectedResult{
 				listeners: []expectedListener{
 					{
-						envoyName:          "listener-10001",
-						k8sName:            "https-listener",
-						gatewayPrincipals:  []string{"spiffe://cluster.local/ns/ns1/sa/sa1"},
-						maxBackendPolicies: 1,
+						envoyName:           "listener-10001",
+						k8sName:             "https-listener",
+						gatewayPrincipals:   []string{"spiffe://cluster.local/ns/ns1/sa/sa1"},
+						maxBackendPolicies:  1,
+						expectedIdentitySDS: constants.SpiffeIdentitySdsConfigName,
+						expectedTrustSDS:    constants.SpiffeTrustSdsConfigName,
 						conditions: []metav1.Condition{
 							{
 								Type:   string(gatewayv1.ListenerConditionProgrammed),
@@ -226,7 +238,7 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 		},
 		{
 			name:    "Multiple Routes Attached to Same Listener",
-			gw:      newTestGateway("multi-route-gw", ns),
+			gw:      newTestGateway("multi-route-gw", ns, nil, nil),
 			backend: newTestBackend("multi-route-backend", ns),
 			routes: []*gatewayv1.HTTPRoute{
 				newTestHTTPRoute("route-1", ns, "multi-route-gw", "multi-route-backend"),
@@ -237,9 +249,11 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 			expected: expectedResult{
 				listeners: []expectedListener{
 					{
-						envoyName:          "listener-10001",
-						k8sName:            "https-listener",
-						maxBackendPolicies: 0,
+						envoyName:           "listener-10001",
+						k8sName:             "https-listener",
+						maxBackendPolicies:  0,
+						expectedIdentitySDS: constants.SpiffeIdentitySdsConfigName,
+						expectedTrustSDS:    constants.SpiffeTrustSdsConfigName,
 						conditions: []metav1.Condition{
 							{
 								Type:   string(gatewayv1.ListenerConditionProgrammed),
@@ -331,22 +345,348 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 				clusters: nil,
 			},
 		},
+		{
+			name:    "Listener programmed with only cert Ref and use default SPIFFE trust",
+			gw:      newTestGateway("cert-only-gw", ns, []gatewayv1.SecretObjectReference{{Name: "my-cert"}}, nil),
+			backend: newTestBackend("cert-only-backend", ns),
+			routes: []*gatewayv1.HTTPRoute{
+				newTestHTTPRoute("cert-only-route", ns, "cert-only-gw", "cert-only-backend"),
+			},
+			policies: []*agenticv0alpha0.XAccessPolicy{
+				newTestAccessPolicy("cert-only-policy", ns, "cert-only-backend", "XBackend", "spiffe://cluster.local/ns/ns1/sa/sa1"),
+			},
+			mcpSvc: newTestService("cert-only-backend-svc", ns, 3001),
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-cert", Namespace: ns},
+					Data: map[string][]byte{
+						"tls.crt": []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"),
+						"tls.key": []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIB\n-----END RSA PRIVATE KEY-----\n"),
+					},
+				},
+			},
+			expected: expectedResult{
+				listeners: []expectedListener{
+					{
+						envoyName:           "listener-10001",
+						k8sName:             "https-listener",
+						maxBackendPolicies:  1,
+						expectedIdentitySDS: "quickstart-ns-my-cert",
+						expectedTrustSDS:    constants.SpiffeTrustSdsConfigName,
+						conditions: []metav1.Condition{
+							{
+								Type:   string(gatewayv1.ListenerConditionProgrammed),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayv1.ListenerReasonProgrammed),
+							},
+							{
+								Type:   string(gatewayv1.ListenerConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayv1.ListenerReasonAccepted),
+							},
+							{
+								Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayv1.ListenerReasonResolvedRefs),
+							},
+						},
+					},
+				},
+				routes: []expectedRoute{
+					{
+						envoyName:         "route-10001",
+						k8sName:           "cert-only-route",
+						k8sNamespace:      ns,
+						backendPrincipals: []string{"spiffe://cluster.local/ns/ns1/sa/sa1"},
+						parentStatuses: []gatewayv1.RouteParentStatus{
+							{
+								ParentRef:      gatewayv1.ParentReference{Name: "cert-only-gw"},
+								ControllerName: gatewayv1.GatewayController(constants.ControllerName),
+								Conditions: []metav1.Condition{
+									{
+										Type:   string(gatewayv1.RouteConditionAccepted),
+										Status: metav1.ConditionTrue,
+										Reason: string(gatewayv1.RouteReasonAccepted),
+									},
+									{
+										Type:   string(gatewayv1.RouteConditionResolvedRefs),
+										Status: metav1.ConditionTrue,
+										Reason: string(gatewayv1.RouteReasonResolvedRefs),
+									},
+								},
+							},
+						},
+					},
+				},
+				clusters: []string{"quickstart-ns-cert-only-backend"},
+				secrets:  []string{"quickstart-ns-my-cert"},
+			},
+		},
+		{
+			name: "Listener programed with both cert Ref and CA Ref",
+			gw: newTestGateway("cert-ca-gw", ns, []gatewayv1.SecretObjectReference{{Name: "my-cert"}}, &gatewayv1.FrontendTLSConfig{
+				Default: gatewayv1.TLSConfig{
+					Validation: &gatewayv1.FrontendTLSValidation{
+						CACertificateRefs: []gatewayv1.ObjectReference{{Name: "my-ca", Kind: "ConfigMap"}},
+					},
+				},
+			}),
+			backend: newTestBackend("cert-ca-backend", ns),
+			routes: []*gatewayv1.HTTPRoute{
+				newTestHTTPRoute("cert-ca-route", ns, "cert-ca-gw", "cert-ca-backend"),
+			},
+			policies: []*agenticv0alpha0.XAccessPolicy{
+				newTestAccessPolicy("cert-ca-policy", ns, "cert-ca-backend", "XBackend", "spiffe://cluster.local/ns/ns1/sa/sa1"),
+			},
+			mcpSvc: newTestService("cert-ca-backend-svc", ns, 3001),
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-cert", Namespace: ns},
+					Data: map[string][]byte{
+						"tls.crt": []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"),
+						"tls.key": []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIB\n-----END RSA PRIVATE KEY-----\n"),
+					},
+				},
+			},
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: ns},
+					Data: map[string]string{
+						"ca.crt": "ca-data",
+					},
+				},
+			},
+			expected: expectedResult{
+				listeners: []expectedListener{
+					{
+						envoyName:           "listener-10001",
+						k8sName:             "https-listener",
+						maxBackendPolicies:  1,
+						expectedIdentitySDS: "quickstart-ns-my-cert",
+						expectedTrustSDS:    "quickstart-ns-my-ca",
+						conditions: []metav1.Condition{
+							{
+								Type:   string(gatewayv1.ListenerConditionProgrammed),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayv1.ListenerReasonProgrammed),
+							},
+							{
+								Type:   string(gatewayv1.ListenerConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayv1.ListenerReasonAccepted),
+							},
+						},
+					},
+				},
+				routes: []expectedRoute{
+					{
+						envoyName:         "route-10001",
+						k8sName:           "cert-ca-route",
+						k8sNamespace:      ns,
+						backendPrincipals: []string{"spiffe://cluster.local/ns/ns1/sa/sa1"},
+						parentStatuses: []gatewayv1.RouteParentStatus{
+							{
+								ParentRef:      gatewayv1.ParentReference{Name: "cert-ca-gw"},
+								ControllerName: gatewayv1.GatewayController(constants.ControllerName),
+								Conditions: []metav1.Condition{
+									{
+										Type:   string(gatewayv1.RouteConditionAccepted),
+										Status: metav1.ConditionTrue,
+										Reason: string(gatewayv1.RouteReasonAccepted),
+									},
+									{
+										Type:   string(gatewayv1.RouteConditionResolvedRefs),
+										Status: metav1.ConditionTrue,
+										Reason: string(gatewayv1.RouteReasonResolvedRefs),
+									},
+								},
+							},
+						},
+					},
+				},
+				clusters: []string{"quickstart-ns-cert-ca-backend"},
+				secrets:  []string{"quickstart-ns-my-cert", "quickstart-ns-my-ca"},
+			},
+		},
+		{
+			name: "Listener programmed with only CA Ref",
+			gw: newTestGateway("ca-only-gw", ns, nil, &gatewayv1.FrontendTLSConfig{
+				Default: gatewayv1.TLSConfig{
+					Validation: &gatewayv1.FrontendTLSValidation{
+						CACertificateRefs: []gatewayv1.ObjectReference{{Name: "my-ca", Kind: "ConfigMap"}},
+					},
+				},
+			}),
+			backend: newTestBackend("ca-only-backend", ns),
+			routes: []*gatewayv1.HTTPRoute{
+				newTestHTTPRoute("ca-only-route", ns, "ca-only-gw", "ca-only-backend"),
+			},
+			policies: []*agenticv0alpha0.XAccessPolicy{
+				newTestAccessPolicy("ca-only-policy", ns, "ca-only-backend", "XBackend", "spiffe://cluster.local/ns/ns1/sa/sa1"),
+			},
+			mcpSvc: newTestService("ca-only-backend-svc", ns, 3001),
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: ns},
+					Data: map[string]string{
+						"ca.crt": "ca-data",
+					},
+				},
+			},
+			expected: expectedResult{
+				listeners: []expectedListener{
+					{
+						envoyName:           "listener-10001",
+						k8sName:             "https-listener",
+						maxBackendPolicies:  1,
+						expectedIdentitySDS: constants.SpiffeIdentitySdsConfigName,
+						expectedTrustSDS:    "quickstart-ns-my-ca",
+						conditions: []metav1.Condition{
+							{
+								Type:   string(gatewayv1.ListenerConditionProgrammed),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayv1.ListenerReasonProgrammed),
+							},
+							{
+								Type:   string(gatewayv1.ListenerConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayv1.ListenerReasonAccepted),
+							},
+						},
+					},
+				},
+				routes: []expectedRoute{
+					{
+						envoyName:         "route-10001",
+						k8sName:           "ca-only-route",
+						k8sNamespace:      ns,
+						backendPrincipals: []string{"spiffe://cluster.local/ns/ns1/sa/sa1"},
+						parentStatuses: []gatewayv1.RouteParentStatus{
+							{
+								ParentRef:      gatewayv1.ParentReference{Name: "ca-only-gw"},
+								ControllerName: gatewayv1.GatewayController(constants.ControllerName),
+								Conditions: []metav1.Condition{
+									{
+										Type:   string(gatewayv1.RouteConditionAccepted),
+										Status: metav1.ConditionTrue,
+										Reason: string(gatewayv1.RouteReasonAccepted),
+									},
+									{
+										Type:   string(gatewayv1.RouteConditionResolvedRefs),
+										Status: metav1.ConditionTrue,
+										Reason: string(gatewayv1.RouteReasonResolvedRefs),
+									},
+								},
+							},
+						},
+					},
+				},
+				clusters: []string{"quickstart-ns-ca-only-backend"},
+				secrets:  []string{"quickstart-ns-my-ca"},
+			},
+		},
+		{
+			name: "Listener programmed with only per-port CA trust",
+			gw: newTestGateway("per-port-ca-gw", ns, nil, &gatewayv1.FrontendTLSConfig{
+				PerPort: []gatewayv1.TLSPortConfig{
+					{
+						Port: 10001,
+						TLS: gatewayv1.TLSConfig{
+							Validation: &gatewayv1.FrontendTLSValidation{
+								CACertificateRefs: []gatewayv1.ObjectReference{{Name: "my-ca", Kind: "ConfigMap"}},
+							},
+						},
+					},
+				},
+			}),
+			backend: newTestBackend("per-port-ca-backend", ns),
+			routes: []*gatewayv1.HTTPRoute{
+				newTestHTTPRoute("per-port-ca-route", ns, "per-port-ca-gw", "per-port-ca-backend"),
+			},
+			policies: []*agenticv0alpha0.XAccessPolicy{
+				newTestAccessPolicy("per-port-ca-policy", ns, "per-port-ca-backend", "XBackend", "spiffe://cluster.local/ns/ns1/sa/sa1"),
+			},
+			mcpSvc: newTestService("per-port-ca-backend-svc", ns, 3001),
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: ns},
+					Data: map[string]string{
+						"ca.crt": "ca-data",
+					},
+				},
+			},
+			expected: expectedResult{
+				listeners: []expectedListener{
+					{
+						envoyName:           "listener-10001",
+						k8sName:             "https-listener",
+						maxBackendPolicies:  1,
+						expectedIdentitySDS: constants.SpiffeIdentitySdsConfigName,
+						expectedTrustSDS:    "quickstart-ns-my-ca",
+						conditions: []metav1.Condition{
+							{
+								Type:   string(gatewayv1.ListenerConditionProgrammed),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayv1.ListenerReasonProgrammed),
+							},
+							{
+								Type:   string(gatewayv1.ListenerConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayv1.ListenerReasonAccepted),
+							},
+						},
+					},
+				},
+				routes: []expectedRoute{
+					{
+						envoyName:         "route-10001",
+						k8sName:           "per-port-ca-route",
+						k8sNamespace:      ns,
+						backendPrincipals: []string{"spiffe://cluster.local/ns/ns1/sa/sa1"},
+						parentStatuses: []gatewayv1.RouteParentStatus{
+							{
+								ParentRef:      gatewayv1.ParentReference{Name: "per-port-ca-gw"},
+								ControllerName: gatewayv1.GatewayController(constants.ControllerName),
+								Conditions: []metav1.Condition{
+									{
+										Type:   string(gatewayv1.RouteConditionAccepted),
+										Status: metav1.ConditionTrue,
+										Reason: string(gatewayv1.RouteReasonAccepted),
+									},
+									{
+										Type:   string(gatewayv1.RouteConditionResolvedRefs),
+										Status: metav1.ConditionTrue,
+										Reason: string(gatewayv1.RouteReasonResolvedRefs),
+									},
+								},
+							},
+						},
+					},
+				},
+				clusters: []string{"quickstart-ns-per-port-ca-backend"},
+				secrets:  []string{"quickstart-ns-my-ca"},
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup Fake Clients and Informers
 			ctx := context.Background()
+
 			var k8sObjs []runtime.Object
 			if tc.mcpSvc != nil {
 				k8sObjs = append(k8sObjs, tc.mcpSvc)
 			}
+			k8sObjs = append(k8sObjs, tc.secrets...)
+			k8sObjs = append(k8sObjs, tc.configMaps...)
 			k8sClient := fake.NewClientset(k8sObjs...)
 			var gwObjs []runtime.Object
 			gwObjs = append(gwObjs, tc.gw)
 			for _, r := range tc.routes {
 				gwObjs = append(gwObjs, r)
 			}
+
 			gwClient := gatewayclient.NewClientset(gwObjs...)
 
 			var agenticObjs []runtime.Object
@@ -370,6 +710,7 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 				coreInformerFactory.Core().V1().Namespaces().Lister(),
 				coreInformerFactory.Core().V1().Services().Lister(),
 				coreInformerFactory.Core().V1().Secrets().Lister(),
+				coreInformerFactory.Core().V1().ConfigMaps().Lister(),
 				gwInformerFactory.Gateway().V1().Gateways().Lister(),
 				gwInformerFactory.Gateway().V1().HTTPRoutes().Lister(),
 				nil, // referenceGrantLister
@@ -391,6 +732,16 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 			for _, p := range tc.policies {
 				_ = agenticInformerFactory.Agentic().V0alpha0().XAccessPolicies().Informer().GetIndexer().Add(p)
 			}
+			for _, obj := range tc.secrets {
+				if secret, ok := obj.(*corev1.Secret); ok {
+					_ = coreInformerFactory.Core().V1().Secrets().Informer().GetIndexer().Add(secret)
+				}
+			}
+			for _, obj := range tc.configMaps {
+				if cm, ok := obj.(*corev1.ConfigMap); ok {
+					_ = coreInformerFactory.Core().V1().ConfigMaps().Informer().GetIndexer().Add(cm)
+				}
+			}
 
 			// Run Translation
 			resources, listenerStatuses, httpRouteStatuses, _, err := tr.TranslateGatewayToXDS(ctx, tc.gw)
@@ -402,6 +753,7 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 			verifyListeners(t, resources[resourcev3.ListenerType], listenerStatuses, tc.expected.listeners)
 			verifyRoutes(t, resources[resourcev3.RouteType], httpRouteStatuses, tc.expected.routes)
 			verifyClusters(t, resources[resourcev3.ClusterType], tc.expected.clusters)
+			verifySecrets(t, resources[resourcev3.SecretType], tc.expected.secrets)
 		})
 	}
 }
@@ -424,7 +776,7 @@ func verifyListeners(t *testing.T, got []envoyproxytypes.Resource, gotStatuses [
 				lis := res.(*listenerv3.Listener)
 				if lis.GetName() == exp.envoyName {
 					found = true
-					checkListenerMTLS(t, lis)
+					checkListenerMTLS(t, lis, exp.expectedIdentitySDS, exp.expectedTrustSDS)
 					checkListenerRBAC(t, lis, exp.gatewayPrincipals, exp.maxBackendPolicies)
 				}
 			}
@@ -545,31 +897,48 @@ func verifyClusters(t *testing.T, got []envoyproxytypes.Resource, expected []str
 	}
 }
 
-func checkListenerMTLS(t *testing.T, lis *listenerv3.Listener) {
+func verifySecrets(t *testing.T, got []envoyproxytypes.Resource, expected []string) {
+	if len(got) != len(expected) {
+		t.Errorf("expected %d secrets, got %d", len(expected), len(got))
+	}
+	for _, expectedName := range expected {
+		found := false
+		for _, res := range got {
+			s := res.(*tlsv3.Secret)
+			if s.GetName() == expectedName {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected secret %s not found", expectedName)
+		}
+	}
+}
+
+func checkListenerMTLS(t *testing.T, lis *listenerv3.Listener, expectedIdentity, expectedTrust string) {
 	foundTLS := false
 	for _, fc := range lis.GetFilterChains() {
-		if fc.GetTransportSocket() != nil && fc.GetTransportSocket().GetName() == "envoy.transport_sockets.tls" {
-			foundTLS = true
-			tlsContext := &tlsv3.DownstreamTlsContext{}
-			if err := fc.GetTransportSocket().GetTypedConfig().UnmarshalTo(tlsContext); err != nil {
-				t.Fatalf("failed to unmarshal TLS context: %v", err)
-			}
-			if !tlsContext.GetRequireClientCertificate().GetValue() {
-				t.Error("RequireClientCertificate should be true for mTLS")
-			}
-
-			// Verify SDS config names
-			common := tlsContext.GetCommonTlsContext()
-			if common.GetTlsCertificateSdsSecretConfigs()[0].GetName() != constants.SpiffeIdentitySdsConfigName {
-				t.Errorf("Identity SDS config name mismatch: got %s, want %s", common.GetTlsCertificateSdsSecretConfigs()[0].GetName(), constants.SpiffeIdentitySdsConfigName)
-			}
-			if common.GetValidationContextSdsSecretConfig().GetName() != constants.SpiffeTrustSdsConfigName {
-				t.Errorf("Trust SDS config name mismatch: got %s, want %s", common.GetValidationContextSdsSecretConfig().GetName(), constants.SpiffeTrustSdsConfigName)
-			}
+		if fc.GetTransportSocket() == nil || fc.GetTransportSocket().GetName() != "envoy.transport_sockets.tls" {
+			continue
+		}
+		foundTLS = true
+		tlsContext := &tlsv3.DownstreamTlsContext{}
+		if err := fc.GetTransportSocket().GetTypedConfig().UnmarshalTo(tlsContext); err != nil {
+			t.Fatalf("failed to unmarshal TLS context: %v", err)
+		}
+		common := tlsContext.GetCommonTlsContext()
+		if common.GetTlsCertificateSdsSecretConfigs()[0].GetName() != expectedIdentity {
+			t.Errorf("Identity SDS config name mismatch: got %s, want %s", common.GetTlsCertificateSdsSecretConfigs()[0].GetName(), expectedIdentity)
+		}
+		if !tlsContext.GetRequireClientCertificate().GetValue() {
+			t.Error("RequireClientCertificate should be true for mTLS")
+		}
+		if common.GetValidationContextSdsSecretConfig().GetName() != expectedTrust {
+			t.Errorf("Trust SDS config name mismatch: got %s, want %s", common.GetValidationContextSdsSecretConfig().GetName(), expectedTrust)
 		}
 	}
 	if !foundTLS {
-		t.Errorf("mTLS transport socket configuration not found in listener %s", lis.GetName())
+		t.Errorf("TLS transport socket configuration not found in listener %s", lis.GetName())
 	}
 }
 

--- a/site-src/guides/.pages
+++ b/site-src/guides/.pages
@@ -2,3 +2,4 @@ nav:
   - Quickstart: quickstart
   - External Auth: external-auth-quickstart
   - AI Agents: ai-agents.md
+  - Mutual TLS: mtls.md

--- a/site-src/guides/mtls.md
+++ b/site-src/guides/mtls.md
@@ -1,0 +1,71 @@
+# Mutual TLS (mTLS) Configuration
+
+This guide explains how to configure Mutual TLS (mTLS) for your Gateway.
+
+## Overview
+
+Mutual TLS (mTLS) ensures that both the client and the server authenticate each other using certificates. In this project, mTLS is configured at the Gateway level.
+
+## Configuration Requirements
+
+To enable mTLS, you must provide **both** a server certificate reference and a CA certificate reference for client validation.
+
+### 1. Server Certificate (Listener Level)
+
+The server certificate is configured within the `listeners` section of the Gateway spec. This certificate is presented by the Gateway to the client.
+
+- **Field**: [`gw.Spec.Listeners[*].TLS.CertificateRefs`](https://gateway-api.sigs.k8s.io/reference/1.5/spec/#listenertlsconfig)
+- **Resource**: Must point to a Kubernetes `Secret` containing `tls.crt` and `tls.key`.
+
+### 2. Client Validation (Gateway Level)
+
+The CA certificate used to validate client certificates is configured in the `tls.frontend` section of the Gateway spec. You can provide a default CA for all ports or specify different CAs per port.
+
+- **Field**: [`gw.Spec.TLS.Frontend.Default.Validation.CACertificateRefs`](https://gateway-api.sigs.k8s.io/reference/1.5/spec/#frontendtlsconfig) (Default)
+- **Field**: [`gw.Spec.TLS.Frontend.PerPort[*].TLS.Validation.CACertificateRefs`](https://gateway-api.sigs.k8s.io/reference/1.5/spec/#frontendtlsconfig) (Per-port)
+- **Resource**: Must point to a Kubernetes `ConfigMap` containing a `ca.crt` key.
+
+> [!IMPORTANT]
+> For mTLS to function correctly, you MUST provide both the `CertificateRefs` in the listener and the `CACertificateRefs` in the frontend validation. If `CACertificateRefs` is omitted, the Gateway will fall back to default trust settings (e.g., SPIFFE trust) which may not be what you intended for a custom mTLS setup.
+>
+> For more details on how we are discussing enforcing strict client validation in the long term, see [Issue #254](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/254).
+
+## Example Configuration
+
+Below is an example of a Gateway configured with mTLS:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: my-gateway
+  namespace: my-namespace
+spec:
+  gatewayClassName: agentic-net-gateway-class
+  listeners:
+  - name: https-listener
+    port: 443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: my-server-cert # Points to a Secret
+    allowedRoutes:
+      namespaces:
+        from: Same
+  tls:
+    frontend:
+      default:
+        validation:
+          caCertificateRefs:
+          - name: my-client-ca # Points to a ConfigMap
+```
+
+## Status Conditions
+
+The controller validates your TLS configuration. You can check the status of your Gateway listeners to ensure references are resolved correctly:
+
+- `ResolvedRefs`: Will be `True` if all certificates and ConfigMaps are found and valid.
+- `Programmed`: Will be `True` if the listener is successfully configured in the underlying proxy (Envoy).
+
+If you provide `CertificateRefs` but omit `CACertificateRefs`, the listener may still be `Programmed`, but you will see a message in the `ResolvedRefs` condition recommending the addition of `CACertificateRefs` for a proper mTLS setup.

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -21,10 +21,12 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"math/big"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -32,14 +34,22 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
 
 	"sigs.k8s.io/kube-agentic-networking/pkg/constants"
+	"sigs.k8s.io/kube-agentic-networking/pkg/infra/agentidentity/localca"
 )
 
 const (
 	agentCertPath = "/run/agent-identity-mtls/credential-bundle.pem"
 	agentKeyPath  = "/run/agent-identity-mtls/credential-bundle.pem"
 	agentCAPath   = "/run/agent-identity-mtls/cluster.local.trust-bundle.pem"
+
+	testClientCertPath = "/tmp/mtls-client/tls.crt"
+	testClientKeyPath  = "/tmp/mtls-client/tls.key"
+	testClientCAPath   = "/tmp/mtls-client/ca.crt"
 
 	xdsUpdateWaitTime = 5 * time.Second
 )
@@ -259,7 +269,10 @@ func TestExternalAuthE2E(t *testing.T) {
 	applyToNamespace(t, "testdata/ext-authz-service.yaml", namespace)
 	runKubectl(t, "wait", "--for=condition=available", "deployment/authorino", "-n", namespace, "--timeout=2m")
 	err := retry(20, 2*time.Second, func() error {
-		out := runKubectlOutput(t, "get", "authconfig", "external-auth-config", "-n", namespace, "-o", "jsonpath={.status.summary.ready}")
+		out, err := runKubectlOutput(t, "get", "authconfig", "external-auth-config", "-n", namespace, "-o", "jsonpath={.status.summary.ready}")
+		if err != nil {
+			return err
+		}
 		if out != "true" {
 			return fmt.Errorf("authconfig not ready yet: %s", out)
 		}
@@ -487,7 +500,10 @@ func deployCommonTestResources(t *testing.T) (namespace, gatewayIP string, clean
 
 	var proxyPodName string
 	err := retry(20, 5*time.Second, func() error {
-		out := runKubectlOutput(t, "get", "pods", "-n", namespace, "-l", fmt.Sprintf("%s=e2e-gateway", constants.GatewayNameLabel), "-o", "jsonpath={.items[*].metadata.name}")
+		out, err := runKubectlOutput(t, "get", "pods", "-n", namespace, "-l", fmt.Sprintf("%s=e2e-gateway", constants.GatewayNameLabel), "-o", "jsonpath={.items[*].metadata.name}")
+		if err != nil {
+			return err
+		}
 		names := strings.Fields(strings.TrimSpace(out))
 		if len(names) == 0 {
 			return fmt.Errorf("envoy proxy pod not found")
@@ -502,8 +518,12 @@ func deployCommonTestResources(t *testing.T) (namespace, gatewayIP string, clean
 
 	// Return the Gateway IP
 	t.Log("Obtain Gateway Address from status")
+
 	err = retry(50, 10*time.Second, func() error {
-		out := runKubectlOutput(t, "get", "gateway", "e2e-gateway", "-n", namespace, "-o", "jsonpath={.status.addresses[*].value}")
+		out, e := runKubectlOutput(t, "get", "gateway", "e2e-gateway", "-n", namespace, "-o", "jsonpath={.status.addresses[*].value}")
+		if e != nil {
+			return e
+		}
 		values := strings.Fields(strings.TrimSpace(out))
 		if len(values) == 0 {
 			return fmt.Errorf("gateway status address not found")
@@ -567,19 +587,18 @@ func deleteFromNamespace(t *testing.T, manifestPath, namespace string) {
 	}
 }
 
-func runKubectlOutput(t *testing.T, args ...string) string {
+func runKubectlOutput(t *testing.T, args ...string) (string, error) {
 	cmd := exec.CommandContext(context.Background(), "kubectl", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		t.Logf("kubectl %v failed: %v\nStderr: %s", args, err, stderr.String())
-		return ""
+		return stdout.String(), fmt.Errorf("kubectl %v failed: %w\nStderr: %s", args, err, stderr.String())
 	}
 	if stderr.Len() > 0 {
 		t.Logf("kubectl %v stderr: %s", args, stderr.String())
 	}
-	return strings.TrimSpace(stdout.String())
+	return strings.TrimSpace(stdout.String()), nil
 }
 
 func retry(attempts int, sleep time.Duration, f func() error) error {
@@ -597,24 +616,25 @@ type mcpTestSession struct {
 	gatewayIP string
 	sessionID string
 	pod       types.NamespacedName
+	certPath  string
+	keyPath   string
+	caPath    string
 }
 
 func initializeMCP(t *testing.T, gatewayIP string, pod types.NamespacedName) *mcpTestSession {
+	return initializeMCPWithCerts(t, gatewayIP, pod, agentCertPath, agentKeyPath, agentCAPath)
+}
+
+func initializeMCPWithCerts(t *testing.T, gatewayIP string, pod types.NamespacedName, certPath, keyPath, caPath string) *mcpTestSession {
 	t.Logf("Initialize MCP session for pod %s", pod)
 	time.Sleep(xdsUpdateWaitTime)
 
 	mcpSessionID := ""
 	err := retry(5, 10*time.Second, func() error {
-		out := runKubectlOutput(t, "exec", pod.Name, "-n", pod.Namespace, "--",
-			"curl", "-ks", "-i",
-			"--cert", agentCertPath,
-			"--key", agentKeyPath,
-			"--cacert", agentCAPath,
-			"-H", "Content-Type: application/json",
-			"-H", "Accept: application/json, text/event-stream",
-			"-H", "mcp-protocol-version: 2025-11-25",
-			"--data-raw", `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl-client","version":"1.0.0"}}}`,
-			fmt.Sprintf("https://%s:10001/mcp", gatewayIP))
+		out, err := execMCPCurl(t, gatewayIP, pod, certPath, keyPath, caPath)
+		if err != nil {
+			return err
+		}
 
 		// Extract mcp-session-id from headers
 		lines := strings.Split(out, "\r\n")
@@ -632,7 +652,28 @@ func initializeMCP(t *testing.T, gatewayIP string, pod types.NamespacedName) *mc
 	}
 	t.Logf("Obtained MCP Session ID for %s: %s", pod, mcpSessionID)
 
-	return &mcpTestSession{t: t, gatewayIP: gatewayIP, sessionID: mcpSessionID, pod: pod}
+	return &mcpTestSession{
+		t:         t,
+		gatewayIP: gatewayIP,
+		sessionID: mcpSessionID,
+		pod:       pod,
+		certPath:  certPath,
+		keyPath:   keyPath,
+		caPath:    caPath,
+	}
+}
+
+func execMCPCurl(t *testing.T, gatewayIP string, pod types.NamespacedName, certPath, keyPath, caPath string) (string, error) {
+	return runKubectlOutput(t, "exec", pod.Name, "-n", pod.Namespace, "--",
+		"curl", "-ks", "-i",
+		"--cert", certPath,
+		"--key", keyPath,
+		"--cacert", caPath,
+		"-H", "Content-Type: application/json",
+		"-H", "Accept: application/json, text/event-stream",
+		"-H", "mcp-protocol-version: 2025-11-25",
+		"--data-raw", `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl-client","version":"1.0.0"}}}`,
+		fmt.Sprintf("https://%s:10001/mcp", gatewayIP))
 }
 
 type mcpResponse struct {
@@ -676,17 +717,20 @@ func (m *mcpTestSession) assertToolCall(t *testing.T, toolName, toolArgs string,
 		t.Fatalf("invalid pod reference in MCP session: %v", m.pod)
 	}
 
-	out := runKubectlOutput(t, "exec", m.pod.Name, "-n", m.pod.Namespace, "--",
+	out, err := runKubectlOutput(t, "exec", m.pod.Name, "-n", m.pod.Namespace, "--",
 		"curl", "-ks", "-w", "\n%{http_code}",
-		"--cert", agentCertPath,
-		"--key", agentKeyPath,
-		"--cacert", agentCAPath,
+		"--cert", m.certPath,
+		"--key", m.keyPath,
+		"--cacert", m.caPath,
 		"-H", "Content-Type: application/json",
 		"-H", "Accept: application/json, text/event-stream",
 		"-H", "mcp-protocol-version: 2025-11-25",
 		"-H", fmt.Sprintf("mcp-session-id: %s", m.sessionID),
 		"--data-raw", data,
 		fmt.Sprintf("https://%s:10001/mcp", m.gatewayIP))
+	if err != nil {
+		t.Fatalf("failed to call tool: %v", err)
+	}
 
 	out = strings.TrimSpace(out)
 	lines := strings.Split(out, "\n")
@@ -756,4 +800,224 @@ func (m *mcpTestSession) assertToolCall(t *testing.T, toolName, toolArgs string,
 		}
 	}
 	t.Logf("Tool call %q from pod %s: got expected response.", toolName, m.pod)
+}
+
+func TestGatewayTLS(t *testing.T) {
+	t.Parallel()
+
+	namespace, gatewayIP, cleanup := deployCommonTestResources(t)
+	defer cleanup()
+
+	kc := getClientset(t)
+	podName := "e2e-tester-no-certs"
+
+	var ca1, ca2 *localca.CA
+	var clientCert1, clientKey1 []byte
+	var clientCert2, clientKey2 []byte
+	var clientCertDefault, clientKeyDefault []byte
+	var serverCert, serverKey []byte
+	var caCertPEM1 []byte
+
+	t.Run("SetupCertificates", func(t *testing.T) {
+		var err error
+		ca1, err = generateCA("test-ca-1")
+		if err != nil {
+			t.Fatalf("failed to generate CA 1: %v", err)
+		}
+
+		ca2, err = generateCA("test-ca-2")
+		if err != nil {
+			t.Fatalf("failed to generate CA 2: %v", err)
+		}
+
+		serverCert, serverKey, err = generateServerCert(ca1, []string{"agentic-net-gateway"})
+		if err != nil {
+			t.Fatalf("failed to generate server cert: %v", err)
+		}
+
+		clientCert1, clientKey1, err = generateClientCert(ca1, fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/e2e-tester-sa", namespace))
+		if err != nil {
+			t.Fatalf("failed to generate client cert 1: %v", err)
+		}
+
+		clientCert2, clientKey2, err = generateClientCert(ca2, fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/e2e-tester-sa", namespace))
+		if err != nil {
+			t.Fatalf("failed to generate client cert 2: %v", err)
+		}
+
+		// Read default CA from secret
+		defaultCA, err := getAgenticIdentityDefaultCA(kc)
+		if err != nil {
+			t.Fatalf("failed to get default CA: %v", err)
+		}
+
+		clientCertDefault, clientKeyDefault, err = generateClientCert(defaultCA, fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/e2e-tester-sa", namespace))
+		if err != nil {
+			t.Fatalf("failed to generate client cert for default CA: %v", err)
+		}
+
+		// Create secrets for Gateway
+		err = createTLSSecret(kc, namespace, "gateway-server-cert", serverCert, serverKey)
+		if err != nil {
+			t.Fatalf("failed to create server secret: %v", err)
+		}
+
+		caCertPEM1 = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca1.RootCertificate.Raw})
+		err = createCACertConfigMap(kc, namespace, "gateway-client-ca", caCertPEM1)
+		if err != nil {
+			t.Fatalf("failed to create CA configmap: %v", err)
+		}
+	})
+
+	t.Run("DeployTesterPod", func(t *testing.T) {
+		applyToNamespace(t, "testdata/tester-pod-no-certs.yaml", namespace)
+		runKubectl(t, "wait", "--for=condition=Ready", "pod/e2e-tester-no-certs", "-n", namespace, "--timeout=5m")
+
+		// Wait for xDS propagation
+		time.Sleep(xdsUpdateWaitTime)
+
+		// Prepare workspace in pod
+		runKubectl(t, "exec", podName, "-n", namespace, "--", "mkdir", "-p", "/tmp/mtls-client")
+	})
+
+	t.Run("TrustedCA_NoGatewayCA", func(t *testing.T) {
+		// Test case 1: client cert signed by trusted CA without gateway CA configuration (should succeed)
+		applyToNamespace(t, "testdata/gateway-no-ca.yaml", namespace)
+		applyToNamespace(t, "testdata/gateway-policy.yaml", namespace)
+
+		// Write files to pod
+		writePodFile(t, namespace, podName, testClientCertPath, clientCertDefault)
+		writePodFile(t, namespace, podName, testClientKeyPath, clientKeyDefault)
+		writePodFile(t, namespace, podName, testClientCAPath, caCertPEM1)
+
+		mcp := initializeMCPWithCerts(t, gatewayIP, types.NamespacedName{Namespace: namespace, Name: podName},
+			testClientCertPath, testClientKeyPath, testClientCAPath)
+
+		mcp.assertToolCall(t, "echo", `{"message":"hello"}`,
+			mcpResponse{
+				StatusCode: 200,
+				Body: respBody{
+					JSONRPC: "2.0",
+					Result: &mcpResult{
+						IsError: false,
+						Content: []mcpContent{
+							{
+								Type: "text",
+								Text: "Echo: hello",
+							},
+						},
+					},
+				},
+			},
+		)
+		mcp.assertToolCall(t, "get-sum", `{"a":2,"b":3}`,
+			mcpResponse{
+				StatusCode: 200,
+				Body: respBody{
+					JSONRPC: "2.0",
+					Error: &mcpError{
+						Code:    403,
+						Message: "Access to this tool is forbidden.",
+					},
+				},
+			},
+		)
+	})
+
+	t.Run("TrustedCA_WithGatewayCA", func(t *testing.T) {
+		// Test case 2: Client cert signed by trusted CA with gateway CA configuration (should succeed)
+		applyToNamespace(t, "testdata/gateway-tls.yaml", namespace)
+
+		// Override certs in the pod
+		writePodFile(t, namespace, podName, testClientCertPath, clientCert1)
+		writePodFile(t, namespace, podName, testClientKeyPath, clientKey1)
+
+		mcp := initializeMCPWithCerts(t, gatewayIP, types.NamespacedName{Namespace: namespace, Name: podName},
+			testClientCertPath, testClientKeyPath, testClientCAPath)
+
+		mcp.assertToolCall(t, "echo", `{"message":"hello"}`,
+			mcpResponse{
+				StatusCode: 200,
+				Body: respBody{
+					JSONRPC: "2.0",
+					Result: &mcpResult{
+						IsError: false,
+						Content: []mcpContent{
+							{
+								Type: "text",
+								Text: "Echo: hello",
+							},
+						},
+					},
+				},
+			},
+		)
+
+		mcp.assertToolCall(t, "get-sum", `{"a":2,"b":3}`,
+			mcpResponse{
+				StatusCode: 200,
+				Body: respBody{
+					JSONRPC: "2.0",
+					Error: &mcpError{
+						Code:    403,
+						Message: "Access to this tool is forbidden.",
+					},
+				},
+			},
+		)
+	})
+
+	t.Run("UntrustedCA_ShouldFail", func(t *testing.T) {
+		// Test case 3: Client cert signed by different CA (should fail)
+		t.Log("Testing with client cert signed by different CA (should fail)")
+
+		// Override client certs with invalid ones
+		writePodFile(t, namespace, podName, testClientCertPath, clientCert2)
+		writePodFile(t, namespace, podName, testClientKeyPath, clientKey2)
+
+		err := retry(5, 5*time.Second, func() error {
+			stdout, e := execMCPCurl(t, gatewayIP, types.NamespacedName{Namespace: namespace, Name: podName},
+				testClientCertPath, testClientKeyPath, testClientCAPath)
+			if e == nil {
+				return fmt.Errorf("expected curl to fail but it succeeded with output: %s", stdout)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("mTLS negative test failed: %v", err)
+		}
+	})
+}
+
+func getClientset(t *testing.T) kubernetes.Interface {
+	kubeConfigDefault := ""
+	if home := homedir.HomeDir(); home != "" {
+		kubeConfigDefault = filepath.Join(home, ".kube", "config")
+	}
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		kubeconfig = kubeConfigDefault
+	}
+
+	kconfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		t.Fatalf("while reading kubeconfig: %v", err)
+	}
+
+	kc, err := kubernetes.NewForConfig(kconfig)
+	if err != nil {
+		t.Fatalf("while creating Kubernetes client: %v", err)
+	}
+	return kc
+}
+
+func writePodFile(t *testing.T, namespace, podName, filePath string, content []byte) {
+	// #nosec G204
+	cmd := exec.CommandContext(context.Background(), "kubectl", "exec", "-i", podName, "-n", namespace, "--", "sh", "-c", "cat > "+filePath)
+	cmd.Stdin = bytes.NewReader(content)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to write file %s to pod %s: %v\nStderr: %s", filePath, podName, err, stderr.String())
+	}
 }

--- a/tests/e2e/testdata/gateway-no-ca.yaml
+++ b/tests/e2e/testdata/gateway-no-ca.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: e2e-gateway
+  namespace: e2e-test-ns
+spec:
+  gatewayClassName: kube-agentic-networking
+  listeners:
+  - name: https-listener
+    port: 10001
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: Same
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: gateway-server-cert
+        kind: Secret
+        group: ""

--- a/tests/e2e/testdata/gateway-tls.yaml
+++ b/tests/e2e/testdata/gateway-tls.yaml
@@ -1,0 +1,28 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: e2e-gateway
+  namespace: e2e-test-ns
+spec:
+  gatewayClassName: kube-agentic-networking
+  listeners:
+  - name: https-listener
+    port: 10001
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: Same
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: gateway-server-cert
+        kind: Secret
+        group: ""
+  tls:
+    frontend:
+      default:
+        validation:
+          caCertificateRefs:
+          - name: gateway-client-ca
+            kind: ConfigMap
+            group: ""

--- a/tests/e2e/testdata/tester-pod-no-certs.yaml
+++ b/tests/e2e/testdata/tester-pod-no-certs.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: e2e-tester-no-certs
+  namespace: e2e-test-ns
+spec:
+  serviceAccountName: e2e-tester-sa
+  containers:
+  - name: tester
+    image: curlimages/curl:latest
+    command: ["sleep", "infinity"]

--- a/tests/e2e/tls_helpers.go
+++ b/tests/e2e/tls_helpers.go
@@ -1,0 +1,194 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/url"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"sigs.k8s.io/kube-agentic-networking/pkg/infra/agentidentity/localca"
+)
+
+// generateCA creates a new CA for testing.
+func generateCA(caID string) (*localca.CA, error) {
+	return localca.GenerateED25519CA(caID)
+}
+
+// generateServerCert generates a server leaf certificate signed by the provided CA.
+func generateServerCert(ca *localca.CA, dnsNames []string) (certPEM, keyPEM []byte, err error) {
+	serverPubKey, serverPrivKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate server key: %w", err)
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(365 * 24 * time.Hour)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	serverTemplate := &x509.Certificate{
+		SerialNumber:          serialNumber,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		IsCA:                  false,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		Subject:               pkix.Name{CommonName: "agentic-net-gateway"},
+		DNSNames:              dnsNames,
+	}
+
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, ca.RootCertificate, serverPubKey, ca.SigningKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create server certificate: %w", err)
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
+
+	privKeyBytes, err := x509.MarshalPKCS8PrivateKey(serverPrivKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privKeyBytes})
+
+	return certPEM, keyPEM, nil
+}
+
+// generateClientCert generates a client certificate signed by the provided CA.
+func generateClientCert(ca *localca.CA, spiffeID string) (certPEM, keyPEM []byte, err error) {
+	clientPrivKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate client key: %w", err)
+	}
+	clientPubKey := &clientPrivKey.PublicKey
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(365 * 24 * time.Hour)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	uri, err := url.Parse(spiffeID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse spiffe ID: %w", err)
+	}
+
+	clientTemplate := &x509.Certificate{
+		SerialNumber:          serialNumber,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		IsCA:                  false,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		Subject:               pkix.Name{CommonName: "test-client"},
+		URIs:                  []*url.URL{uri},
+	}
+
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, ca.RootCertificate, clientPubKey, ca.SigningKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create client certificate: %w", err)
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER})
+	// Append CA cert to client cert chain
+	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.RootCertificate.Raw})
+	certPEM = append(certPEM, caCertPEM...)
+
+	privKeyBytes, err := x509.MarshalPKCS8PrivateKey(clientPrivKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privKeyBytes})
+
+	return certPEM, keyPEM, nil
+}
+
+// createTLSSecret creates a standard TLS Secret in Kubernetes.
+func createTLSSecret(kc kubernetes.Interface, namespace, name string, certPEM, keyPEM []byte) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certPEM,
+			corev1.TLSPrivateKeyKey: keyPEM,
+		},
+	}
+
+	_, err := kc.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+	return err
+}
+
+// createCACertConfigMap creates a ConfigMap containing the CA certificate.
+func createCACertConfigMap(kc kubernetes.Interface, namespace, name string, caCertPEM []byte) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Data: map[string]string{
+			corev1.ServiceAccountRootCAKey: string(caCertPEM),
+		},
+	}
+
+	_, err := kc.CoreV1().ConfigMaps(namespace).Create(context.TODO(), cm, metav1.CreateOptions{})
+	return err
+}
+
+// getAgenticIdentityDefaultCA reads the default CA from the agentic-identity-ca-pool secret.
+func getAgenticIdentityDefaultCA(kc kubernetes.Interface) (*localca.CA, error) {
+	secret, err := kc.CoreV1().Secrets("agentic-net-system").Get(context.TODO(), "agentic-identity-ca-pool", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret agentic-identity-ca-pool: %w", err)
+	}
+	poolBytes, ok := secret.Data["ca-pool.json"]
+	if !ok {
+		return nil, fmt.Errorf("secret agentic-identity-ca-pool missing key ca-pool.json")
+	}
+	pool, err := localca.Unmarshal(poolBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal CA pool: %w", err)
+	}
+	if len(pool.CAs) == 0 {
+		return nil, fmt.Errorf("CA pool is empty")
+	}
+	return pool.CAs[0], nil
+}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/jsonpointer v0.21.2 // indirect


### PR DESCRIPTION
/kind feature

## Description
This PR introduces support for Gateway TLS and `frontendValidation` (mTLS) within the `kube-agentic-networking` translator. It enables the controller to dynamically resolve server certificates and CA bundles to configure secure client-to-gateway connections.

### Key Changes
- **Downstream TLS Support**: Implemented translation logic to convert Gateway `TLS` and `FrontendTLSValidation` fields into Envoy `DownstreamTlsContext` configurations.
- **mTLS Resolution**: Supports both `CertificateRefs` for server identities and `CACertificateRefs` for client certificate validation (supporting both default and per-port overrides).
- **Documentation**: Added a new guide in `site-src` explaining how to configure mTLS correctly.
- **Test Coverage**: 
    - New unit tests for TLS resolution in `pkg/translator`.
    - Refactored E2E tests using Go subtests to cover positive and negative mTLS scenarios.
- **Status Reporting**: The Gateway status now provides feedback if `CACertificateRefs` is missing during an intended mTLS setup.

## How Has This Been Tested?
- **Unit Tests**: `go test ./pkg/translator/...` passes with new TLS test cases.
- **E2E Tests**: `make test-e2e` (specifically `TestGatewayTLS`) verifies that the gateway correctly enforces mTLS and rejects untrusted clients.
- **Confromance Tests** : results in https://github.com/kubernetes-sigs/kube-agentic-networking/issues/94#issuecomment-4331532024


**What this PR does / why we need it**:
Ref #94


**Does this PR introduce a user-facing change?**:

```release-note
None, the API field is not exposed to users yet.
```
