### PR TITLE
fix(controller): cap workqueue retries and RetryOnConflict on writes

### DIFF
--- a/pkg/controller/accesspolicy.go
+++ b/pkg/controller/accesspolicy.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
@@ -277,52 +278,56 @@ func getTargetID(ref gwapiv1.LocalPolicyTargetReferenceWithSectionName) string {
 }
 
 func (c *Controller) updateAccessPolicyStatus(ctx context.Context, policy *agenticv0alpha0.XAccessPolicy, targetRef gwapiv1.LocalPolicyTargetReferenceWithSectionName, accepted bool, reason gwapiv1.PolicyConditionReason, message string) error {
-	policyCopy := policy.DeepCopy()
-
-	status := metav1.ConditionTrue
-	if !accepted {
-		status = metav1.ConditionFalse
-	}
-
-	newCondition := metav1.Condition{
-		Type:               string(agenticv0alpha0.PolicyConditionAccepted),
-		Status:             status,
-		Reason:             string(reason),
-		Message:            message,
-		ObservedGeneration: policy.Generation,
-	}
-
-	parentRef := gwapiv1.ParentReference{
-		Group:     ptr.To(targetRef.Group),
-		Kind:      ptr.To(targetRef.Kind),
-		Namespace: ptr.To(gwapiv1.Namespace(policy.Namespace)),
-		Name:      targetRef.Name,
-	}
-
-	// Find or create the AncestorStatus for this target.
-	var ancestorStatus *gwapiv1.PolicyAncestorStatus
-	for i := range policyCopy.Status.Ancestors {
-		if reflect.DeepEqual(policyCopy.Status.Ancestors[i].AncestorRef, parentRef) {
-			ancestorStatus = &policyCopy.Status.Ancestors[i]
-			break
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		fresh, err := c.agentic.accessPolicyLister.XAccessPolicies(policy.Namespace).Get(policy.Name)
+		if err != nil {
+			return err
 		}
-	}
+		policyCopy := fresh.DeepCopy()
 
-	if ancestorStatus == nil {
-		policyCopy.Status.Ancestors = append(policyCopy.Status.Ancestors, gwapiv1.PolicyAncestorStatus{
-			AncestorRef:    parentRef,
-			ControllerName: gwapiv1.GatewayController(constants.ControllerName),
-		})
-		ancestorStatus = &policyCopy.Status.Ancestors[len(policyCopy.Status.Ancestors)-1]
-	}
+		status := metav1.ConditionTrue
+		if !accepted {
+			status = metav1.ConditionFalse
+		}
 
-	// meta.SetStatusCondition will only update LastTransitionTime if the status, reason or message changes.
-	meta.SetStatusCondition(&ancestorStatus.Conditions, newCondition)
+		newCondition := metav1.Condition{
+			Type:               string(agenticv0alpha0.PolicyConditionAccepted),
+			Status:             status,
+			Reason:             string(reason),
+			Message:            message,
+			ObservedGeneration: fresh.Generation,
+		}
 
-	if reflect.DeepEqual(policy.Status, policyCopy.Status) {
-		return nil
-	}
+		parentRef := gwapiv1.ParentReference{
+			Group:     ptr.To(targetRef.Group),
+			Kind:      ptr.To(targetRef.Kind),
+			Namespace: ptr.To(gwapiv1.Namespace(policy.Namespace)),
+			Name:      targetRef.Name,
+		}
 
-	_, err := c.agentic.client.AgenticV0alpha0().XAccessPolicies(policy.Namespace).UpdateStatus(ctx, policyCopy, metav1.UpdateOptions{})
-	return err
+		var ancestorStatus *gwapiv1.PolicyAncestorStatus
+		for i := range policyCopy.Status.Ancestors {
+			if reflect.DeepEqual(policyCopy.Status.Ancestors[i].AncestorRef, parentRef) {
+				ancestorStatus = &policyCopy.Status.Ancestors[i]
+				break
+			}
+		}
+
+		if ancestorStatus == nil {
+			policyCopy.Status.Ancestors = append(policyCopy.Status.Ancestors, gwapiv1.PolicyAncestorStatus{
+				AncestorRef:    parentRef,
+				ControllerName: gwapiv1.GatewayController(constants.ControllerName),
+			})
+			ancestorStatus = &policyCopy.Status.Ancestors[len(policyCopy.Status.Ancestors)-1]
+		}
+
+		meta.SetStatusCondition(&ancestorStatus.Conditions, newCondition)
+
+		if reflect.DeepEqual(fresh.Status, policyCopy.Status) {
+			return nil
+		}
+
+		_, err = c.agentic.client.AgenticV0alpha0().XAccessPolicies(policy.Namespace).UpdateStatus(ctx, policyCopy, metav1.UpdateOptions{})
+		return err
+	})
 }

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -142,7 +143,18 @@ func (c *Controller) syncBackendFinalizer(ctx context.Context, key string) error
 			return nil
 		}
 		if removeFinalizer(&newBackend.ObjectMeta, constants.XBackendFinalizer) {
-			if _, err := c.agentic.client.AgenticV0alpha0().XBackends(namespace).Update(ctx, newBackend, metav1.UpdateOptions{}); err != nil {
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				latest, err := c.agentic.backendLister.XBackends(namespace).Get(name)
+				if err != nil {
+					return err
+				}
+				u := latest.DeepCopy()
+				if !removeFinalizer(&u.ObjectMeta, constants.XBackendFinalizer) {
+					return nil
+				}
+				_, err = c.agentic.client.AgenticV0alpha0().XBackends(namespace).Update(ctx, u, metav1.UpdateOptions{})
+				return err
+			}); err != nil {
 				return fmt.Errorf("failed to remove finalizer from XBackend: %w", err)
 			}
 		}
