### PR TITLE
fix: update XAccessPolicy status when rules are skipped during translation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 15m # cold CI: go/packages load can approach 5m before linters run
   modules-download-mode: readonly
   issues-exit-code: 1
   tests: true

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -45,7 +45,7 @@ for module in $(find . -name "go.mod" | xargs -n1 dirname); do
     -e GOMODCACHE="/gomodcache" \
     -e GOCACHE="/gocache" \
     "golangci/golangci-lint:$VERSION" \
-    golangci-lint run -v --timeout=5m || failed=true
+    golangci-lint run -v --timeout=15m || failed=true
 done
 
 if ${failed}; then

--- a/k8s/client/clientset/versioned/fake/clientset_constructor.go
+++ b/k8s/client/clientset/versioned/fake/clientset_constructor.go
@@ -1,0 +1,61 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/testing"
+)
+
+// NewClientset returns a fake Clientset seeded with the given objects.
+//
+// Prefer this over NewSimpleClientset (deprecated by client-gen). This constructor does not call
+// NewSimpleClientset so callers avoid nesting deprecated APIs.
+//
+// Implementation matches generated NewSimpleClientset (testing.NewObjectTracker). Upstream
+// Kubernetes fake NewClientset uses testing.NewFieldManagedObjectTracker when apply configurations
+// exist; regenerate this clientset with apply configs (client-gen --with-applyconfig) to match that.
+func NewClientset(objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &Clientset{tracker: o}
+	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		var opts metav1.ListOptions
+		if watchAction, ok := action.(testing.WatchActionImpl); ok {
+			opts = watchAction.ListOptions
+		}
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns, opts)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}

--- a/pkg/controller/accesspolicy.go
+++ b/pkg/controller/accesspolicy.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -39,28 +40,7 @@ import (
 	agenticinformersv1alpha1 "sigs.k8s.io/kube-agentic-networking/k8s/client/informers/externalversions/api/v1alpha1"
 	"sigs.k8s.io/kube-agentic-networking/pkg/constants"
 	helpersv1alpha1 "sigs.k8s.io/kube-agentic-networking/pkg/helpers"
-	"sigs.k8s.io/kube-agentic-networking/pkg/translator"
 )
-
-// AccessPolicyTargetRefIndex is the index name for looking up AccessPolicies by target ref (namespace/name of XBackend).
-const AccessPolicyTargetRefIndex = "targetRef"
-
-// accessPolicyTargetRefIndexFunc indexes AccessPolicies by each XBackend targetRef (namespace/name).
-// Used by the informer cache to support O(1) lookup of policies targeting a given backend.
-func accessPolicyTargetRefIndexFunc(obj interface{}) ([]string, error) {
-	policy, ok := obj.(*agenticv1alpha1.XAccessPolicy)
-	if !ok {
-		return nil, nil
-	}
-	var keys []string
-	for _, targetRef := range policy.Spec.TargetRefs {
-		if !isXBackendTargetRef(targetRef) {
-			continue
-		}
-		keys = append(keys, policy.Namespace+"/"+string(targetRef.Name))
-	}
-	return keys, nil
-}
 
 func (c *Controller) setupAccessPolicyEventHandlers(accessPolicyInformer agenticinformersv1alpha1.XAccessPolicyInformer) error {
 	_, err := accessPolicyInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -80,11 +60,6 @@ func (c *Controller) onAccessPolicyAdd(obj interface{}) {
 		return
 	}
 
-	// Validate CEL expressions.
-	if !c.validateCELSpec(context.Background(), policy) {
-		return
-	}
-
 	c.enqueueGatewaysForAccessPolicy(policy)
 }
 
@@ -100,11 +75,6 @@ func (c *Controller) onAccessPolicyUpdate(old, newObj interface{}) {
 			if !c.isPolicyUnderTargetLimit(context.Background(), newPolicy) {
 				return
 			}
-		}
-
-		// Validate CEL expressions.
-		if !c.validateCELSpec(context.Background(), newPolicy) {
-			return
 		}
 
 		c.enqueueGatewaysForAccessPolicy(newPolicy)
