### PR TITLE
Align AccessPolicy condition comments and constants with Gateway API

### DIFF
--- a/api/v0alpha0/accesspolicy_types.go
+++ b/api/v0alpha0/accesspolicy_types.go
@@ -166,9 +166,23 @@ const (
 
 const (
 	// PolicyConditionAccepted indicates whether the policy has been accepted by the controller.
+	//
+	// Possible reasons for this condition to be True are:
+	//
+	// * "Accepted"
+	//
+	// Possible reasons for this condition to be False are:
+	//
+	// * "LimitPerTargetExceeded"
+	//
 	PolicyConditionAccepted gwapiv1.PolicyConditionType = "Accepted"
 
-	// PolicyLimitPerTargetExceeded indicates that the policy was rejected because the maximum number of policies per target was exceeded.
+	// This reason is used with the "Accepted" condition when the policy
+	// has been accepted by the controller.
+	PolicyReasonAccepted gwapiv1.PolicyConditionReason = "Accepted"
+
+	// This reason is used with the "Accepted" condition when the policy
+	// was rejected because the maximum number of policies per target was exceeded.
 	PolicyLimitPerTargetExceeded gwapiv1.PolicyConditionReason = "LimitPerTargetExceeded"
 )
 

--- a/pkg/controller/accesspolicy.go
+++ b/pkg/controller/accesspolicy.go
@@ -233,7 +233,7 @@ func (c *Controller) isPolicyUnderTargetLimit(ctx context.Context, policy *agent
 
 	// 3. Update status for all targets based on the overall result.
 	for _, targetRef := range policy.Spec.TargetRefs {
-		reason := gwapiv1.PolicyConditionReason("Accepted")
+		reason := agenticv0alpha0.PolicyReasonAccepted
 		message := "AccessPolicy accepted for target"
 
 		if !shouldAccept {

--- a/pkg/translator/common_test.go
+++ b/pkg/translator/common_test.go
@@ -113,7 +113,7 @@ func newTestAccessPolicy(name, ns, targetName, targetKind, principal string) *ag
 						{
 							Type:               string(agenticv0alpha0.PolicyConditionAccepted),
 							Status:             metav1.ConditionTrue,
-							Reason:             "Accepted",
+							Reason:             string(agenticv0alpha0.PolicyReasonAccepted),
 							LastTransitionTime: metav1.Now(),
 						},
 					},


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind cleanup

**What this PR does / why we need it**:
- Update comments for `PolicyConditionAccepted` in `accesspolicy_types.go` to explicitly list valid reasons for True and False states, matching Gateway API style.
- Define `PolicyReasonAccepted` as a `PolicyConditionReason` constant to avoid hardcoding `"Accepted"`.
- Update `pkg/controller/accesspolicy.go` and `pkg/translator/common_test.go` to use the new `PolicyReasonAccepted` constant instead of literal strings.
- Refine comments for reasons to use "This reason is used..." phrasing.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