@@ -150,7 +162,18 @@ func (c *Controller) syncBackendFinalizer(ctx context.Context, key string) error
 	}
 
 	if ensureFinalizer(&newBackend.ObjectMeta, constants.XBackendFinalizer) {
-		if _, err := c.agentic.client.AgenticV0alpha0().XBackends(namespace).Update(ctx, newBackend, metav1.UpdateOptions{}); err != nil {
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latest, err := c.agentic.backendLister.XBackends(namespace).Get(name)
+			if err != nil {
+				return err
+			}
+			u := latest.DeepCopy()
+			if !ensureFinalizer(&u.ObjectMeta, constants.XBackendFinalizer) {
+				return nil
+			}
+			_, err = c.agentic.client.AgenticV0alpha0().XBackends(namespace).Update(ctx, u, metav1.UpdateOptions{})
+			return err
+		}); err != nil {
 			return fmt.Errorf("failed to add finalizer to XBackend: %w", err)
 		}
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
@@ -44,6 +45,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -55,6 +57,13 @@ import (
 	"sigs.k8s.io/kube-agentic-networking/pkg/infra/xds"
 	"sigs.k8s.io/kube-agentic-networking/pkg/translator"
 )
+
+// maxGatewaySyncRetries is the maximum number of rate-limited requeues for a
+// single Gateway key before the worker drops it (avoids infinite hot loops).
+const maxGatewaySyncRetries = 15
+
+// maxBackendFinalizerRetries is the same cap for the XBackend finalizer queue.
+const maxBackendFinalizerRetries = 15
 
 type coreResources struct {
 	client kubernetes.Interface
@@ -277,9 +286,13 @@ func (c *Controller) processNextGatewayItem(ctx context.Context) bool {
 
 	// We expect strings (namespace/name) to come off the workqueue.
 	if err := c.syncGateway(ctx, obj); err != nil {
-		// Put the item back on the workqueue to handle any transient errors.
-		c.gatewayqueue.AddRateLimited(obj)
-		klog.ErrorS(err, "Error syncing", "key", obj)
+		if c.gatewayqueue.NumRequeues(obj) < maxGatewaySyncRetries {
+			c.gatewayqueue.AddRateLimited(obj)
+			klog.ErrorS(err, "Error syncing gateway; will retry with rate limit", "key", obj, "requeues", c.gatewayqueue.NumRequeues(obj))
+		} else {
+			c.gatewayqueue.Forget(obj)
+			klog.ErrorS(err, "Dropping gateway sync after max retries", "key", obj, "maxRetries", maxGatewaySyncRetries)
+		}
 		return true
 	}
 
@@ -302,8 +315,13 @@ func (c *Controller) processNextBackendFinalizerItem(ctx context.Context) bool {
 	}
 	defer c.backendFinalizerQueue.Done(obj)
 	if err := c.syncBackendFinalizer(ctx, obj); err != nil {
-		c.backendFinalizerQueue.AddRateLimited(obj)
-		klog.ErrorS(err, "Error syncing backend finalizer", "key", obj)
+		if c.backendFinalizerQueue.NumRequeues(obj) < maxBackendFinalizerRetries {
+			c.backendFinalizerQueue.AddRateLimited(obj)
+			klog.ErrorS(err, "Error syncing backend finalizer; will retry with rate limit", "key", obj, "requeues", c.backendFinalizerQueue.NumRequeues(obj))
+		} else {
+			c.backendFinalizerQueue.Forget(obj)
+			klog.ErrorS(err, "Dropping backend finalizer sync after max retries", "key", obj, "maxRetries", maxBackendFinalizerRetries)
+		}
 		return true
 	}
 	c.backendFinalizerQueue.Forget(obj)
@@ -359,25 +377,24 @@ func (c *Controller) syncGateway(ctx context.Context, key string) error {
 		if errDel := envoy.DeleteProxy(ctx, c.core.client, namespace, name); errDel != nil {
 			return errDel
 		}
-		newGW := gateway.DeepCopy()
-		if removeFinalizer(&newGW.ObjectMeta, constants.GatewayFinalizer) {
-			if _, errUpdate := c.gateway.client.GatewayV1().Gateways(namespace).Update(ctx, newGW, metav1.UpdateOptions{}); errUpdate != nil {
-				return fmt.Errorf("failed to remove finalizer from Gateway: %w", errUpdate)
-			}
+		if err = c.updateGatewayRemoveFinalizer(ctx, namespace, name); err != nil {
+			return fmt.Errorf("failed to remove finalizer from Gateway: %w", err)
 		}
 		return nil
 	}
 
-	newGW := gateway.DeepCopy()
-	if ensureFinalizer(&newGW.ObjectMeta, constants.GatewayFinalizer) {
-		if _, errUpdate := c.gateway.client.GatewayV1().Gateways(namespace).Update(ctx, newGW, metav1.UpdateOptions{}); errUpdate != nil {
-			return fmt.Errorf("failed to add finalizer to Gateway: %w", errUpdate)
-		}
+	finalizerAdded, err := c.ensureGatewayFinalizer(ctx, namespace, name)
+	if err != nil {
+		return fmt.Errorf("failed to add finalizer to Gateway: %w", err)
+	}
+	if finalizerAdded {
 		c.gatewayqueue.Add(key)
 		return nil
 	}
 
 	logger.Info("Syncing gateway")
+
+	newGW := gateway.DeepCopy()
 
 	// Ensure Envoy proxy deployment and service exist.
 	rm := envoy.NewResourceManager(c.core.client, gateway, c.envoyImage, c.agenticIdentityTrustDomain)
@@ -414,14 +431,81 @@ func (c *Controller) syncGateway(ctx context.Context, key string) error {
 	setGatewayConditions(newGW, listenerStatuses, err)
 
 	if !reflect.DeepEqual(gateway.Status, newGW.Status) {
-		_, err := c.gateway.client.GatewayV1().Gateways(newGW.Namespace).UpdateStatus(ctx, newGW, metav1.UpdateOptions{})
-		if err != nil {
-			klog.Errorf("Failed to update gateway status: %v", err)
-			return err
+		if err := c.updateGatewayStatus(ctx, newGW.Namespace, newGW.Name, &newGW.Status); err != nil {
+			return fmt.Errorf("failed to update gateway status: %w", err)
 		}
 		logger.Info("Updated gateway status")
 	}
 	return c.updateHTTPRouteStatuses(ctx, httpRouteStatuses)
+}
+
+func (c *Controller) updateGatewayRemoveFinalizer(ctx context.Context, namespace, name string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := c.gateway.gatewayLister.Gateways(namespace).Get(name)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		u := latest.DeepCopy()
+		if !removeFinalizer(&u.ObjectMeta, constants.GatewayFinalizer) {
+			return nil
+		}
+		_, err = c.gateway.client.GatewayV1().Gateways(namespace).Update(ctx, u, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+// ensureGatewayFinalizer adds the controller finalizer via the API when missing.
+// It returns (true, nil) when the finalizer was absent at the start of the call and is present
+// after a successful retry loop (caller should requeue and exit early so metadata is fresh).
+func (c *Controller) ensureGatewayFinalizer(ctx context.Context, namespace, name string) (requeue bool, err error) {
+	gw, err := c.gateway.gatewayLister.Gateways(namespace).Get(name)
+	if err != nil {
+		return false, err
+	}
+	hadFinalizer := sets.New(gw.Finalizers...).Has(constants.GatewayFinalizer)
+	probe := gw.DeepCopy()
+	if !ensureFinalizer(&probe.ObjectMeta, constants.GatewayFinalizer) {
+		return false, nil
+	}
+	if retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, getErr := c.gateway.gatewayLister.Gateways(namespace).Get(name)
+		if getErr != nil {
+			return getErr
+		}
+		u := latest.DeepCopy()
+		if !ensureFinalizer(&u.ObjectMeta, constants.GatewayFinalizer) {
+			return nil
+		}
+		_, updErr := c.gateway.client.GatewayV1().Gateways(namespace).Update(ctx, u, metav1.UpdateOptions{})
+		return updErr
+	}); retryErr != nil {
+		return false, retryErr
+	}
+	fresh, err := c.gateway.gatewayLister.Gateways(namespace).Get(name)
+	if err != nil {
+		return false, err
+	}
+	nowHas := sets.New(fresh.Finalizers...).Has(constants.GatewayFinalizer)
+	return !hadFinalizer && nowHas, nil
+}
+
+func (c *Controller) updateGatewayStatus(ctx context.Context, namespace, name string, desired *gatewayv1.GatewayStatus) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := c.gateway.gatewayLister.Gateways(namespace).Get(name)
+		if err != nil {
+			return err
+		}
+		if reflect.DeepEqual(latest.Status, *desired) {
+			return nil
+		}
+		u := latest.DeepCopy()
+		u.Status = *desired.DeepCopy()
+		_, err = c.gateway.client.GatewayV1().Gateways(namespace).UpdateStatus(ctx, u, metav1.UpdateOptions{})
+		return err
+	})
 }
 
 // hasHTTPRoutesReferencingGateway returns true if any HTTPRoute has a ParentRef to the given Gateway.

--- a/pkg/controller/gatewayclass.go
+++ b/pkg/controller/gatewayclass.go
@@ -18,11 +18,13 @@ package controller
 
 import (
 	"context"
+	"reflect"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -86,37 +88,66 @@ func (c *Controller) syncGatewayClass(ctx context.Context, key string) {
 			return
 		}
 		if removeFinalizer(&newGwc.ObjectMeta, constants.GatewayClassFinalizer) {
-			if _, err := c.gateway.client.GatewayV1().GatewayClasses().Update(ctx, newGwc, metav1.UpdateOptions{}); err != nil {
-				klog.Errorf("failed to remove finalizer from GatewayClass: %v", err)
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				latest, err := c.gateway.gatewayClassLister.Get(key)
+				if err != nil {
+					return err
+				}
+				u := latest.DeepCopy()
+				if !removeFinalizer(&u.ObjectMeta, constants.GatewayClassFinalizer) {
+					return nil
+				}
+				_, err = c.gateway.client.GatewayV1().GatewayClasses().Update(ctx, u, metav1.UpdateOptions{})
+				return err
+			}); err != nil {
+				klog.ErrorS(err, "failed to remove finalizer from GatewayClass", "gatewayclass", key)
 			}
 		}
 		return
 	}
 
 	if ensureFinalizer(&newGwc.ObjectMeta, constants.GatewayClassFinalizer) {
-		if _, err := c.gateway.client.GatewayV1().GatewayClasses().Update(ctx, newGwc, metav1.UpdateOptions{}); err != nil {
-			klog.Errorf("failed to add finalizer to GatewayClass: %v", err)
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latest, err := c.gateway.gatewayClassLister.Get(key)
+			if err != nil {
+				return err
+			}
+			u := latest.DeepCopy()
+			if !ensureFinalizer(&u.ObjectMeta, constants.GatewayClassFinalizer) {
+				return nil
+			}
+			_, err = c.gateway.client.GatewayV1().GatewayClasses().Update(ctx, u, metav1.UpdateOptions{})
+			return err
+		}); err != nil {
+			klog.ErrorS(err, "failed to add finalizer to GatewayClass", "gatewayclass", key)
 			return
 		}
 		return
 	}
 