@@ -266,7 +236,7 @@ func (c *Controller) isPolicyUnderTargetLimit(ctx context.Context, policy *agent
 	// 3. Update status for all targets based on the overall result.
 	for _, targetRef := range policy.Spec.TargetRefs {
 		reason := agenticv1alpha1.PolicyReasonAccepted
-		message := "AccessPolicy accepted for target"
+		message := accessPolicyAcceptedMessage
 
 		if !shouldAccept {
 			reason = agenticv1alpha1.PolicyLimitPerTargetExceeded
@@ -363,31 +333,78 @@ func (c *Controller) updateAccessPolicyStatus(ctx context.Context, policy *agent
 	})
 }
 
-// validateCELSpec validates that all CEL expressions in the policy are syntactically valid.
-// It returns true if all expressions are valid, false otherwise.
-// It also updates the policy status accordingly.
-func (c *Controller) validateCELSpec(ctx context.Context, policy *agenticv1alpha1.XAccessPolicy) bool {
-	if policy.Spec.Rules == nil {
-		return true
-	}
-
-	for _, rule := range policy.Spec.Rules {
-		if rule.Authorization != nil && rule.Authorization.Type == agenticv1alpha1.AuthorizationRuleTypeCEL && rule.Authorization.CEL != nil {
-			if _, err := translator.CompileCelExpression(rule.Authorization.CEL.Expression); err != nil {
-				msg := fmt.Sprintf("Failed to compile CEL expression %q: %v", rule.Authorization.CEL.Expression, err)
-				c.rejectPolicyForAllTargets(ctx, policy, msg)
-				return false
-			}
+// filterEmptyStrings returns a copy of ss without "" elements.
+func filterEmptyStrings(ss []string) []string {
+	var out []string
+	for _, s := range ss {
+		if s != "" {
+			out = append(out, s)
 		}
 	}
-
-	return true
+	return out
 }
 
-func (c *Controller) rejectPolicyForAllTargets(ctx context.Context, policy *agenticv1alpha1.XAccessPolicy, message string) {
-	for _, targetRef := range policy.Spec.TargetRefs {
-		if err := c.updateAccessPolicyStatus(ctx, policy, targetRef, false, agenticv1alpha1.PolicyReasonInvalidCEL, message); err != nil {
-			runtime.HandleError(fmt.Errorf("failed to update AccessPolicy status: %w", err))
+const (
+	accessPolicyAcceptedMessage    = "AccessPolicy accepted for target"
+	accessPolicySkippedRulesPrefix = "some rules were not programmed"
+	accessPolicyStaleInvalidReason = string(gwapiv1.PolicyReasonInvalid)
+)
+
+func accessPolicyNeedsTranslationStatusRefresh(policy *agenticv1alpha1.XAccessPolicy) bool {
+	for _, anc := range policy.Status.Ancestors {
+		cond := meta.FindStatusCondition(anc.Conditions, string(agenticv1alpha1.PolicyConditionAccepted))
+		if cond == nil {
+			continue
+		}
+		// Clear status left by older reconciliations that marked the whole policy Invalid.
+		if cond.Status == metav1.ConditionFalse && cond.Reason == accessPolicyStaleInvalidReason {
+			return true
+		}
+		if cond.Status == metav1.ConditionTrue && strings.Contains(cond.Message, accessPolicySkippedRulesPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func accessPolicyTranslationWarningMessage(skippedRuleMsgs []string) string {
+	return fmt.Sprintf("%s; %s: %s", accessPolicyAcceptedMessage, accessPolicySkippedRulesPrefix,
+		strings.Join(deduplicateStrings(filterEmptyStrings(skippedRuleMsgs)), "; "))
+}
+
+// reconcileAccessPolicyTranslationStatus updates XAccessPolicy status when the translator skips rules.
+// Skipped rules are treated as "never match" at enforcement time; the policy stays Accepted so it
+// remains attached (default deny for allow policies when no rules match). Valid rules in the same
+// policy continue to be enforced.
+//
+// ListAccessPoliciesAttachedToGateway defines which policies are in scope for this Gateway sync.
+// The translator's issues map only contains policies that reported errors this pass; policies that
+// now translate cleanly but still carry a skipped-rules warning (or stale Invalid from older code)
+// are reset via isPolicyUnderTargetLimit when issues omits the policy.
+func (c *Controller) reconcileAccessPolicyTranslationStatus(ctx context.Context, gateway *gwapiv1.Gateway, issues map[types.NamespacedName][]string) {
+	attached, err := c.translator.ListAccessPoliciesAttachedToGateway(gateway)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("list AccessPolicies attached to gateway: %w", err))
+		return
+	}
+	for _, policy := range attached {
+		nn := types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}
+		if msgs, hasErr := issues[nn]; hasErr {
+			if !helpersv1alpha1.IsXAccessPolicyAccepted(policy) {
+				if !c.isPolicyUnderTargetLimit(ctx, policy) {
+					continue
+				}
+			}
+			msg := accessPolicyTranslationWarningMessage(msgs)
+			for _, tr := range policy.Spec.TargetRefs {
+				if err := c.updateAccessPolicyStatus(ctx, policy, tr, true, agenticv1alpha1.PolicyReasonAccepted, msg); err != nil {
+					runtime.HandleError(fmt.Errorf("update AccessPolicy %s status for skipped rules: %w", nn, err))
+				}
+			}
+			continue
+		}
+		if accessPolicyNeedsTranslationStatusRefresh(policy) {
+			_ = c.isPolicyUnderTargetLimit(ctx, policy)
 		}
 	}
 }

--- a/pkg/controller/accesspolicy_test.go
+++ b/pkg/controller/accesspolicy_test.go
@@ -18,17 +18,24 @@ package controller
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayclientfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
+	gatewayinformers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
 
 	agenticv0alpha0 "sigs.k8s.io/kube-agentic-networking/api/v0alpha0"
 	agenticv1alpha1 "sigs.k8s.io/kube-agentic-networking/api/v1alpha1"
 	agenticclient "sigs.k8s.io/kube-agentic-networking/k8s/client/clientset/versioned/fake"
 	agenticinformers "sigs.k8s.io/kube-agentic-networking/k8s/client/informers/externalversions"
+	"sigs.k8s.io/kube-agentic-networking/pkg/constants"
+	"sigs.k8s.io/kube-agentic-networking/pkg/translator"
 )
 
 func TestIsPolicyUnderTargetLimit(t *testing.T) {
@@ -220,7 +227,7 @@ func TestIsPolicyUnderTargetLimit(t *testing.T) {
 			allPolicies := make([]runtime.Object, 0, len(tt.existing)+1)
 			allPolicies = append(allPolicies, tt.existing...)
 			allPolicies = append(allPolicies, tt.currentPolicy)
-			fakeClient := agenticclient.NewSimpleClientset(allPolicies...)
+			fakeClient := agenticclient.NewClientset(allPolicies...)
 			informerFactory := agenticinformers.NewSharedInformerFactory(fakeClient, 0)
 			lister := informerFactory.Agentic().V1alpha1().XAccessPolicies().Lister()
 
@@ -255,5 +262,260 @@ func TestIsPolicyUnderTargetLimit(t *testing.T) {
 				t.Errorf("Expected %d status updates, got %d", expectedUpdates, updateCount)
 			}
 		})
+	}
+}
+
+func TestFilterEmptyStrings(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{name: "empty", in: nil, want: nil},
+		{name: "drops empties", in: []string{"a", "", "b", ""}, want: []string{"a", "b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterEmptyStrings(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("filterEmptyStrings() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAccessPolicyNeedsTranslationStatusRefresh(t *testing.T) {
+	ns := gwapiv1.Namespace("default")
+	gwGroup := gwapiv1.Group(gwapiv1.GroupName)
+	gwKind := gwapiv1.Kind("Gateway")
+	invalidAncestor := gwapiv1.PolicyAncestorStatus{
+		AncestorRef: gwapiv1.ParentReference{
+			Group:     &gwGroup,
+			Kind:      &gwKind,
+			Namespace: &ns,
+			Name:      "gw",
+		},
+		ControllerName: gwapiv1.GatewayController(constants.ControllerName),
+		Conditions: []metav1.Condition{
+			{
+				Type:   string(agenticv1alpha1.PolicyConditionAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(gwapiv1.PolicyReasonInvalid),
+			},
+		},
+	}
+	warningAncestor := gwapiv1.PolicyAncestorStatus{
+		AncestorRef:    invalidAncestor.AncestorRef,
+		ControllerName: invalidAncestor.ControllerName,
+		Conditions: []metav1.Condition{
+			{
+				Type:    string(agenticv1alpha1.PolicyConditionAccepted),
+				Status:  metav1.ConditionTrue,
+				Reason:  string(agenticv1alpha1.PolicyReasonAccepted),
+				Message: accessPolicyTranslationWarningMessage([]string{`rule "r1": broken`}),
+			},
+		},
+	}
+	tests := []struct {
+		name   string
+		policy *agenticv1alpha1.XAccessPolicy
+		want   bool
+	}{
+		{
+			name:   "no ancestors",
+			policy: &agenticv1alpha1.XAccessPolicy{},
+			want:   false,
+		},
+		{
+			name: "stale invalid translation status",
+			policy: &agenticv1alpha1.XAccessPolicy{
+				Status: agenticv1alpha1.AccessPolicyStatus{Ancestors: []gwapiv1.PolicyAncestorStatus{invalidAncestor}},
+			},
+			want: true,
+		},
+		{
+			name: "stale skipped-rules warning",
+			policy: &agenticv1alpha1.XAccessPolicy{
+				Status: agenticv1alpha1.AccessPolicyStatus{Ancestors: []gwapiv1.PolicyAncestorStatus{warningAncestor}},
+			},
+			want: true,
+		},
+		{
+			name: "false for limit exceeded",
+			policy: &agenticv1alpha1.XAccessPolicy{
+				Status: agenticv1alpha1.AccessPolicyStatus{
+					Ancestors: []gwapiv1.PolicyAncestorStatus{
+						{
+							AncestorRef: invalidAncestor.AncestorRef,
+							Conditions: []metav1.Condition{
+								{
+									Type:   string(agenticv1alpha1.PolicyConditionAccepted),
+									Status: metav1.ConditionFalse,
+									Reason: string(agenticv1alpha1.PolicyLimitPerTargetExceeded),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := accessPolicyNeedsTranslationStatusRefresh(tt.policy); got != tt.want {
+				t.Errorf("accessPolicyNeedsTranslationStatusRefresh() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func testPolicyGatewayTarget(name, ns, gwName string) *agenticv1alpha1.XAccessPolicy {
+	spiffeID := agenticv1alpha1.AuthorizationSourceSPIFFE("spiffe://cluster.local/ns/x/sa/y")
+	return &agenticv1alpha1.XAccessPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Generation: 1},
+		Spec: agenticv1alpha1.AccessPolicySpec{
+			Action: agenticv1alpha1.ActionTypeAllow,
+			TargetRefs: []gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+				{
+					LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
+						Group: gwapiv1.GroupName,
+						Kind:  "Gateway",
+						Name:  gwapiv1.ObjectName(gwName),
+					},
+				},
+			},
+			Rules: []agenticv1alpha1.AccessRule{
+				{
+					Name:   "r1",
+					Source: agenticv1alpha1.AccessRuleSource{Type: agenticv1alpha1.AuthorizationSourceTypeSPIFFE, SPIFFE: &spiffeID},
+				},
+			},
+		},
+	}
+}
+
+func TestReconcileAccessPolicyTranslationStatus_setsAcceptedWithSkippedRuleWarning(t *testing.T) {
+	ctx := context.Background()
+	ns := "default"
+	gwName := "gw1"
+	policy := testPolicyGatewayTarget("pol1", ns, gwName)
+
+	fakeAgentic := agenticclient.NewClientset(policy)
+	agenticFactory := agenticinformers.NewSharedInformerFactory(fakeAgentic, 0)
+	_ = agenticFactory.Agentic().V1alpha1().XAccessPolicies().Informer().GetIndexer().Add(policy)
+	apLister := agenticFactory.Agentic().V1alpha1().XAccessPolicies().Lister()
+
+	tr := translator.New(
+		"cluster.local",
+		nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil,
+		apLister,
+		nil,
+		nil,
+	)
+
+	c := &Controller{
+		agentic: agenticNetResources{
+			client:             fakeAgentic,
+			accessPolicyLister: apLister,
+		},
+		translator: tr,
+	}
+
+	gw := &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns}}
+	issues := map[types.NamespacedName][]string{
+		{Namespace: ns, Name: "pol1"}: {"dup", "dup", "rule x: broken"},
+	}
+	c.reconcileAccessPolicyTranslationStatus(ctx, gw, issues)
+
+	updated, err := fakeAgentic.AgenticV1alpha1().XAccessPolicies(ns).Get(ctx, "pol1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get policy: %v", err)
+	}
+	if len(updated.Status.Ancestors) != 1 {
+		t.Fatalf("expected 1 ancestor status, got %d", len(updated.Status.Ancestors))
+	}
+	cond := meta.FindStatusCondition(updated.Status.Ancestors[0].Conditions, string(agenticv1alpha1.PolicyConditionAccepted))
+	if cond == nil {
+		t.Fatal("missing Accepted condition")
+	}
+	if cond.Status != metav1.ConditionTrue || cond.Reason != string(agenticv1alpha1.PolicyReasonAccepted) {
+		t.Fatalf("Accepted condition = %+v, want True/Accepted", cond)
+	}
+	wantMsg := accessPolicyTranslationWarningMessage([]string{"dup", "rule x: broken"})
+	if cond.Message != wantMsg {
+		t.Errorf("message = %q, want %q", cond.Message, wantMsg)
+	}
+}
+
+func TestReconcileAccessPolicyTranslationStatus_clearsInvalidViaLimitCheck(t *testing.T) {
+	ctx := context.Background()
+	ns := "default"
+	gwName := "gw1"
+	policy := testPolicyGatewayTarget("pol1", ns, gwName)
+	nsG := gwapiv1.Namespace(ns)
+	gwG := gwapiv1.Group(gwapiv1.GroupName)
+	gwK := gwapiv1.Kind("Gateway")
+	policy.Status = agenticv1alpha1.AccessPolicyStatus{
+		Ancestors: []gwapiv1.PolicyAncestorStatus{
+			{
+				AncestorRef: gwapiv1.ParentReference{
+					Group:     &gwG,
+					Kind:      &gwK,
+					Namespace: &nsG,
+					Name:      gwapiv1.ObjectName(gwName),
+				},
+				ControllerName: gwapiv1.GatewayController(constants.ControllerName),
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(agenticv1alpha1.PolicyConditionAccepted),
+						Status: metav1.ConditionFalse,
+						Reason: string(gwapiv1.PolicyReasonInvalid),
+					},
+				},
+			},
+		},
+	}
+
+	fakeAgentic := agenticclient.NewClientset(policy)
+	agenticFactory := agenticinformers.NewSharedInformerFactory(fakeAgentic, 0)
+	_ = agenticFactory.Agentic().V1alpha1().XAccessPolicies().Informer().GetIndexer().Add(policy)
+	apLister := agenticFactory.Agentic().V1alpha1().XAccessPolicies().Lister()
+
+	gwClient := gatewayclientfake.NewClientset()
+	gwFactory := gatewayinformers.NewSharedInformerFactory(gwClient, 0)
+	httprouteLister := gwFactory.Gateway().V1().HTTPRoutes().Lister()
+
+	tr := translator.New(
+		"cluster.local",
+		nil, nil, nil, nil, nil, nil, nil,
+		nil, httprouteLister, nil,
+		apLister,
+		nil,
+		nil,
+	)
+
+	c := &Controller{
+		agentic: agenticNetResources{
+			client:             fakeAgentic,
+			accessPolicyLister: apLister,
+		},
+		translator: tr,
+	}
+
+	gw := &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns}}
+	c.reconcileAccessPolicyTranslationStatus(ctx, gw, nil)
+
+	updated, err := fakeAgentic.AgenticV1alpha1().XAccessPolicies(ns).Get(ctx, "pol1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get policy: %v", err)
+	}
+	cond := meta.FindStatusCondition(updated.Status.Ancestors[0].Conditions, string(agenticv1alpha1.PolicyConditionAccepted))
+	if cond == nil {
+		t.Fatal("missing Accepted condition")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected Accepted True after translation cleared, got %+v", cond)
 	}
 }

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -184,9 +184,9 @@ func (c *Controller) syncBackendFinalizer(ctx context.Context, key string) error
 func hasAccessPoliciesTargetingBackend(c *Controller, backend *agenticv0alpha0.XBackend) bool {
 	if c.agentic.accessPolicyIndexer != nil {
 		key := backend.Namespace + "/" + backend.Name
-		objs, err := c.agentic.accessPolicyIndexer.ByIndex(AccessPolicyTargetRefIndex, key)
+		objs, err := c.agentic.accessPolicyIndexer.ByIndex(AccessPolicyBackendTargetIndex, key)
 		if err != nil {
-			klog.V(4).ErrorS(err, "failed to list XAccessPolicies by targetRef index for XBackend finalizer")
+			klog.V(4).ErrorS(err, "failed to list XAccessPolicies by backendTarget index for XBackend finalizer")
 			return true
 		}
 		return len(objs) > 0

--- a/pkg/controller/backend_test.go
+++ b/pkg/controller/backend_test.go
@@ -29,17 +29,21 @@ import (
 	agenticv0alpha0 "sigs.k8s.io/kube-agentic-networking/api/v0alpha0"
 	agenticv1alpha1 "sigs.k8s.io/kube-agentic-networking/api/v1alpha1"
 	agenticlistersv1alpha1 "sigs.k8s.io/kube-agentic-networking/k8s/client/listers/api/v1alpha1"
+	"sigs.k8s.io/kube-agentic-networking/pkg/translator"
 )
+
+func accessPolicyTestIndexers() cache.Indexers {
+	ix := translator.NewAccessPolicyIndexers()
+	ix[cache.NamespaceIndex] = cache.MetaNamespaceIndexFunc
+	return ix
+}
 
 func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
 	ns := "default"
 	backendName := "my-backend"
 
 	t.Run("no policies in namespace", func(t *testing.T) {
-		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
-			cache.NamespaceIndex:       cache.MetaNamespaceIndexFunc,
-			AccessPolicyTargetRefIndex: accessPolicyTargetRefIndexFunc,
-		})
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, accessPolicyTestIndexers())
 		c := &Controller{
 			agentic: agenticNetResources{
 				accessPolicyLister:  agenticlistersv1alpha1.NewXAccessPolicyLister(indexer),
@@ -55,10 +59,7 @@ func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
 	})
 
 	t.Run("policy targets different backend", func(t *testing.T) {
-		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
-			cache.NamespaceIndex:       cache.MetaNamespaceIndexFunc,
-			AccessPolicyTargetRefIndex: accessPolicyTargetRefIndexFunc,
-		})
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, accessPolicyTestIndexers())
 		policy := &agenticv1alpha1.XAccessPolicy{
 			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "policy-1"},
 			Spec: agenticv1alpha1.AccessPolicySpec{
@@ -92,10 +93,7 @@ func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
 	})
 
 	t.Run("policy targets this backend", func(t *testing.T) {
-		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
-			cache.NamespaceIndex:       cache.MetaNamespaceIndexFunc,
-			AccessPolicyTargetRefIndex: accessPolicyTargetRefIndexFunc,
-		})
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, accessPolicyTestIndexers())
 		policy := &agenticv1alpha1.XAccessPolicy{
 			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "policy-1"},
 			Spec: agenticv1alpha1.AccessPolicySpec{
@@ -129,10 +127,7 @@ func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
 	})
 
 	t.Run("policy targets this backend by name but wrong group is skipped", func(t *testing.T) {
-		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
-			cache.NamespaceIndex:       cache.MetaNamespaceIndexFunc,
-			AccessPolicyTargetRefIndex: accessPolicyTargetRefIndexFunc,
-		})
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, accessPolicyTestIndexers())
 		policy := &agenticv1alpha1.XAccessPolicy{
 			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "policy-1"},
 			Spec: agenticv1alpha1.AccessPolicySpec{
@@ -166,10 +161,7 @@ func TestHasAccessPoliciesTargetingBackend(t *testing.T) {
 	})
 
 	t.Run("multiple targetRefs one matches backend", func(t *testing.T) {
-		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
-			cache.NamespaceIndex:       cache.MetaNamespaceIndexFunc,
-			AccessPolicyTargetRefIndex: accessPolicyTargetRefIndexFunc,
-		})
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, accessPolicyTestIndexers())
 		policy := &agenticv1alpha1.XAccessPolicy{
 			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "policy-1"},
 			Spec: agenticv1alpha1.AccessPolicySpec{

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -69,6 +69,9 @@ const maxGatewaySyncRetries = 30
 // maxBackendFinalizerRetries is the same cap for the XBackend finalizer queue.
 const maxBackendFinalizerRetries = 15
 
+// AccessPolicyBackendTargetIndex is re-exported for tests and helpers that look up policies by XBackend target key.
+const AccessPolicyBackendTargetIndex = translator.AccessPolicyBackendTargetIndex
+
 type coreResources struct {
 	client kubernetes.Interface
 
@@ -152,8 +155,8 @@ func New(
 	accessPolicyInformer agenticinformersv1alpha1.XAccessPolicyInformer,
 ) (*Controller, error) {
 	apInformer := accessPolicyInformer.Informer()
-	if err := apInformer.AddIndexers(cache.Indexers{AccessPolicyTargetRefIndex: accessPolicyTargetRefIndexFunc}); err != nil {
-		return nil, fmt.Errorf("add AccessPolicy targetRef index: %w", err)
+	if err := apInformer.AddIndexers(translator.NewAccessPolicyIndexers()); err != nil {
+		return nil, fmt.Errorf("add AccessPolicy indexers: %w", err)
 	}
 
 	if err := httprouteInformer.Informer().AddIndexers(cache.Indexers{HTTPRouteBackendRefNamespaceIndex: HTTPRouteBackendRefNamespaceIndexFunc}); err != nil {
@@ -225,6 +228,7 @@ func New(
 		httprouteInformer.Lister(),
 		referenceGrantInformer.Lister(),
 		accessPolicyInformer.Lister(),
+		apInformer.GetIndexer(),
 		backendInformer.Lister(),
 	)
 
@@ -463,13 +467,15 @@ func (c *Controller) syncGateway(ctx context.Context, key string) error {
 	logger.Info("Ensured Envoy proxy for gateway exists", "nodeID", rm.NodeID(), "proxyAddress", proxyAddress)
 
 	// Translate Gateway to xDS resources (includes only current HTTPRoutes/XAccessPolicies; stale rules are omitted).
-	resources, listenerStatuses, httpRouteStatuses, _, err := c.translator.TranslateGatewayToXDS(ctx, gateway)
+	resources, listenerStatuses, httpRouteStatuses, _, policyIssues, err := c.translator.TranslateGatewayToXDS(ctx, gateway)
 	if err != nil {
 		updateErr := updateGatewayStatus(ctx, c, gateway, newGW, nil, fmt.Errorf("failed to translate gateway to xDS resources: %w", err))
 		return errors.Join(err, updateErr)
 	}
 
 	logger.Info("Translated gateway to xDS resources")
+
+	c.reconcileAccessPolicyTranslationStatus(ctx, gateway, policyIssues)
 
 	newGW.Status.Listeners = listenerStatuses
 	// Update the xDS server with the new resources.

--- a/pkg/controller/referencegrant.go
+++ b/pkg/controller/referencegrant.go
@@ -206,6 +206,8 @@ func HTTPRouteBackendRefNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	return keys, nil
 }
 
+// deduplicateStrings returns input with duplicate strings removed, preserving the
+// order of first occurrences. The empty string is kept like any other value.
 func deduplicateStrings(input []string) []string {
 	keys := make(map[string]bool)
 	list := []string{}

--- a/pkg/controller/referencegrant_test.go
+++ b/pkg/controller/referencegrant_test.go
@@ -252,6 +252,16 @@ func TestDeduplicateStrings(t *testing.T) {
 			input:    []string{"a", "a", "a"},
 			expected: []string{"a"},
 		},
+		{
+			name:     "preserves empty string",
+			input:    []string{"a", "", "b"},
+			expected: []string{"a", "", "b"},
+		},
+		{
+			name:     "dedupes including empty",
+			input:    []string{"", "", "x"},
+			expected: []string{"", "x"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/translator/accesspolicy.go
+++ b/pkg/translator/accesspolicy.go
@@ -27,6 +27,7 @@ import (
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/protobuf/types/known/anypb"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -37,7 +38,7 @@ import (
 )
 
 // buildGatewayLevelRBACFilters finds all AccessPolicies targeting the Gateway and translates them into HTTP filters.
-func (t *Translator) buildGatewayLevelRBACFilters(gateway *gatewayv1.Gateway) ([]*hcm.HttpFilter, error) {
+func (t *Translator) buildGatewayLevelRBACFilters(gateway *gatewayv1.Gateway, te *translationErrors) ([]*hcm.HttpFilter, error) {
 	gwPolicies, err := t.findAccessPoliciesForTarget(gatewayv1.GroupName, "Gateway", gateway.Namespace, gateway.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find Gateway access policies: %w", err)
@@ -59,7 +60,7 @@ func (t *Translator) buildGatewayLevelRBACFilters(gateway *gatewayv1.Gateway) ([
 
 	// 1. Handle ExternalAuth policy (at most one)
 	if extAuthPolicy != nil {
-		rbacProto := t.buildRBACConfigWithCommonPolicies(extAuthPolicy)
+		rbacProto := t.buildRBACConfigWithCommonPolicies(extAuthPolicy, te)
 		rbacTypedConfig, err := anypb.New(rbacProto)
 		if err != nil {
 			return nil, err
@@ -74,7 +75,7 @@ func (t *Translator) buildGatewayLevelRBACFilters(gateway *gatewayv1.Gateway) ([
 
 	// 2. Handle all Allow policies (merged into one filter)
 	if len(allowPolicies) > 0 {
-		rbacProto := t.mergeAllowPoliciesToRBAC(allowPolicies)
+		rbacProto := t.mergeAllowPoliciesToRBAC(allowPolicies, te)
 		rbacTypedConfig, err := anypb.New(rbacProto)
 		if err != nil {
 			return nil, err
@@ -118,7 +119,7 @@ func (t *Translator) buildBackendLevelRBACFilters() ([]*hcm.HttpFilter, error) {
 }
 
 // buildBackendLevelRBACOverrides creates the TypedPerFilterConfig for a cluster, specifically for the RBAC filter overrides.
-func (t *Translator) buildBackendLevelRBACOverrides(backend *agenticv0alpha0.XBackend) (map[string]*anypb.Any, error) {
+func (t *Translator) buildBackendLevelRBACOverrides(backend *agenticv0alpha0.XBackend, te *translationErrors) (map[string]*anypb.Any, error) {
 	perFilterConfig := make(map[string]*anypb.Any)
 
 	// 1. Find and sort AccessPolicies targeting the Backend.
@@ -142,7 +143,7 @@ func (t *Translator) buildBackendLevelRBACOverrides(backend *agenticv0alpha0.XBa
 
 	// 1. Handle ExternalAuth policy (at most one)
 	if extAuthPolicy != nil {
-		rbacProto := t.buildRBACConfigWithCommonPolicies(extAuthPolicy)
+		rbacProto := t.buildRBACConfigWithCommonPolicies(extAuthPolicy, te)
 		rbacPerRouteProto := &rbacv3.RBACPerRoute{
 			Rbac: rbacProto,
 		}
@@ -155,7 +156,7 @@ func (t *Translator) buildBackendLevelRBACOverrides(backend *agenticv0alpha0.XBa
 
 	// 2. Handle all Allow policies (merged into one filter)
 	if len(allowPolicies) > 0 {
-		rbacProto := t.mergeAllowPoliciesToRBAC(allowPolicies)
+		rbacProto := t.mergeAllowPoliciesToRBAC(allowPolicies, te)
 		rbacPerRouteProto := &rbacv3.RBACPerRoute{
 			Rbac: rbacProto,
 		}
@@ -171,11 +172,19 @@ func (t *Translator) buildBackendLevelRBACOverrides(backend *agenticv0alpha0.XBa
 
 // buildRBACConfigWithCommonPolicies generates an RBAC config for an AccessPolicy.
 // It includes the common policies needed for MCP session management to avoid blocking basic operations.
-func (t *Translator) buildRBACConfigWithCommonPolicies(accessPolicy *agenticv1alpha1.XAccessPolicy) *rbacv3.RBAC {
-	return t.translateAccessPolicyToRBAC(accessPolicy)
+func (t *Translator) buildRBACConfigWithCommonPolicies(accessPolicy *agenticv1alpha1.XAccessPolicy, te *translationErrors) *rbacv3.RBAC {
+	rbacConfig := t.translateAccessPolicyToRBAC(accessPolicy, te)
+
+	// Add common policies to avoid blocking basic MCP operations.
+	// These are added to the 'Rules' section which is where allowed traffic is defined.
+	addPolicyToRBACRules(rbacConfig, constants.AllowMCPSessionClosePolicyName, buildAllowMCPSessionClosePolicy())
+	addPolicyToRBACRules(rbacConfig, constants.AllowAnyoneToInitializeAndListToolsPolicyName, buildAllowAnyoneToInitializeAndListToolsPolicy())
+	addPolicyToRBACRules(rbacConfig, constants.AllowHTTPGetPolicyName, buildAllowHTTPGetPolicy())
+
+	return rbacConfig
 }
 
-func (t *Translator) mergeAllowPoliciesToRBAC(policies []*agenticv1alpha1.XAccessPolicy) *rbacv3.RBAC {
+func (t *Translator) mergeAllowPoliciesToRBAC(policies []*agenticv1alpha1.XAccessPolicy, te *translationErrors) *rbacv3.RBAC {
 	rbacConfig := &rbacv3.RBAC{}
 
 	for _, policy := range policies {
@@ -214,6 +223,9 @@ func (t *Translator) mergeAllowPoliciesToRBAC(policies []*agenticv1alpha1.XAcces
 						ast, err := CompileCelExpression(rule.Authorization.CEL.Expression)
 						if err != nil {
 							klog.Errorf("Failed to compile CEL expression %q: %v", rule.Authorization.CEL.Expression, err)
+							if te != nil {
+								te.accessPolicyError(types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}, rule.Name, "compile CEL expression", err)
+							}
 							continue
 						}
 						rbacPolicy.Condition = ast.Expr()
@@ -279,7 +291,7 @@ func convertSAtoSPIFFEID(trustDomain, namespace, saName string) string {
 	return fmt.Sprintf(constants.SpiffeIDFormat, trustDomain, namespace, saName)
 }
 
-func (t *Translator) translateAccessPolicyToRBAC(accessPolicy *agenticv1alpha1.XAccessPolicy) *rbacv3.RBAC {
+func (t *Translator) translateAccessPolicyToRBAC(accessPolicy *agenticv1alpha1.XAccessPolicy, te *translationErrors) *rbacv3.RBAC {
 	rbacConfig := &rbacv3.RBAC{}
 
 	if len(accessPolicy.Spec.Rules) == 0 {
@@ -349,6 +361,9 @@ func (t *Translator) translateAccessPolicyToRBAC(accessPolicy *agenticv1alpha1.X
 					ast, err := CompileCelExpression(rule.Authorization.CEL.Expression)
 					if err != nil {
 						klog.Errorf("Failed to compile CEL expression %q: %v", rule.Authorization.CEL.Expression, err)
+						if te != nil {
+							te.accessPolicyError(types.NamespacedName{Namespace: accessPolicy.Namespace, Name: accessPolicy.Name}, rule.Name, "compile CEL expression", err)
+						}
 						continue
 					}
 					rbacPolicy.Condition = ast.Expr()
@@ -362,6 +377,9 @@ func (t *Translator) translateAccessPolicyToRBAC(accessPolicy *agenticv1alpha1.X
 			hash, err := externalAuthUniqueID(accessPolicy.Spec.ExternalAuth)
 			if err != nil {
 				klog.Errorf("Failed to generate unique ID for externalAuth config in AccessPolicy %s/%s: %v", accessPolicy.Namespace, accessPolicy.Name, err)
+				if te != nil {
+					te.accessPolicyError(types.NamespacedName{Namespace: accessPolicy.Namespace, Name: accessPolicy.Name}, "", "cannot fingerprint external authorization config", err)
+				}
 				continue
 			}
 			rbacConfig.ShadowRulesStatPrefix = fmt.Sprintf("%s_%s_", constants.ExternalAuthzShadowRulePrefix, hash)

--- a/pkg/translator/accesspolicy_index.go
+++ b/pkg/translator/accesspolicy_index.go
@@ -1,0 +1,80 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translator
+
+import (
+	"k8s.io/client-go/tools/cache"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	agenticv1alpha1 "sigs.k8s.io/kube-agentic-networking/api/v1alpha1"
+)
+
+const (
+	// AccessPolicyBackendTargetIndex indexes XAccessPolicies by XBackend target key "namespace/name"
+	// (policy namespace + backend name). Must stay aligned with the controller informer registration.
+	AccessPolicyBackendTargetIndex = "backendTarget"
+	// AccessPolicyGatewayTargetIndex indexes XAccessPolicies by Gateway targetRef key "namespace/name"
+	// (policy namespace + gateway name) for LocalPolicyTargetReference Gateway targets.
+	AccessPolicyGatewayTargetIndex = "gatewayTarget"
+)
+
+// NewAccessPolicyIndexers returns indexers for XAccessPolicy informers (backendTarget, gatewayTarget).
+// Register with AddIndexers; index keys must stay aligned with isAccessPolicyAttachedToGateway
+// and listAccessPoliciesAttachedToGatewayIndexed.
+func NewAccessPolicyIndexers() cache.Indexers {
+	return cache.Indexers{
+		AccessPolicyBackendTargetIndex: xAccessPolicyByBackendTarget,
+		AccessPolicyGatewayTargetIndex: xAccessPolicyByGatewayTarget,
+	}
+}
+
+// xAccessPolicyByBackendTarget implements cache.IndexFunc for AccessPolicyBackendTargetIndex.
+func xAccessPolicyByBackendTarget(obj interface{}) ([]string, error) {
+	policy, ok := obj.(*agenticv1alpha1.XAccessPolicy)
+	if !ok {
+		return nil, nil
+	}
+	var keys []string
+	for _, targetRef := range policy.Spec.TargetRefs {
+		if targetRef.Group != agenticv1alpha1.GroupName || targetRef.Kind != "XBackend" {
+			continue
+		}
+		keys = append(keys, policy.Namespace+"/"+string(targetRef.Name))
+	}
+	return keys, nil
+}
+
+// xAccessPolicyByGatewayTarget implements cache.IndexFunc for AccessPolicyGatewayTargetIndex.
+// Keys match isAccessPolicyAttachedToGateway for direct Gateway targets (local ref → policy namespace).
+func xAccessPolicyByGatewayTarget(obj interface{}) ([]string, error) {
+	policy, ok := obj.(*agenticv1alpha1.XAccessPolicy)
+	if !ok {
+		return nil, nil
+	}
+	var keys []string
+	for _, targetRef := range policy.Spec.TargetRefs {
+		if targetRef.Kind != "Gateway" {
+			continue
+		}
+		g := targetRef.Group
+		if g != "" && g != gwapiv1.GroupName {
+			continue
+		}
+		keys = append(keys, policy.Namespace+"/"+string(targetRef.Name))
+	}
+	return keys, nil
+}

--- a/pkg/translator/accesspolicy_test.go
+++ b/pkg/translator/accesspolicy_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package translator
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,6 +26,7 @@ import (
 	rbacv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -146,7 +149,7 @@ func TestBuildGatewayLevelRBACFilters(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			agenticClient := agenticclient.NewSimpleClientset(tt.policies...)
+			agenticClient := agenticclient.NewClientset(tt.policies...)
 			agenticInformerFactory := agenticinformers.NewSharedInformerFactory(agenticClient, 0)
 			lister := agenticInformerFactory.Agentic().V1alpha1().XAccessPolicies().Lister()
 
@@ -158,7 +161,7 @@ func TestBuildGatewayLevelRBACFilters(t *testing.T) {
 
 			for gwn, expectedNames := range tt.gatewaysToCheck {
 				gw := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwn, Namespace: ns}}
-				filters, err := tr.buildGatewayLevelRBACFilters(gw)
+				filters, err := tr.buildGatewayLevelRBACFilters(gw, nil)
 				if err != nil {
 					t.Fatalf("Gateway %s: Failed to build filters: %v", gwn, err)
 				}
@@ -274,7 +277,7 @@ func TestBuildBackendLevelRBACOverrides(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			agenticClient := agenticclient.NewSimpleClientset(tt.policies...)
+			agenticClient := agenticclient.NewClientset(tt.policies...)
 			agenticInformerFactory := agenticinformers.NewSharedInformerFactory(agenticClient, 0)
 			lister := agenticInformerFactory.Agentic().V1alpha1().XAccessPolicies().Lister()
 
@@ -287,7 +290,7 @@ func TestBuildBackendLevelRBACOverrides(t *testing.T) {
 			for ben, expectedFilterNames := range tt.backendsToCheck {
 				xbackend := &agenticv0alpha0.XBackend{ObjectMeta: metav1.ObjectMeta{Name: ben, Namespace: ns}}
 
-				configs, err := tr.buildBackendLevelRBACOverrides(xbackend)
+				configs, err := tr.buildBackendLevelRBACOverrides(xbackend, nil)
 				if err != nil {
 					t.Fatalf("Backend %s: Failed to build configs: %v", ben, err)
 				}
@@ -324,7 +327,7 @@ func TestBuildRBACConfigWithCommonPolicies(t *testing.T) {
 		},
 	}
 
-	rbac := tr.buildRBACConfigWithCommonPolicies(policy)
+	rbac := tr.buildRBACConfigWithCommonPolicies(policy, nil)
 
 	rbacPolicy := rbac.GetRules().GetPolicies()["custom-rule"]
 	if rbacPolicy == nil {
@@ -423,7 +426,7 @@ func TestBuildRBACConfigWithoutCommonPolicies(t *testing.T) {
 		},
 	}
 
-	rbac := tr.buildRBACConfigWithCommonPolicies(policy)
+	rbac := tr.translateAccessPolicyToRBAC(policy, nil)
 
 	expectedPolicies := []string{
 		"custom-rule",
@@ -489,7 +492,7 @@ func TestFindAccessPoliciesForTarget(t *testing.T) {
 		},
 	}
 
-	agenticClient := agenticclient.NewSimpleClientset(policies...)
+	agenticClient := agenticclient.NewClientset(policies...)
 	agenticInformerFactory := agenticinformers.NewSharedInformerFactory(agenticClient, 0)
 	lister := agenticInformerFactory.Agentic().V1alpha1().XAccessPolicies().Lister()
 
@@ -864,7 +867,7 @@ func TestTranslateAccessPolicyToRBAC(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tr := &Translator{agenticIdentityTrustDomain: testTrustDomain}
-			rbac := tr.translateAccessPolicyToRBAC(tc.accessPolicy)
+			rbac := tr.translateAccessPolicyToRBAC(tc.accessPolicy, nil)
 
 			verifyRBAC(t, rbac.GetRules(), tc.expectedRules)
 			verifyRBAC(t, rbac.GetShadowRules(), tc.expectedShadowRules)
@@ -873,6 +876,140 @@ func TestTranslateAccessPolicyToRBAC(t *testing.T) {
 				t.Errorf("ShadowRulesStatPrefix: expected set=%v, got %q", tc.expectShadowStatPrefix, rbac.GetShadowRulesStatPrefix())
 			}
 		})
+	}
+}
+
+// TestTranslateAccessPolicyToRBAC_recordsExternalAuthFingerprintFailure exercises the path at
+// accesspolicy.go where externalAuthUniqueID fails. json.Marshal on well-formed Gateway API
+// objects essentially never fails in production; this replaces marshalExternalAuthForUniqueID to
+// prove the collector message is what reconcileAccessPolicyTranslationStatus surfaces on status.
+// Do not call t.Parallel here: the test temporarily mutates that package-level hook.
+func TestTranslateAccessPolicyToRBAC_recordsExternalAuthFingerprintFailure(t *testing.T) {
+	const (
+		simulatedMarshalFailureErrText = "simulated marshal failure"
+		wantIssueContainsFingerprint   = "cannot fingerprint external authorization config"
+	)
+
+	orig := marshalExternalAuthForUniqueID
+	marshalExternalAuthForUniqueID = func(_ any) ([]byte, error) {
+		return nil, errors.New(simulatedMarshalFailureErrText)
+	}
+	t.Cleanup(func() { marshalExternalAuthForUniqueID = orig })
+
+	spiffe := agenticv1alpha1.AuthorizationSourceSPIFFE("spiffe://cluster.local/ns/default/sa/sa1")
+	policy := &agenticv1alpha1.XAccessPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pol-fingerprint"},
+		Spec: agenticv1alpha1.AccessPolicySpec{
+			Action: agenticv1alpha1.ActionTypeExternalAuth,
+			ExternalAuth: &gatewayv1.HTTPExternalAuthFilter{
+				ExternalAuthProtocol: gatewayv1.HTTPRouteExternalAuthGRPCProtocol,
+				BackendRef:           gatewayv1.BackendObjectReference{Name: "auth-svc"},
+			},
+			TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+				{
+					LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+						Group: gatewayv1.GroupName,
+						Kind:  "Gateway",
+						Name:  "gw",
+					},
+				},
+			},
+			Rules: []agenticv1alpha1.AccessRule{
+				{
+					Name:   "ext-rule",
+					Source: agenticv1alpha1.AccessRuleSource{Type: agenticv1alpha1.AuthorizationSourceTypeSPIFFE, SPIFFE: &spiffe},
+				},
+			},
+		},
+	}
+
+	coll := newTranslationErrors()
+	tr := &Translator{agenticIdentityTrustDomain: testTrustDomain}
+	_ = tr.translateAccessPolicyToRBAC(policy, coll)
+
+	snap := coll.policyIssues()
+	nn := types.NamespacedName{Namespace: "default", Name: "pol-fingerprint"}
+	msgs, ok := snap[nn]
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("expected one recorded issue for %v, got %#v", nn, snap)
+	}
+	if !strings.Contains(msgs[0], wantIssueContainsFingerprint) {
+		t.Errorf("message %q should mention fingerprint failure", msgs[0])
+	}
+	if !strings.Contains(msgs[0], simulatedMarshalFailureErrText) {
+		t.Errorf("message should include underlying error: %q", msgs[0])
+	}
+}
+
+func TestMergeAllowPoliciesToRBAC_skipsInvalidCELAndEnforcesValidRules(t *testing.T) {
+	tr := &Translator{agenticIdentityTrustDomain: testTrustDomain}
+	spiffe := agenticv1alpha1.AuthorizationSourceSPIFFE("spiffe://cluster.local/ns/default/sa/tester")
+	policy := &agenticv1alpha1.XAccessPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "allow-partial"},
+		Spec: agenticv1alpha1.AccessPolicySpec{
+			Action: agenticv1alpha1.ActionTypeAllow,
+			Rules: []agenticv1alpha1.AccessRule{
+				{
+					Name:   "bad-cel",
+					Source: agenticv1alpha1.AccessRuleSource{Type: agenticv1alpha1.AuthorizationSourceTypeSPIFFE, SPIFFE: &spiffe},
+					Authorization: &agenticv1alpha1.AuthorizationRule{
+						Type: agenticv1alpha1.AuthorizationRuleTypeCEL,
+						CEL:  &agenticv1alpha1.AccessPolicyCELRule{Expression: "this is not valid cel"},
+					},
+				},
+				{
+					Name:   "good-inline",
+					Source: agenticv1alpha1.AccessRuleSource{Type: agenticv1alpha1.AuthorizationSourceTypeSPIFFE, SPIFFE: &spiffe},
+					Authorization: &agenticv1alpha1.AuthorizationRule{
+						Type: agenticv1alpha1.AuthorizationRuleTypeInline,
+						MCP: agenticv1alpha1.MCPAttributes{
+							Methods: []agenticv1alpha1.MCPMethod{{Name: agenticv1alpha1.MCPMethodName("echo")}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	coll := newTranslationErrors()
+	rbac := tr.mergeAllowPoliciesToRBAC([]*agenticv1alpha1.XAccessPolicy{policy}, coll)
+
+	if _, ok := rbac.GetRules().GetPolicies()["bad-cel"]; ok {
+		t.Fatal("invalid CEL rule should not be programmed")
+	}
+	if _, ok := rbac.GetRules().GetPolicies()["good-inline"]; !ok {
+		t.Fatal("expected valid rule to be programmed")
+	}
+
+	msgs := coll.policyIssues()[types.NamespacedName{Namespace: "default", Name: "allow-partial"}]
+	if len(msgs) != 1 || !strings.Contains(msgs[0], `rule "bad-cel"`) {
+		t.Fatalf("expected skipped-rule issue for bad-cel, got %#v", msgs)
+	}
+}
+
+func TestTranslateAccessPolicyToRBAC_allRulesInvalidProducesNoAllowRules(t *testing.T) {
+	tr := &Translator{agenticIdentityTrustDomain: testTrustDomain}
+	spiffe := agenticv1alpha1.AuthorizationSourceSPIFFE("spiffe://cluster.local/ns/default/sa/tester")
+	policy := &agenticv1alpha1.XAccessPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "allow-all-invalid"},
+		Spec: agenticv1alpha1.AccessPolicySpec{
+			Action: agenticv1alpha1.ActionTypeAllow,
+			Rules: []agenticv1alpha1.AccessRule{
+				{
+					Name:   "only-rule",
+					Source: agenticv1alpha1.AccessRuleSource{Type: agenticv1alpha1.AuthorizationSourceTypeSPIFFE, SPIFFE: &spiffe},
+					Authorization: &agenticv1alpha1.AuthorizationRule{
+						Type: agenticv1alpha1.AuthorizationRuleTypeCEL,
+						CEL:  &agenticv1alpha1.AccessPolicyCELRule{Expression: "not valid"},
+					},
+				},
+			},
+		},
+	}
+
+	rbac := tr.translateAccessPolicyToRBAC(policy, newTranslationErrors())
+	if len(rbac.GetRules().GetPolicies()) != 0 {
+		t.Fatalf("expected no programmed allow rules, got %#v", rbac.GetRules().GetPolicies())
 	}
 }
 

--- a/pkg/translator/httproute.go
+++ b/pkg/translator/httproute.go
@@ -38,6 +38,7 @@ import (
 // It now correctly handles RequestHeaderModifier filters.
 func (t *Translator) translateHTTPRouteToEnvoyRoutes(
 	httpRoute *gatewayv1.HTTPRoute,
+	te *translationErrors,
 ) ([]*routev3.Route, []*routeBackend, metav1.Condition) {
 	var envoyRoutes []*routev3.Route
 	var allValidBackends []*routeBackend
@@ -101,6 +102,7 @@ func (t *Translator) translateHTTPRouteToEnvoyRoutes(
 				routeAction, validBackends, err := t.buildHTTPRouteAction(
 					httpRoute.Namespace,
 					rule.BackendRefs,
+					te,
 				)
 				var controllerErr *ControllerError
 				if errors.As(err, &controllerErr) {
@@ -262,6 +264,7 @@ func processRequestHeaderModifierFilter(f *gatewayv1.HTTPHeaderFilter) ([]*corev
 func (t *Translator) buildHTTPRouteAction(
 	namespace string,
 	backendRefs []gatewayv1.HTTPBackendRef,
+	te *translationErrors,
 ) (*routev3.RouteAction, []*routeBackend, error) {
 	weightedClusters := &routev3.WeightedCluster{}
 	var validBackends []*routeBackend
@@ -293,7 +296,7 @@ func (t *Translator) buildHTTPRouteAction(
 		}
 
 		if rb.XBackend() != nil {
-			clusterWeight.TypedPerFilterConfig, err = t.buildBackendLevelRBACOverrides(rb.XBackend())
+			clusterWeight.TypedPerFilterConfig, err = t.buildBackendLevelRBACOverrides(rb.XBackend(), te)
 			if err != nil {
 				klog.Errorf("Failed to build per-cluster RBAC config for backend %s: %v", rb.ClusterName(), err)
 			}

--- a/pkg/translator/listener.go
+++ b/pkg/translator/listener.go
@@ -38,6 +38,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
@@ -309,13 +310,101 @@ func (t *Translator) validateCACertificateRef(gateway *gatewayv1.Gateway, caRef 
 	return nil
 }
 
-func (t *Translator) translateListenerToFilterChain(lis gatewayv1.Listener, routeName string, gateway *gatewayv1.Gateway) (*listener.FilterChain, error) {
+// ListAccessPoliciesAttachedToGateway returns every XAccessPolicy that is attached to the Gateway
+// via a Gateway targetRef or an XBackend targetRef reachable from this Gateway's HTTPRoutes.
+//
+// When accessPolicyIndexer is set (controller wiring), this prefers informer indexes; if the indexer
+// is unset or any index lookup fails, it falls back to listing every XAccessPolicy and filtering with
+// isAccessPolicyAttachedToGateway.
+func (t *Translator) ListAccessPoliciesAttachedToGateway(gateway *gatewayv1.Gateway) ([]*v1alpha1.XAccessPolicy, error) {
+	// 1. Resolve attached AccessPolicies via informer indexes when available.
+	var policies []*v1alpha1.XAccessPolicy
+	fallbackToListingAllAccessPolicies := false
+	if t.accessPolicyIndexer != nil {
+		var err error
+		policies, err = t.listAccessPoliciesAttachedToGatewayIndexed(gateway)
+		if err != nil {
+			klog.Errorf("failed to get AccessPolicies by index: %v", err)
+			fallbackToListingAllAccessPolicies = true
+		}
+	} else {
+		fallbackToListingAllAccessPolicies = true
+	}
+
+	if fallbackToListingAllAccessPolicies {
+		// Fallback to listing all AccessPolicies.
+		return t.listAccessPoliciesAttachedToGatewaySlow(gateway)
+	}
+	return policies, nil
+}
+
+func (t *Translator) listAccessPoliciesAttachedToGatewaySlow(gateway *gatewayv1.Gateway) ([]*v1alpha1.XAccessPolicy, error) {
+	all, err := t.accessPolicyLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list AccessPolicies: %w", err)
+	}
+	var out []*v1alpha1.XAccessPolicy
+	for _, ap := range all {
+		if t.isAccessPolicyAttachedToGateway(ap, gateway) {
+			out = append(out, ap)
+		}
+	}
+	return out, nil
+}
+
+func (t *Translator) listAccessPoliciesAttachedToGatewayIndexed(gateway *gatewayv1.Gateway) ([]*v1alpha1.XAccessPolicy, error) {
+	seen := make(map[types.UID]struct{})
+	var out []*v1alpha1.XAccessPolicy
+
+	addFromIndex := func(indexName, key string) error {
+		objs, err := t.accessPolicyIndexer.ByIndex(indexName, key)
+		if err != nil {
+			return fmt.Errorf("AccessPolicy index %q key %q: %w", indexName, key, err)
+		}
+		for _, obj := range objs {
+			ap := obj.(*v1alpha1.XAccessPolicy)
+			if _, ok := seen[ap.UID]; ok {
+				continue
+			}
+			seen[ap.UID] = struct{}{}
+			out = append(out, ap)
+		}
+		return nil
+	}
+
+	gwKey := gateway.Namespace + "/" + gateway.Name
+	if err := addFromIndex(AccessPolicyGatewayTargetIndex, gwKey); err != nil {
+		return nil, err
+	}
+
+	routes := t.getHTTPRoutesForGateway(gateway)
+	for _, route := range routes {
+		for _, rule := range route.Spec.Rules {
+			for _, beRef := range rule.BackendRefs {
+				if beRef.Group == nil || *beRef.Group != v0alpha0.GroupName || beRef.Kind == nil || *beRef.Kind != "XBackend" {
+					continue
+				}
+				ns := route.Namespace
+				if beRef.Namespace != nil {
+					ns = string(*beRef.Namespace)
+				}
+				key := ns + "/" + string(beRef.Name)
+				if err := addFromIndex(AccessPolicyBackendTargetIndex, key); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	return out, nil
+}
+
+func (t *Translator) translateListenerToFilterChain(lis gatewayv1.Listener, routeName string, gateway *gatewayv1.Gateway, te *translationErrors) (*listener.FilterChain, error) {
 	var filterChain *listener.FilterChain
 	var err error
 
 	switch lis.Protocol {
 	case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType:
-		filterChain, err = t.buildHTTPFilterChain(lis, routeName, gateway)
+		filterChain, err = t.buildHTTPFilterChain(lis, routeName, gateway, te)
 	case gatewayv1.TCPProtocolType, gatewayv1.TLSProtocolType:
 		filterChain, err = buildTCPFilterChain(lis)
 	case gatewayv1.UDPProtocolType:
@@ -354,8 +443,8 @@ func (t *Translator) translateListenerToFilterChain(lis gatewayv1.Listener, rout
 
 // buildLocalReplyConfig constructs the local reply configuration for 403 responses
 
-func (t *Translator) buildHTTPFilterChain(lis gatewayv1.Listener, routeName string, gateway *gatewayv1.Gateway) (*listener.FilterChain, error) {
-	httpFilters, err := t.buildHTTPFilters(gateway)
+func (t *Translator) buildHTTPFilterChain(lis gatewayv1.Listener, routeName string, gateway *gatewayv1.Gateway, te *translationErrors) (*listener.FilterChain, error) {
+	httpFilters, err := t.buildHTTPFilters(gateway, te)
 	if err != nil {
 		return nil, err
 	}
@@ -433,7 +522,7 @@ func buildUDPFilterChain(lis gatewayv1.Listener) (*listener.FilterChain, error) 
 	}, nil
 }
 
-func (t *Translator) buildHTTPFilters(gateway *gatewayv1.Gateway) ([]*hcm.HttpFilter, error) {
+func (t *Translator) buildHTTPFilters(gateway *gatewayv1.Gateway, te *translationErrors) ([]*hcm.HttpFilter, error) {
 	// 1. Add MCP filter.
 	mcpFilter, err := buildMCPFilter()
 	if err != nil {
@@ -441,7 +530,7 @@ func (t *Translator) buildHTTPFilters(gateway *gatewayv1.Gateway) ([]*hcm.HttpFi
 	}
 
 	// 2. Add Gateway-level RBAC filters.
-	gatewayRBACFilters, err := t.buildGatewayLevelRBACFilters(gateway)
+	gatewayRBACFilters, err := t.buildGatewayLevelRBACFilters(gateway, te)
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +543,7 @@ func (t *Translator) buildHTTPFilters(gateway *gatewayv1.Gateway) ([]*hcm.HttpFi
 	}
 
 	// 4. Add ext_authz filters.
-	extAuthzFilters, err := t.buildExtAuthzFilters(gateway)
+	extAuthzFilters, err := t.buildExtAuthzFilters(gateway, te)
 	if err != nil {
 		return nil, err
 	}
@@ -511,7 +600,7 @@ func (t *Translator) buildHTTPFilters(gateway *gatewayv1.Gateway) ([]*hcm.HttpFi
 	return filters, nil
 }
 
-func (t *Translator) buildExtAuthzFilters(gateway *gatewayv1.Gateway) ([]*hcm.HttpFilter, error) {
+func (t *Translator) buildExtAuthzFilters(gateway *gatewayv1.Gateway, te *translationErrors) ([]*hcm.HttpFilter, error) {
 	var filters []*hcm.HttpFilter
 	uniqueExtAuthzConfigs := make(map[string]struct{})
 
@@ -533,16 +622,25 @@ func (t *Translator) buildExtAuthzFilters(gateway *gatewayv1.Gateway) ([]*hcm.Ht
 		}
 
 		if extAuthPolicy != nil {
+			apKey := types.NamespacedName{Namespace: extAuthPolicy.Namespace, Name: extAuthPolicy.Name}
 			extAuthz := extAuthPolicy.Spec.ExternalAuth
 			uniqueID, err := externalAuthUniqueID(extAuthz)
 			if err != nil {
-				return err
+				klog.Error(err)
+				if te != nil {
+					te.accessPolicyError(apKey, "", "cannot fingerprint external authorization config", err)
+				}
+				return nil
 			}
 			if _, exists := uniqueExtAuthzConfigs[uniqueID]; !exists {
 				uniqueExtAuthzConfigs[uniqueID] = struct{}{}
 				extAuthzFilter, err := buildExtAuthzFilterForRBACFilter(extAuthz, uniqueID, extAuthPolicy.GetNamespace())
 				if err != nil {
-					return err
+					klog.Error(err)
+					if te != nil {
+						te.accessPolicyError(apKey, "", "build external authorization filter", err)
+					}
+					return nil
 				}
 				filters = append(filters, extAuthzFilter)
 			}
@@ -580,6 +678,35 @@ func (t *Translator) buildExtAuthzFilters(gateway *gatewayv1.Gateway) ([]*hcm.Ht
 	}
 
 	return filters, nil
+}
+
+func (t *Translator) isAccessPolicyAttachedToGateway(ap *v1alpha1.XAccessPolicy, gateway *gatewayv1.Gateway) bool {
+	for _, targetRef := range ap.Spec.TargetRefs {
+		if (targetRef.Group == "" || targetRef.Group == gatewayv1.GroupName) && targetRef.Kind == "Gateway" && string(targetRef.Name) == gateway.Name {
+			return true
+		}
+	}
+	routes := t.getHTTPRoutesForGateway(gateway)
+	for _, targetRef := range ap.Spec.TargetRefs {
+		if targetRef.Group == v0alpha0.GroupName && targetRef.Kind == "XBackend" {
+			for _, route := range routes {
+				for _, rule := range route.Spec.Rules {
+					for _, beRef := range rule.BackendRefs {
+						if beRef.Group != nil && *beRef.Group == v0alpha0.GroupName && beRef.Kind != nil && *beRef.Kind == "XBackend" {
+							ns := route.Namespace
+							if beRef.Namespace != nil {
+								ns = string(*beRef.Namespace)
+							}
+							if ns == ap.Namespace && string(beRef.Name) == string(targetRef.Name) {
+								return true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
 }
 
 func buildExtAuthzFilterForRBACFilter(extAuthz *gatewayv1.HTTPExternalAuthFilter, extAuthzUniqueID, namespace string) (*hcm.HttpFilter, error) {
@@ -728,8 +855,17 @@ func buildDownstreamTLSContext(lis gatewayv1.Listener, gateway *gatewayv1.Gatewa
 	return anyObj, nil
 }
 
+// marshalExternalAuthForUniqueID is the JSON encoder used by externalAuthUniqueID. In normal
+// operation it is always [json.Marshal]. It exists as a package-level variable only so unit
+// tests can replace it to inject a marshal error (see
+// TestTranslateAccessPolicyToRBAC_recordsExternalAuthFingerprintFailure). Production code must
+// not assign to this. Test helpers that override it must restore the previous function (e.g. with
+// t.Cleanup) and must not use [testing.T.Parallel], because concurrent tests mutating this
+// variable would race.
+var marshalExternalAuthForUniqueID = json.Marshal
+
 func externalAuthUniqueID(externalAuth *gatewayv1.HTTPExternalAuthFilter) (string, error) {
-	j, err := json.Marshal(externalAuth)
+	j, err := marshalExternalAuthForUniqueID(externalAuth)
 	if err != nil {
 		return "", fmt.Errorf("Failed to marshal externalAuth config for unique ID generation: %v", err)
 	}

--- a/pkg/translator/listener_test.go
+++ b/pkg/translator/listener_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
@@ -225,11 +226,11 @@ func TestBuildDownstreamTLSContext(t *testing.T) {
 }
 
 func TestTranslateListenerToFilterChain(t *testing.T) {
-	agenticClient := agenticclient.NewSimpleClientset()
+	agenticClient := agenticclient.NewClientset()
 	agenticInformerFactory := agenticinformers.NewSharedInformerFactory(agenticClient, 0)
 	accessPolicyLister := agenticInformerFactory.Agentic().V1alpha1().XAccessPolicies().Lister()
 
-	gwClient := gatewayclient.NewSimpleClientset()
+	gwClient := gatewayclient.NewClientset()
 	gwInformerFactory := gatewayinformers.NewSharedInformerFactory(gwClient, 0)
 	httprouteLister := gwInformerFactory.Gateway().V1().HTTPRoutes().Lister()
 
@@ -283,7 +284,7 @@ func TestTranslateListenerToFilterChain(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fc, err := translator.translateListenerToFilterChain(tc.listener, "route-config", gw)
+			fc, err := translator.translateListenerToFilterChain(tc.listener, "route-config", gw, newTranslationErrors())
 			if err != nil {
 				t.Fatalf("failed to translate listener: %v", err)
 			}
@@ -472,7 +473,7 @@ func TestBuildHTTPFilters(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			agenticClient := agenticclient.NewSimpleClientset(tt.policies...)
+			agenticClient := agenticclient.NewClientset(tt.policies...)
 			agenticInformerFactory := agenticinformers.NewSharedInformerFactory(agenticClient, 0)
 			lister := agenticInformerFactory.Agentic().V1alpha1().XAccessPolicies().Lister()
 
@@ -485,7 +486,7 @@ func TestBuildHTTPFilters(t *testing.T) {
 			for i, r := range tt.routes {
 				gwObjs[i] = r
 			}
-			gwClient := gatewayclient.NewSimpleClientset(gwObjs...)
+			gwClient := gatewayclient.NewClientset(gwObjs...)
 			gwInformerFactory := gatewayinformers.NewSharedInformerFactory(gwClient, 0)
 			for _, r := range tt.routes {
 				_ = gwInformerFactory.Gateway().V1().HTTPRoutes().Informer().GetIndexer().Add(r)
@@ -497,7 +498,7 @@ func TestBuildHTTPFilters(t *testing.T) {
 			}
 			gw := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns}}
 
-			filters, err := tr.buildHTTPFilters(gw)
+			filters, err := tr.buildHTTPFilters(gw, newTranslationErrors())
 			if err != nil {
 				t.Fatalf("Failed to build filters: %v", err)
 			}
@@ -584,7 +585,7 @@ func TestBuildExtAuthzFiltersOldestFirst(t *testing.T) {
 	}
 	gw := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns}}
 
-	filters, err := tr.buildExtAuthzFilters(gw)
+	filters, err := tr.buildExtAuthzFilters(gw, nil)
 	if err != nil {
 		t.Fatalf("Failed to build filters: %v", err)
 	}
@@ -1227,5 +1228,52 @@ func TestValidateCACertificateRef(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBuildExtAuthzRecordsTranslationIssueForHTTPNonServiceBackend(t *testing.T) {
+	ns := "test-ns"
+	gwName := "test-gw"
+	kind := gatewayv1.Kind("XBackend")
+	p := newTestAccessPolicy("bad-http-ext", ns, gwName, "Gateway", "spiffe://cluster.local/ns/ns1/sa/sa1")
+	p.Spec.Action = agenticv1alpha1.ActionTypeExternalAuth
+	p.Spec.ExternalAuth = &gatewayv1.HTTPExternalAuthFilter{
+		ExternalAuthProtocol: gatewayv1.HTTPRouteExternalAuthHTTPProtocol,
+		HTTPAuthConfig:       &gatewayv1.HTTPAuthConfig{Path: "/check"},
+		BackendRef: gatewayv1.BackendObjectReference{
+			Name: "auth",
+			Kind: &kind,
+		},
+	}
+
+	agenticClient := agenticclient.NewClientset(p)
+	agenticInformerFactory := agenticinformers.NewSharedInformerFactory(agenticClient, 0)
+	_ = agenticInformerFactory.Agentic().V1alpha1().XAccessPolicies().Informer().GetIndexer().Add(p)
+	lister := agenticInformerFactory.Agentic().V1alpha1().XAccessPolicies().Lister()
+
+	gwClient := gatewayclient.NewClientset()
+	gwInformerFactory := gatewayinformers.NewSharedInformerFactory(gwClient, 0)
+	tr := &Translator{
+		accessPolicyLister: lister,
+		httprouteLister:    gwInformerFactory.Gateway().V1().HTTPRoutes().Lister(),
+	}
+	gw := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns}}
+
+	coll := newTranslationErrors()
+	_, err := tr.buildExtAuthzFilters(gw, coll)
+	if err != nil {
+		t.Fatalf("buildExtAuthzFilters: %v", err)
+	}
+	snap := coll.policyIssues()
+	nn := types.NamespacedName{Namespace: ns, Name: "bad-http-ext"}
+	msgs, ok := snap[nn]
+	if !ok || len(msgs) == 0 {
+		t.Fatalf("expected translation issue for policy %v, got %#v", nn, snap)
+	}
+	if !strings.Contains(msgs[0], "build external authorization filter") {
+		t.Errorf("expected build error in message: %q", msgs[0])
+	}
+	if !strings.Contains(msgs[0], "XBackend") {
+		t.Errorf("expected unsupported backend kind in message: %q", msgs[0])
 	}
 }

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	discoverylisters "k8s.io/client-go/listers/discovery/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	corev1 "k8s.io/api/core/v1"
@@ -61,6 +62,52 @@ func (e *ControllerError) Error() string {
 	return e.Message
 }
 
+// translationErrors accumulates non-fatal semantic issues during one Gateway translation run.
+// Fields group issues by resource kind so callers can update status selectively; additional maps
+// can be added when other resources need translation feedback without threading new parameters.
+//
+// XAccessPolicy issues are stored as Go errors (preserving wrap chains); policyIssues() converts
+// them to strings for Gateway API condition messages.
+type translationErrors struct {
+	policyErrs map[types.NamespacedName][]error
+}
+
+func newTranslationErrors() *translationErrors {
+	return &translationErrors{policyErrs: make(map[types.NamespacedName][]error)}
+}
+
+// accessPolicyError attaches a short description and wraps err for one XAccessPolicy issue.
+// ruleName is optional; when set, the formatted error begins with rule "<ruleName>": ...
+func (e *translationErrors) accessPolicyError(nn types.NamespacedName, ruleName, desc string, err error) {
+	if e == nil || err == nil {
+		return
+	}
+	var combined error
+	if ruleName != "" {
+		combined = fmt.Errorf("rule %q: %s: %w", ruleName, desc, err)
+	} else {
+		combined = fmt.Errorf("%s: %w", desc, err)
+	}
+	e.policyErrs[nn] = append(e.policyErrs[nn], combined)
+}
+
+func (e *translationErrors) policyIssues() map[types.NamespacedName][]string {
+	if e == nil {
+		return nil
+	}
+	out := make(map[types.NamespacedName][]string, len(e.policyErrs))
+	for k, errs := range e.policyErrs {
+		ss := make([]string, 0, len(errs))
+		for _, err := range errs {
+			if err != nil {
+				ss = append(ss, err.Error())
+			}
+		}
+		out[k] = ss
+	}
+	return out
+}
+
 // Translator holds the xDS cache and version for generating snapshots.
 type Translator struct {
 	agenticIdentityTrustDomain string
@@ -75,6 +122,7 @@ type Translator struct {
 	httprouteLister            gatewaylisters.HTTPRouteLister
 	referenceGrantLister       gatewaylistersv1beta1.ReferenceGrantLister // optional, for Service ref cross-namespace validation
 	accessPolicyLister         agenticlistersv1alpha1.XAccessPolicyLister
+	accessPolicyIndexer        cache.Indexer // optional; enables indexed attachment queries instead of listing all policies
 	backendLister              agenticlisters.XBackendLister
 }
 
@@ -91,6 +139,7 @@ func New(
 	httpRouteLister gatewaylisters.HTTPRouteLister,
 	referenceGrantLister gatewaylistersv1beta1.ReferenceGrantLister,
 	accessPolicyLister agenticlistersv1alpha1.XAccessPolicyLister,
+	accessPolicyIndexer cache.Indexer,
 	backendLister agenticlisters.XBackendLister,
 ) *Translator {
 	return &Translator{
@@ -106,19 +155,28 @@ func New(
 		httpRouteLister,
 		referenceGrantLister,
 		accessPolicyLister,
+		accessPolicyIndexer,
 		backendLister,
 	}
 }
 
 // TranslateGatewayToXDS translates Gateway and HTTPRoute resources into Envoy xDS resources.
-func (t *Translator) TranslateGatewayToXDS(_ context.Context, gw *gatewayv1.Gateway) (map[resourcev3.Type][]envoyproxytypes.Resource, []gatewayv1.ListenerStatus, map[types.NamespacedName][]gatewayv1.RouteParentStatus, map[types.NamespacedName][]gatewayv1.RouteParentStatus, error) {
-	// Get the desired state
-	envoyResources, listenerStatuses, httpRouteStatuses, grpcRouteStatuses, err := t.buildEnvoyResourcesForGateway(gw)
+// The returned map keys XAccessPolicies that had rules skipped or only partially translated;
+// values are human-readable failure messages for status updates.
+func (t *Translator) TranslateGatewayToXDS(_ context.Context, gw *gatewayv1.Gateway) (
+	map[resourcev3.Type][]envoyproxytypes.Resource,
+	[]gatewayv1.ListenerStatus,
+	map[types.NamespacedName][]gatewayv1.RouteParentStatus,
+	map[types.NamespacedName][]gatewayv1.RouteParentStatus,
+	map[types.NamespacedName][]string,
+	error,
+) {
+	envoyResources, listenerStatuses, httpRouteStatuses, grpcRouteStatuses, policyIssues, err := t.buildEnvoyResourcesForGateway(gw)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 
-	return envoyResources, listenerStatuses, httpRouteStatuses, grpcRouteStatuses, nil
+	return envoyResources, listenerStatuses, httpRouteStatuses, grpcRouteStatuses, policyIssues, nil
 }
 
 var SupportedKinds = sets.New[gatewayv1.Kind](
@@ -133,8 +191,10 @@ func (t *Translator) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 	[]gatewayv1.ListenerStatus,
 	map[types.NamespacedName][]gatewayv1.RouteParentStatus, // HTTPRoutes
 	map[types.NamespacedName][]gatewayv1.RouteParentStatus, // GRPCRoutes
+	map[types.NamespacedName][]string, // XAccessPolicy translation issues
 	error,
 ) {
+	te := newTranslationErrors()
 	routesByListener, httpRouteStatuses := t.HTTPRoutesAndStatuses(gateway)
 
 	// Start building Envoy config using only the pre-validated and accepted routes
@@ -224,7 +284,7 @@ func (t *Translator) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 				// (and optionally XAccessPolicy) exists but no HTTPRoute routes traffic to it, no cluster
 				// or RBAC config is generated for that backend.
 				for _, httpRoute := range routesByListener[listener.Name] {
-					routes, allValidBackends, resolvedRefsCondition := t.translateHTTPRouteToEnvoyRoutes(httpRoute)
+					routes, allValidBackends, resolvedRefsCondition := t.translateHTTPRouteToEnvoyRoutes(httpRoute, te)
 
 					key := types.NamespacedName{Name: httpRoute.Name, Namespace: httpRoute.Namespace}
 					currentParentStatuses := httpRouteStatuses[key]
@@ -238,7 +298,7 @@ func (t *Translator) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 
 					clusters, err := t.buildClustersFromRouteBackends(allValidBackends)
 					if err != nil {
-						return nil, nil, nil, nil, fmt.Errorf("failed to build clusters from HTTPRoute %s/%s: %w", httpRoute.Namespace, httpRoute.Name, err)
+						return nil, nil, nil, nil, nil, fmt.Errorf("failed to build clusters from HTTPRoute %s/%s: %w", httpRoute.Namespace, httpRoute.Name, err)
 					}
 					for _, cluster := range clusters {
 						envoyClusters[cluster.GetName()] = cluster
@@ -276,7 +336,7 @@ func (t *Translator) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 			}
 
 			// 8. translate listener into a filter chain (HTTP connection manager that references route config 'route-<port>')
-			filterChain, err := t.translateListenerToFilterChain(listener, routeName, gateway)
+			filterChain, err := t.translateListenerToFilterChain(listener, routeName, gateway, te)
 			switch {
 			case err != nil:
 				meta.SetStatusCondition(&listenerStatus.Conditions, metav1.Condition{
@@ -347,7 +407,7 @@ func (t *Translator) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 			// For HTTPS, we create one filter chain per listener because they have unique
 			// SNI matches and TLS settings.
 			if listeners[0].Protocol == gatewayv1.HTTPProtocolType {
-				filterChain, _ := t.translateListenerToFilterChain(listeners[0], routeName, gateway)
+				filterChain, _ := t.translateListenerToFilterChain(listeners[0], routeName, gateway, te)
 				envoyListener.FilterChains = []*listenerv3.FilterChain{filterChain}
 			}
 			finalEnvoyListeners = append(finalEnvoyListeners, envoyListener)
@@ -372,7 +432,7 @@ func (t *Translator) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 			resourcev3.ClusterType:  clustersSlice,
 			resourcev3.SecretType:   envoySecrets,
 		}, orderedStatuses,
-		httpRouteStatuses, nil, nil
+		httpRouteStatuses, nil, te.policyIssues(), nil
 }
 
 func (t *Translator) HTTPRoutesAndStatuses(gateway *gatewayv1.Gateway) (

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -18,6 +18,7 @@ package translator
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -750,8 +751,7 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 			for _, p := range tc.policies {
 				agenticObjs = append(agenticObjs, p)
 			}
-			//nolint:staticcheck // generated clientset doesn't have NewClientset without applyconfig
-			agenticClient := agenticclient.NewSimpleClientset(agenticObjs...)
+			agenticClient := agenticclient.NewClientset(agenticObjs...)
 
 			gwInformerFactory := gatewayinformers.NewSharedInformerFactory(gwClient, 0)
 			agenticInformerFactory := agenticinformers.NewSharedInformerFactory(agenticClient, 0)
@@ -770,6 +770,7 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 				gwInformerFactory.Gateway().V1().HTTPRoutes().Lister(),
 				nil, // referenceGrantLister
 				agenticInformerFactory.Agentic().V1alpha1().XAccessPolicies().Lister(),
+				nil, // accessPolicyIndexer (tests use slow attachment path)
 				agenticInformerFactory.Agentic().V0alpha0().XBackends().Lister(),
 			)
 
@@ -799,7 +800,7 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 			}
 
 			// Run Translation
-			resources, listenerStatuses, httpRouteStatuses, _, err := tr.TranslateGatewayToXDS(ctx, tc.gw)
+			resources, listenerStatuses, httpRouteStatuses, _, _, err := tr.TranslateGatewayToXDS(ctx, tc.gw)
 			if err != nil {
 				t.Fatalf("Translation failed: %v", err)
 			}
@@ -1086,5 +1087,75 @@ func checkListenerRBAC(t *testing.T, lis *listenerv3.Listener, expectedGWPrincip
 				}
 			}
 		}
+	}
+}
+
+func TestTranslateGatewayToXDS_AccessPolicyTranslationIssues(t *testing.T) {
+	ctx := context.Background()
+	ns := "quickstart-ns"
+	trustDomain := "cluster.local"
+	gw := newTestGateway("agentic-net-gateway", ns, nil, nil)
+	backend := newTestBackend("local-mcp-backend", ns)
+	route := newTestHTTPRoute("httproute-local-mcp", ns, "agentic-net-gateway", "local-mcp-backend")
+	mcpSvc := newTestService("local-mcp-backend-svc", ns, 3001)
+
+	principal := "spiffe://cluster.local/ns/quickstart-ns/sa/adk-agent-sa"
+	inlinePol := newTestAccessPolicy("auth-policy-local-mcp", ns, "local-mcp-backend", "XBackend", principal)
+
+	kind := gatewayv1.Kind("XBackend")
+	badExtPol := newTestAccessPolicy("bad-ext-pol", ns, "agentic-net-gateway", "Gateway", principal)
+	badExtPol.Spec.Action = agenticv1alpha1.ActionTypeExternalAuth
+	badExtPol.Spec.ExternalAuth = &gatewayv1.HTTPExternalAuthFilter{
+		ExternalAuthProtocol: gatewayv1.HTTPRouteExternalAuthHTTPProtocol,
+		HTTPAuthConfig:       &gatewayv1.HTTPAuthConfig{Path: "/check"},
+		BackendRef: gatewayv1.BackendObjectReference{
+			Name: "auth",
+			Kind: &kind,
+		},
+	}
+
+	k8sClient := fake.NewClientset(mcpSvc)
+	gwClient := gatewayclient.NewClientset(gw, route)
+	agenticClient := agenticclient.NewClientset(backend, inlinePol, badExtPol)
+
+	gwInformerFactory := gatewayinformers.NewSharedInformerFactory(gwClient, 0)
+	agenticInformerFactory := agenticinformers.NewSharedInformerFactory(agenticClient, 0)
+	coreInformerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+
+	tr := New(
+		trustDomain,
+		k8sClient,
+		gwClient,
+		coreInformerFactory.Core().V1().Namespaces().Lister(),
+		coreInformerFactory.Core().V1().Services().Lister(),
+		coreInformerFactory.Discovery().V1().EndpointSlices().Lister(),
+		coreInformerFactory.Core().V1().Secrets().Lister(),
+		coreInformerFactory.Core().V1().ConfigMaps().Lister(),
+		gwInformerFactory.Gateway().V1().Gateways().Lister(),
+		gwInformerFactory.Gateway().V1().HTTPRoutes().Lister(),
+		nil,
+		agenticInformerFactory.Agentic().V1alpha1().XAccessPolicies().Lister(),
+		nil,
+		agenticInformerFactory.Agentic().V0alpha0().XBackends().Lister(),
+	)
+
+	_ = coreInformerFactory.Core().V1().Services().Informer().GetIndexer().Add(mcpSvc)
+	_ = gwInformerFactory.Gateway().V1().Gateways().Informer().GetIndexer().Add(gw)
+	_ = gwInformerFactory.Gateway().V1().HTTPRoutes().Informer().GetIndexer().Add(route)
+	_ = agenticInformerFactory.Agentic().V0alpha0().XBackends().Informer().GetIndexer().Add(backend)
+	_ = agenticInformerFactory.Agentic().V1alpha1().XAccessPolicies().Informer().GetIndexer().Add(inlinePol)
+	_ = agenticInformerFactory.Agentic().V1alpha1().XAccessPolicies().Informer().GetIndexer().Add(badExtPol)
+
+	_, _, _, _, issues, err := tr.TranslateGatewayToXDS(ctx, gw)
+	if err != nil {
+		t.Fatalf("TranslateGatewayToXDS: %v", err)
+	}
+	key := types.NamespacedName{Namespace: ns, Name: "bad-ext-pol"}
+	msgs, ok := issues[key]
+	if !ok || len(msgs) == 0 {
+		t.Fatalf("expected translation issues for %v, got %#v", key, issues)
+	}
+	if !strings.Contains(strings.Join(msgs, " "), "build external authorization filter") {
+		t.Errorf("expected build error in issue messages: %v", msgs)
 	}
 }

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -809,6 +809,84 @@ func retry(attempts int, sleep time.Duration, f func() error) error {
 	return fmt.Errorf("after %d attempts, last error: %w", attempts, lastErr)
 }
 
+// waitForGatewayProgrammed blocks until the Gateway status reflects the latest spec generation
+// and the https-listener is programmed. TLS subtests must call this after patching Gateway TLS
+// so Envoy receives the updated client-validation configuration before MCP initialization.
+func waitForGatewayProgrammed(t *testing.T, namespace string) {
+	t.Helper()
+	err := retry(30, 2*time.Second, func() error {
+		genOut, err := runKubectlOutput(t, "get", "gateway", "e2e-gateway", "-n", namespace, "-o", "jsonpath={.metadata.generation}")
+		if err != nil {
+			return err
+		}
+		generation := strings.TrimSpace(genOut)
+		if generation == "" {
+			return fmt.Errorf("gateway generation not found")
+		}
+
+		progOut, err := runKubectlOutput(t, "get", "gateway", "e2e-gateway", "-n", namespace,
+			"-o", `jsonpath={.status.conditions[?(@.type=="Programmed")].status}{"\n"}{.status.conditions[?(@.type=="Programmed")].observedGeneration}`)
+		if err != nil {
+			return err
+		}
+		lines := strings.Split(strings.TrimSpace(progOut), "\n")
+		if len(lines) < 2 || lines[0] != "True" {
+			return fmt.Errorf("gateway Programmed status not True yet: %q", progOut)
+		}
+		if lines[1] != generation {
+			return fmt.Errorf("gateway observedGeneration=%q, want %q", lines[1], generation)
+		}
+
+		listenerProgOut, err := runKubectlOutput(t, "get", "gateway", "e2e-gateway", "-n", namespace,
+			"-o", `jsonpath={.status.listeners[?(@.name=="https-listener")].conditions[?(@.type=="Programmed")].status}`)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(listenerProgOut) != "True" {
+			return fmt.Errorf("https-listener Programmed status not True yet: %q", listenerProgOut)
+		}
+
+		resolvedOut, err := runKubectlOutput(t, "get", "gateway", "e2e-gateway", "-n", namespace,
+			"-o", `jsonpath={.status.listeners[?(@.name=="https-listener")].conditions[?(@.type=="ResolvedRefs")].status}`)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(resolvedOut) != "True" {
+			return fmt.Errorf("https-listener ResolvedRefs status not True yet: %q", resolvedOut)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Gateway did not become programmed in namespace %s: %v", namespace, err)
+	}
+}
+
+// restartGatewayEnvoyProxy rolls the gateway's Envoy deployment so downstream TLS context
+// changes (e.g. SPIFFE trust -> explicit CACertificateRefs) are picked up cleanly.
+func restartGatewayEnvoyProxy(t *testing.T, namespace string) {
+	t.Helper()
+	label := fmt.Sprintf("%s=e2e-gateway", constants.GatewayNameLabel)
+	runKubectl(t, "rollout", "restart", "deployment", "-n", namespace, "-l", label)
+	runKubectl(t, "rollout", "status", "deployment", "-n", namespace, "-l", label, "--timeout=5m")
+	err := retry(20, 5*time.Second, func() error {
+		out, err := runKubectlOutput(t, "get", "pods", "-n", namespace, "-l", label,
+			"-o", `jsonpath={.items[*].status.conditions[?(@.type=="Ready")].status}`)
+		if err != nil {
+			return err
+		}
+		for _, status := range strings.Fields(out) {
+			if status != "True" {
+				return fmt.Errorf("envoy proxy pod not ready: %q", out)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Envoy proxy did not become ready after restart in namespace %s: %v", namespace, err)
+	}
+}
+
 type mcpTestSession struct {
 	t         *testing.T
 	gatewayIP string
@@ -836,7 +914,7 @@ func tryInitializeMCPWithCerts(t *testing.T, gatewayIP string, pod types.Namespa
 	t.Logf("Initialize MCP session for pod %s at %s", pod, mcpPath)
 
 	mcpSessionID := ""
-	err := retry(5, 10*time.Second, func() error {
+	err := retry(10, 10*time.Second, func() error {
 		out, err := execMCPCurl(t, gatewayIP, pod, mcpPath, certPath, keyPath, caPath)
 		if err != nil {
 			return err
@@ -1193,6 +1271,7 @@ func TestGatewayTLS(t *testing.T) {
 		// Test case 1: client cert signed by trusted CA without gateway CA configuration (should succeed)
 		applyToNamespace(t, "testdata/gateway-no-ca.yaml", namespace)
 		applyToNamespace(t, "testdata/gateway-policy.yaml", namespace)
+		waitForGatewayProgrammed(t, namespace)
 
 		// Write files to pod
 		writePodFile(t, namespace, podName, testClientCertPath, clientCertDefault)
@@ -1236,10 +1315,24 @@ func TestGatewayTLS(t *testing.T) {
 	t.Run("TrustedCA_WithGatewayCA", func(t *testing.T) {
 		// Test case 2: Client cert signed by trusted CA with gateway CA configuration (should succeed)
 		applyToNamespace(t, "testdata/gateway-tls.yaml", namespace)
+		applyToNamespace(t, "testdata/gateway-policy.yaml", namespace)
+		waitForGatewayProgrammed(t, namespace)
+		restartGatewayEnvoyProxy(t, namespace)
+		waitForGatewayProgrammed(t, namespace)
 
-		// Override certs in the pod
-		writePodFile(t, namespace, podName, testClientCertPath, clientCert1)
+		caRefOut, err := runKubectlOutput(t, "get", "gateway", "e2e-gateway", "-n", namespace,
+			"-o", "jsonpath={.spec.tls.frontend.default.validation.caCertificateRefs[0].name}")
+		if err != nil {
+			t.Fatalf("failed to read gateway CA reference: %v", err)
+		}
+		if strings.TrimSpace(caRefOut) != "gateway-client-ca" {
+			t.Fatalf("gateway frontend CA reference not applied (got %q, want gateway-client-ca)", caRefOut)
+		}
+
+		// Override certs in the pod to match the gateway-configured client CA.
+		writePodFile(t, namespace, podName, testClientCertPath, appendPEMs(clientCert1, caCertPEM1))
 		writePodFile(t, namespace, podName, testClientKeyPath, clientKey1)
+		writePodFile(t, namespace, podName, testClientCAPath, caCertPEM1)
 
 		mcp := initializeMCPWithCerts(t, gatewayIP, types.NamespacedName{Namespace: namespace, Name: podName}, defaultMCPPath,
 			testClientCertPath, testClientKeyPath, testClientCAPath)
@@ -1329,4 +1422,12 @@ func writePodFile(t *testing.T, namespace, podName, filePath string, content []b
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to write file %s to pod %s: %v\nStderr: %s", filePath, podName, err, stderr.String())
 	}
+}
+
+func appendPEMs(parts ...[]byte) []byte {
+	var out []byte
+	for _, part := range parts {
+		out = append(out, part...)
+	}
+	return out
 }

--- a/tests/e2e/tls_helpers.go
+++ b/tests/e2e/tls_helpers.go
@@ -18,10 +18,8 @@ package e2e
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/ed25519"
-	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -37,14 +35,53 @@ import (
 	"sigs.k8s.io/kube-agentic-networking/pkg/infra/agentidentity/localca"
 )
 
-// generateCA creates a new CA for testing.
+// generateCA creates a new RSA CA for testing. RSA is used instead of Ed25519 so the custom
+// gateway CA validation path exercised by TestGatewayTLS is compatible with Envoy and curl.
 func generateCA(caID string) (*localca.CA, error) {
-	return localca.GenerateED25519CA(caID)
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate CA key: %w", err)
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(365 * 24 * time.Hour)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	rootTemplate := &x509.Certificate{
+		SerialNumber:          serialNumber,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		Subject:               pkix.Name{CommonName: caID},
+	}
+
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTemplate, rootTemplate, &key.PublicKey, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CA certificate: %w", err)
+	}
+
+	rootCert, err := x509.ParseCertificate(rootDER)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CA certificate: %w", err)
+	}
+
+	return &localca.CA{
+		ID:              caID,
+		SigningKey:      key,
+		RootCertificate: rootCert,
+	}, nil
 }
 
 // generateServerCert generates a server leaf certificate signed by the provided CA.
 func generateServerCert(ca *localca.CA, dnsNames []string) (certPEM, keyPEM []byte, err error) {
-	serverPubKey, serverPrivKey, err := ed25519.GenerateKey(rand.Reader)
+	serverPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate server key: %w", err)
 	}
@@ -70,7 +107,7 @@ func generateServerCert(ca *localca.CA, dnsNames []string) (certPEM, keyPEM []by
 		DNSNames:              dnsNames,
 	}
 
-	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, ca.RootCertificate, serverPubKey, ca.SigningKey)
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, ca.RootCertificate, &serverPrivKey.PublicKey, ca.SigningKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create server certificate: %w", err)
 	}
@@ -87,12 +124,13 @@ func generateServerCert(ca *localca.CA, dnsNames []string) (certPEM, keyPEM []by
 }
 
 // generateClientCert generates a client certificate signed by the provided CA.
+// RSA keys are used so custom gateway CA validation (ADS trust context) matches
+// server/CA PKI and works reliably with Envoy and curl in e2e.
 func generateClientCert(ca *localca.CA, spiffeID string) (certPEM, keyPEM []byte, err error) {
-	clientPrivKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	clientPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate client key: %w", err)
 	}
-	clientPubKey := &clientPrivKey.PublicKey
 
 	notBefore := time.Now()
 	notAfter := notBefore.Add(365 * 24 * time.Hour)
@@ -120,15 +158,12 @@ func generateClientCert(ca *localca.CA, spiffeID string) (certPEM, keyPEM []byte
 		URIs:                  []*url.URL{uri},
 	}
 
-	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, ca.RootCertificate, clientPubKey, ca.SigningKey)
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, ca.RootCertificate, &clientPrivKey.PublicKey, ca.SigningKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create client certificate: %w", err)
 	}
 
 	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER})
-	// Append CA cert to client cert chain
-	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.RootCertificate.Raw})
-	certPEM = append(certPEM, caCertPEM...)
 
 	privKeyBytes, err := x509.MarshalPKCS8PrivateKey(clientPrivKey)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR implements [[translation feedback]](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/233) so the controller no longer leaves XAccessPolicy in a misleading Accepted: True state when the translator skips or only partially applies rules that still pass API validation.
Today, failures such as HTTP ExternalAuth with a non-Service backend or externalAuthUniqueID errors are only logged; Envoy may omit behaviour while status still looks healthy. [Issue #233](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/233) asks for Gateway API–style policy conditions: Accepted: False with reason Invalid (PolicyReasonInvalid).

**Which issue(s) this PR fixes**:
Fixes #233 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