-	// Set the "Accepted" condition to True and update the observedGeneration.
-	meta.SetStatusCondition(&newGwc.Status.Conditions, metav1.Condition{
-		Type:               string(gatewayv1.GatewayClassConditionStatusAccepted),
-		Status:             metav1.ConditionTrue,
-		Reason:             string(gatewayv1.GatewayClassReasonAccepted),
-		Message:            "GatewayClass is accepted by this controller.",
-		ObservedGeneration: gwc.Generation,
-	})
-
-	// Update the GatewayClass status
-	if _, err := c.gateway.client.GatewayV1().GatewayClasses().UpdateStatus(ctx, newGwc, metav1.UpdateOptions{}); err != nil {
-		klog.Errorf("failed to update gatewayclass status: %v", err)
-	} else {
-		klog.InfoS("GatewayClass status updated", "gatewayclass", key)
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := c.gateway.gatewayClassLister.Get(key)
+		if err != nil {
+			return err
+		}
+		u := latest.DeepCopy()
+		meta.SetStatusCondition(&u.Status.Conditions, metav1.Condition{
+			Type:               string(gatewayv1.GatewayClassConditionStatusAccepted),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(gatewayv1.GatewayClassReasonAccepted),
+			Message:            "GatewayClass is accepted by this controller.",
+			ObservedGeneration: latest.Generation,
+		})
+		if reflect.DeepEqual(latest.Status, u.Status) {
+			return nil
+		}
+		_, err = c.gateway.client.GatewayV1().GatewayClasses().UpdateStatus(ctx, u, metav1.UpdateOptions{})
+		return err
+	}); err != nil {
+		klog.ErrorS(err, "failed to update gatewayclass status", "gatewayclass", key)
+		return
 	}
-
+	klog.InfoS("GatewayClass status updated", "gatewayclass", key)
 	c.enqueueGatewaysForClass(newGwc.Name)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
- Gateway workqueue: On syncGateway error, requeue with AddRateLimited only while NumRequeues(key) < 15; otherwise Forget and log (stops unbounded retries).
- Backend finalizer workqueue: Same pattern with cap 15 for syncBackendFinalizer.
- Gateway writes: Finalizer add/remove and UpdateStatus go through retry.RetryOnConflict, re-reading the Gateway from the lister inside each attempt.
- GatewayClass writes: Finalizer add/remove and UpdateStatus use retry.RetryOnConflict + lister read; on successful status update, still calls enqueueGatewaysForClass.
- XBackend finalizer: Add/remove finalizer Update wrapped in retry.RetryOnConflict + lister read.
- XAccessPolicy status: UpdateStatus wrapped in retry.RetryOnConflict; each attempt loads the policy from the lister; ObservedGeneration uses that copy’s Generation.

**Which issue(s) this PR fixes**:
Fixes #100 

**Does this PR introduce a user-facing change?**:

```release-note
 NONE
```
