### PR TITLE
implement logic OR for access policies with the same target

### DIFF
--- a/pkg/translator/accesspolicy.go
+++ b/pkg/translator/accesspolicy.go
@@ -68,15 +68,16 @@ func (t *Translator) buildGatewayLevelRBACFilters(gateway *gatewayv1.Gateway) ([
 		return nil, fmt.Errorf("failed to find Gateway access policies: %w", err)
 	}
 	var filters []*hcm.HttpFilter
-	for i, policy := range gwPolicies {
-		// Build the RBAC config for this policy
-		rbacProto := t.buildRBACConfigWithCommonPolicies(policy)
-		rbacAny, err := anypb.New(rbacProto)
+
+	rbacConfigs := t.buildRBACConfigsForPolicies(gwPolicies)
+
+	for _, rbacConfig := range rbacConfigs {
+		rbacAny, err := anypb.New(rbacConfig)
 		if err != nil {
 			return nil, err
 		}
 		filters = append(filters, &hcm.HttpFilter{
-			Name: fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, i+1),
+			Name: fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, len(filters)+1),
 			ConfigType: &hcm.HttpFilter_TypedConfig{
 				TypedConfig: rbacAny,
 			},
@@ -84,6 +85,82 @@ func (t *Translator) buildGatewayLevelRBACFilters(gateway *gatewayv1.Gateway) ([
 	}
 
 	return filters, nil
+}
+
+// buildRBACConfigsForPolicies creates RBAC configs for merged InlineTools and individual ExternalAuth rules.
+func (t *Translator) buildRBACConfigsForPolicies(policies []*agenticv0alpha0.XAccessPolicy) []*rbacv3.RBAC {
+	mergedInlineToolsRBAC := &rbacv3.RBAC{
+		Rules: &rbacconfigv3.RBAC{
+			Action:   rbacconfigv3.RBAC_ALLOW,
+			Policies: map[string]*rbacconfigv3.Policy{},
+		},
+	}
+	hasInlineToolsRules := false
+
+	var extAuthConfigs []*rbacv3.RBAC
+
+	for _, policy := range policies {
+		var extAuthRBAC *rbacv3.RBAC
+		hasExtAuthInThisPolicy := false
+
+		for _, rule := range policy.Spec.Rules {
+			rbacPolicy, isExternalAuth, extAuthStatPrefix, err := t.translateAccessRuleToRBACPolicy(policy.Namespace, rule)
+			if err != nil {
+				klog.Errorf("Failed to translate access rule %s in policy %s/%s: %v", rule.Name, policy.Namespace, policy.Name, err)
+				continue
+			}
+
+			if isExternalAuth {
+				hasExtAuthInThisPolicy = true
+				if extAuthRBAC == nil {
+					extAuthRBAC = &rbacv3.RBAC{
+						ShadowRules: &rbacconfigv3.RBAC{
+							Action:   rbacconfigv3.RBAC_DENY,
+							Policies: map[string]*rbacconfigv3.Policy{},
+						},
+						ShadowRulesStatPrefix: extAuthStatPrefix,
+						Rules: &rbacconfigv3.RBAC{
+							Action:   rbacconfigv3.RBAC_ALLOW,
+							Policies: map[string]*rbacconfigv3.Policy{},
+						},
+					}
+				}
+				extAuthRBAC.ShadowRules.Policies[rule.Name] = rbacPolicy
+				extAuthRBAC.Rules.Policies[rule.Name] = rbacPolicy
+			} else {
+				// InlineTools rule
+				prefixedName := fmt.Sprintf("%s.%s.%s", policy.Namespace, policy.Name, rule.Name)
+				mergedInlineToolsRBAC.Rules.Policies[prefixedName] = rbacPolicy
+				hasInlineToolsRules = true
+			}
+		}
+
+		if hasExtAuthInThisPolicy {
+			// Add common policies to this filter
+			t.addCommonPoliciesToRBAC(extAuthRBAC)
+			extAuthConfigs = append(extAuthConfigs, extAuthRBAC)
+		}
+	}
+
+	// Inject merged InlineTools rules into ExternalAuth filters
+	if len(extAuthConfigs) > 0 && hasInlineToolsRules {
+		for _, extAuthRBAC := range extAuthConfigs {
+			for ruleName, routePolicy := range mergedInlineToolsRBAC.GetRules().GetPolicies() {
+				extAuthRBAC.Rules.Policies[ruleName] = routePolicy
+			}
+		}
+	}
+
+	// Return logic to avoid redundant filters
+	var result []*rbacv3.RBAC
+	if len(extAuthConfigs) > 0 {
+		result = extAuthConfigs
+	} else if hasInlineToolsRules {
+		t.addCommonPoliciesToRBAC(mergedInlineToolsRBAC)
+		result = []*rbacv3.RBAC{mergedInlineToolsRBAC}
+	}
+
+	return result
 }
 
 // buildBackendLevelRBACFilters creates placeholder RBAC filters for backends.
@@ -132,14 +209,39 @@ func (t *Translator) calculateMaxBackendRBACFilters(gateway *gatewayv1.Gateway) 
 
 	maxCount := 0
 
-	// 3. For each backend, count its accepted policies.
+	// 3. For each backend, count its needed filters after merging.
 	for beKey := range backendNames {
 		policies, err := t.findAccessPoliciesForTarget(agenticv0alpha0.GroupName, "XBackend", beKey.Namespace, beKey.Name)
 		if err != nil {
 			klog.Errorf("Failed to count policies for backend %s: %v", beKey, err)
 			continue
 		}
-		count := len(policies)
+
+		hasInlineTools := false
+		extAuthCount := 0
+
+		for _, policy := range policies {
+			hasPolicyExtAuth := false
+
+			for _, rule := range policy.Spec.Rules {
+				if rule.Authorization != nil && rule.Authorization.Type == agenticv0alpha0.AuthorizationRuleTypeExternalAuth {
+					hasPolicyExtAuth = true
+				} else {
+					hasInlineTools = true
+				}
+			}
+			// only increase the count by 1 for each policy that contains ExternalAuth,
+			// as all rules of this type in a policy are handled by a single filter.
+			if hasPolicyExtAuth {
+				extAuthCount++
+			}
+		}
+
+		count := extAuthCount
+		if count == 0 && hasInlineTools {
+			count = 1
+		}
+
 		if count > maxCount {
 			maxCount = count
 		}
@@ -158,21 +260,17 @@ func (t *Translator) buildBackendLevelRBACOverrides(backend *agenticv0alpha0.XBa
 		return nil, err
 	}
 
-	for i, policy := range backendPolicies {
-		// Envoy's per-cluster configuration requires an RBACPerRoute message containing
-		// RBAC rules derived from AccessPolicy resources targeting this backend.
-		rbacConfig := t.buildRBACConfigWithCommonPolicies(policy)
+	rbacConfigs := t.buildRBACConfigsForPolicies(backendPolicies)
+
+	for _, rbacConfig := range rbacConfigs {
 		rbacPerRouteProto := &rbacv3.RBACPerRoute{
 			Rbac: rbacConfig,
 		}
-
-		// Marshal the RBAC config into an Any proto.
 		rbacAny, err := anypb.New(rbacPerRouteProto)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal RBACPerRoute proto: %w", err)
+			return nil, err
 		}
-
-		filterName := fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, i+1)
+		filterName := fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, len(perFilterConfig)+1)
 		perFilterConfig[filterName] = rbacAny
 	}
 
@@ -185,12 +283,16 @@ func (t *Translator) buildRBACConfigWithCommonPolicies(accessPolicy *agenticv0al
 	rbacConfig := t.translateAccessPolicyToRBAC(accessPolicy)
 
 	// Add common policies to avoid blocking basic MCP operations.
-	// These are added to the 'Rules' section which is where allowed traffic is defined.
+	t.addCommonPoliciesToRBAC(rbacConfig)
+
+	return rbacConfig
+}
+
+// addCommonPoliciesToRBAC adds the common policies needed for MCP session management to the RBAC config.
+func (t *Translator) addCommonPoliciesToRBAC(rbacConfig *rbacv3.RBAC) {
 	addPolicyToRBACRules(rbacConfig, allowMCPSessionClosePolicyName, buildAllowMCPSessionClosePolicy())
 	addPolicyToRBACRules(rbacConfig, allowAnyoneToInitializeAndListToolsPolicyName, buildAllowAnyoneToInitializeAndListToolsPolicy())
 	addPolicyToRBACRules(rbacConfig, allowHTTPGet, buildAllowHTTPGetPolicy())
-
-	return rbacConfig
 }
 
 // findAccessPoliciesForTarget finds all AccessPolicies that target the given resource.
@@ -233,61 +335,78 @@ func (t *Translator) translateAccessPolicyToRBAC(accessPolicy *agenticv0alpha0.X
 
 	// Each AccessRule in the XAccessPolicy is translated into a named policy within the Envoy RBAC filter.
 	for _, rule := range accessPolicy.Spec.Rules {
-		policyName := rule.Name
-
-		source := t.ruleSourceToPrincipalName(accessPolicy.Namespace, rule.Source)
-
-		var principalIDs []*rbacconfigv3.Principal
-		if source != "" {
-			principalIDs = append(principalIDs, &rbacconfigv3.Principal{
-				Identifier: &rbacconfigv3.Principal_Authenticated_{
-					Authenticated: &rbacconfigv3.Principal_Authenticated{
-						PrincipalName: &matcherv3.StringMatcher{
-							MatchPattern: &matcherv3.StringMatcher_Exact{Exact: source},
-						},
-					},
-				},
-			})
+		rbacPolicy, isExternalAuth, extAuthStatPrefix, err := t.translateAccessRuleToRBACPolicy(accessPolicy.Namespace, rule)
+		if err != nil {
+			klog.Errorf("Failed to translate access rule %s in policy %s/%s: %v", rule.Name, accessPolicy.Namespace, accessPolicy.Name, err)
+			continue
 		}
 
-		if len(principalIDs) == 0 {
-			principalIDs = []*rbacconfigv3.Principal{buildAnyPrincipal()}
+		if isExternalAuth {
+			rbacConfig.ShadowRulesStatPrefix = extAuthStatPrefix
+			addPolicyToRBACShadowRules(rbacConfig, rule.Name, rbacPolicy)
 		}
 
-		rbacPolicy := &rbacconfigv3.Policy{
-			Principals: principalIDs,
-		}
-
-		if rule.Authorization != nil {
-			switch rule.Authorization.Type {
-			case agenticv0alpha0.AuthorizationRuleTypeInlineTools:
-				if permission := translateInlineToolsToRBACPermission(rule.Authorization.Tools); permission != nil {
-					rbacPolicy.Permissions = []*rbacconfigv3.Permission{permission}
-				}
-			case agenticv0alpha0.AuthorizationRuleTypeExternalAuth:
-				if rule.Authorization.ExternalAuth != nil {
-					hash, err := externalAuthUniqueID(rule.Authorization.ExternalAuth)
-					if err != nil {
-						klog.Errorf("Failed to generate unique ID for externalAuth config in AccessPolicy %s/%s: %v", accessPolicy.Namespace, accessPolicy.Name, err)
-						continue
-					}
-					rbacConfig.ShadowRulesStatPrefix = fmt.Sprintf("%s_%s_", externalAuthzShadowRulePrefix, hash) // a maximum of one ExternalAuth rule per policy is allowed, so we can safely set the shadow rule stat prefix at the RBAC config level
-					rbacPolicy.Permissions = []*rbacconfigv3.Permission{buildToolsCallMethodPermission()}
-					addPolicyToRBACShadowRules(rbacConfig, policyName, rbacPolicy)
-				}
-			}
-		}
-
-		// Ensure permissions is never empty to satisfy Envoy's schema validation (min_items: 1).
-		// If authorization is omitted or unsupported, we default to a "Disallow tool call" permission.
-		if len(rbacPolicy.GetPermissions()) == 0 {
-			rbacPolicy.Permissions = []*rbacconfigv3.Permission{buildDisallowToolCallPermission()}
-		}
-
-		addPolicyToRBACRules(rbacConfig, policyName, rbacPolicy)
+		addPolicyToRBACRules(rbacConfig, rule.Name, rbacPolicy)
 	}
 
 	return rbacConfig
+}
+
+// translateAccessRuleToRBACPolicy translates a single AccessRule into an Envoy RBAC Policy.
+// It returns the policy, a boolean indicating if it is an ExternalAuth rule, the shadow rule stat prefix if applicable, and an error.
+func (t *Translator) translateAccessRuleToRBACPolicy(policyNamespace string, rule agenticv0alpha0.AccessRule) (*rbacconfigv3.Policy, bool, string, error) {
+	source := t.ruleSourceToPrincipalName(policyNamespace, rule.Source)
+
+	var principalIDs []*rbacconfigv3.Principal
+	if source != "" {
+		principalIDs = append(principalIDs, &rbacconfigv3.Principal{
+			Identifier: &rbacconfigv3.Principal_Authenticated_{
+				Authenticated: &rbacconfigv3.Principal_Authenticated{
+					PrincipalName: &matcherv3.StringMatcher{
+						MatchPattern: &matcherv3.StringMatcher_Exact{Exact: source},
+					},
+				},
+			},
+		})
+	}
+
+	if len(principalIDs) == 0 {
+		principalIDs = []*rbacconfigv3.Principal{buildAnyPrincipal()}
+	}
+
+	rbacPolicy := &rbacconfigv3.Policy{
+		Principals: principalIDs,
+	}
+
+	isExternalAuth := false
+	shadowRulesStatPrefix := ""
+
+	if rule.Authorization != nil {
+		switch rule.Authorization.Type {
+		case agenticv0alpha0.AuthorizationRuleTypeInlineTools:
+			if permission := translateInlineToolsToRBACPermission(rule.Authorization.Tools); permission != nil {
+				rbacPolicy.Permissions = []*rbacconfigv3.Permission{permission}
+			}
+		case agenticv0alpha0.AuthorizationRuleTypeExternalAuth:
+			if rule.Authorization.ExternalAuth != nil {
+				hash, err := externalAuthUniqueID(rule.Authorization.ExternalAuth)
+				if err != nil {
+					return nil, false, "", fmt.Errorf("failed to generate unique ID for externalAuth config: %w", err)
+				}
+				isExternalAuth = true
+				shadowRulesStatPrefix = fmt.Sprintf("%s_%s_", externalAuthzShadowRulePrefix, hash)
+				rbacPolicy.Permissions = []*rbacconfigv3.Permission{buildToolsCallMethodPermission()}
+			}
+		}
+	}
+
+	// Ensure permissions is never empty to satisfy Envoy's schema validation (min_items: 1).
+	// If authorization is omitted or unsupported, we default to a "Disallow tool call" permission.
+	if len(rbacPolicy.GetPermissions()) == 0 {
+		rbacPolicy.Permissions = []*rbacconfigv3.Permission{buildDisallowToolCallPermission()}
+	}
+
+	return rbacPolicy, isExternalAuth, shadowRulesStatPrefix, nil
 }
 
 // ruleSourceToPrincipalName converts an AccessRule source into a SPIFFE ID string.

--- a/pkg/translator/accesspolicy_test.go
+++ b/pkg/translator/accesspolicy_test.go
@@ -20,11 +20,15 @@ import (
 	"fmt"
 	"testing"
 
+	"google.golang.org/protobuf/types/known/anypb"
+
 	rbacconfigv3 "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	rbacv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 	gatewayinformers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
@@ -81,6 +85,7 @@ func TestBuildGatewayLevelRBACFilters(t *testing.T) {
 		name            string
 		policies        []runtime.Object
 		gatewaysToCheck map[string][]string // gateway name -> expected filter names in order
+		verify          func(t *testing.T, filters []*hcm.HttpFilter)
 	}{
 		{
 			name:     "no policies targeting gateway",
@@ -99,7 +104,7 @@ func TestBuildGatewayLevelRBACFilters(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple policies targeting the same gateway",
+			name: "multiple policies targeting the same gateway (merged)",
 			policies: []runtime.Object{
 				newTestAccessPolicy("gw-policy-1", ns, gwName, "Gateway", "spiffe://cluster.local/ns/ns1/sa/sa1"),
 				newTestAccessPolicy("gw-policy-2", ns, gwName, "Gateway", "spiffe://cluster.local/ns/ns2/sa/sa2"),
@@ -107,7 +112,6 @@ func TestBuildGatewayLevelRBACFilters(t *testing.T) {
 			gatewaysToCheck: map[string][]string{
 				gwName: {
 					fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, 1),
-					fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, 2),
 				},
 			},
 		},
@@ -143,6 +147,122 @@ func TestBuildGatewayLevelRBACFilters(t *testing.T) {
 				"other-gw": {fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, 1)},
 			},
 		},
+		{
+			name: "merged InLineTools across policies",
+			policies: []runtime.Object{
+				func() *agenticv0alpha0.XAccessPolicy {
+					p := newTestAccessPolicy("gw-policy-1", ns, gwName, "Gateway", "spiffe://cluster.local/ns/ns1/sa/sa1")
+					p.Spec.Rules[0].Authorization = &agenticv0alpha0.AuthorizationRule{
+						Type:  agenticv0alpha0.AuthorizationRuleTypeInlineTools,
+						Tools: []string{"tool-1"},
+					}
+					return p
+				}(),
+				func() *agenticv0alpha0.XAccessPolicy {
+					p := newTestAccessPolicy("gw-policy-2", ns, gwName, "Gateway", "spiffe://cluster.local/ns/ns2/sa/sa2")
+					p.Spec.Rules[0].Authorization = &agenticv0alpha0.AuthorizationRule{
+						Type:  agenticv0alpha0.AuthorizationRuleTypeInlineTools,
+						Tools: []string{"tool-2"},
+					}
+					p.Spec.Rules[0].Name = "rule-1"
+					return p
+				}(),
+			},
+			gatewaysToCheck: map[string][]string{
+				gwName: {fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, 1)},
+			},
+			verify: func(t *testing.T, filters []*hcm.HttpFilter) {
+				expectedPrefixedName1 := fmt.Sprintf("%s.%s.%s", ns, "gw-policy-1", "rule-1")
+				expectedPrefixedName2 := fmt.Sprintf("%s.%s.%s", ns, "gw-policy-2", "rule-1")
+				verifyRBACConfig(t, filters, 1, nil, []string{expectedPrefixedName1, expectedPrefixedName2}, 5)
+			},
+		},
+		{
+			name: "mixed inline and external auth rules",
+			policies: []runtime.Object{
+				func() *agenticv0alpha0.XAccessPolicy {
+					mixedPolicy := newTestAccessPolicy("mixed-policy", ns, gwName, "Gateway", "spiffe://cluster.local/ns/ns1/sa/sa1")
+					mixedPolicy.Spec.Rules[0].Name = "inline-rule"
+					mixedPolicy.Spec.Rules[0].Authorization = &agenticv0alpha0.AuthorizationRule{
+						Type:  agenticv0alpha0.AuthorizationRuleTypeInlineTools,
+						Tools: []string{"tool-1"},
+					}
+					mixedPolicy.Spec.Rules = append(mixedPolicy.Spec.Rules, agenticv0alpha0.AccessRule{
+						Name: "ext-auth-rule",
+						Source: agenticv0alpha0.Source{
+							Type:   agenticv0alpha0.AuthorizationSourceTypeSPIFFE,
+							SPIFFE: (*agenticv0alpha0.AuthorizationSourceSPIFFE)(ptr.To("spiffe://cluster.local/ns/ns2/sa/sa2")),
+						},
+						Authorization: &agenticv0alpha0.AuthorizationRule{
+							Type: agenticv0alpha0.AuthorizationRuleTypeExternalAuth,
+							ExternalAuth: &gatewayv1.HTTPExternalAuthFilter{
+								ExternalAuthProtocol: gatewayv1.HTTPRouteExternalAuthGRPCProtocol,
+								BackendRef: gatewayv1.BackendObjectReference{
+									Name: "ext-auth-svc",
+								},
+							},
+						},
+					})
+					return mixedPolicy
+				}(),
+			},
+			gatewaysToCheck: map[string][]string{
+				gwName: {
+					fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, 1),
+				},
+			},
+			verify: func(t *testing.T, filters []*hcm.HttpFilter) {
+				expectedPrefixedName := fmt.Sprintf("%s.%s.%s", ns, "mixed-policy", "inline-rule")
+				verifyRBACConfig(t, filters, 1, []string{"ext-auth-rule"}, []string{expectedPrefixedName, "ext-auth-rule"}, 5)
+			},
+		},
+		{
+			name: "multiple mixed inline and external auth rules",
+			policies: []runtime.Object{
+				func() *agenticv0alpha0.XAccessPolicy {
+					p := newTestAccessPolicy("gw-policy-1", ns, gwName, "Gateway", "spiffe://cluster.local/ns/ns1/sa/sa1")
+					p.Spec.Rules[0].Name = "inline-rule-1"
+					p.Spec.Rules[0].Authorization = &agenticv0alpha0.AuthorizationRule{
+						Type:  agenticv0alpha0.AuthorizationRuleTypeInlineTools,
+						Tools: []string{"tool-1"},
+					}
+					return p
+				}(),
+				func() *agenticv0alpha0.XAccessPolicy {
+					p := newTestAccessPolicy("gw-policy-2", ns, gwName, "Gateway", "spiffe://cluster.local/ns/ns2/sa/sa2")
+					p.Spec.Rules[0].Name = "ext-auth-rule-1"
+					p.Spec.Rules[0].Authorization = &agenticv0alpha0.AuthorizationRule{
+						Type: agenticv0alpha0.AuthorizationRuleTypeExternalAuth,
+						ExternalAuth: &gatewayv1.HTTPExternalAuthFilter{
+							ExternalAuthProtocol: gatewayv1.HTTPRouteExternalAuthGRPCProtocol,
+							BackendRef: gatewayv1.BackendObjectReference{
+								Name: "ext-auth-svc-1",
+							},
+						},
+					}
+					return p
+				}(),
+				func() *agenticv0alpha0.XAccessPolicy {
+					p := newTestAccessPolicy("gw-policy-3", ns, gwName, "Gateway", "spiffe://cluster.local/ns/ns3/sa/sa3")
+					p.Spec.Rules[0].Name = "inline-rule-2"
+					p.Spec.Rules[0].Authorization = &agenticv0alpha0.AuthorizationRule{
+						Type:  agenticv0alpha0.AuthorizationRuleTypeInlineTools,
+						Tools: []string{"tool-2"},
+					}
+					return p
+				}(),
+			},
+			gatewaysToCheck: map[string][]string{
+				gwName: {
+					fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, 1),
+				},
+			},
+			verify: func(t *testing.T, filters []*hcm.HttpFilter) {
+				expectedPrefixedName1 := fmt.Sprintf("%s.%s.%s", ns, "gw-policy-1", "inline-rule-1")
+				expectedPrefixedName3 := fmt.Sprintf("%s.%s.%s", ns, "gw-policy-3", "inline-rule-2")
+				verifyRBACConfig(t, filters, 1, []string{"ext-auth-rule-1"}, []string{expectedPrefixedName1, expectedPrefixedName3, "ext-auth-rule-1"}, 6)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -172,6 +292,11 @@ func TestBuildGatewayLevelRBACFilters(t *testing.T) {
 					if f.GetName() != expectedNames[i] {
 						t.Errorf("Gateway %s, Filter %d: expected name %s, got %s", gwn, i, expectedNames[i], f.GetName())
 					}
+				}
+
+				// Call custom verify if specified
+				if tt.verify != nil {
+					tt.verify(t, filters)
 				}
 			}
 		})
@@ -234,8 +359,9 @@ func TestCalculateMaxBackendRBACFilters(t *testing.T) {
 				newTestAccessPolicy("policy-1", ns, "backend-1", "XBackend", "principal-1"),
 				newTestAccessPolicy("policy-2", ns, "backend-1", "XBackend", "principal-2"),
 			},
-			want: 2,
+			want: 1,
 		},
+
 		{
 			name: "two routes, multiple backends, max policies is 3",
 			routes: []*gatewayv1.HTTPRoute{
@@ -249,8 +375,9 @@ func TestCalculateMaxBackendRBACFilters(t *testing.T) {
 				newTestAccessPolicy("p4", ns, "backend-2", "XBackend", "pr4"),
 				newTestAccessPolicy("p5", ns, "backend-2", "XBackend", "pr5"),
 			},
-			want: 3,
+			want: 1,
 		},
+
 		{
 			name: "policies targeting multiple backends",
 			routes: []*gatewayv1.HTTPRoute{
@@ -283,7 +410,7 @@ func TestCalculateMaxBackendRBACFilters(t *testing.T) {
 				},
 				newTestAccessPolicy("p1", ns, "backend-1", "XBackend", "pr1"),
 			},
-			want: 2, // backend-1 has 2 policies, backend-2 has 1 policy
+			want: 1, // policies are merged
 		},
 	}
 
@@ -337,6 +464,7 @@ func TestBuildBackendLevelRBACOverrides(t *testing.T) {
 		name            string
 		policies        []runtime.Object
 		backendsToCheck map[string][]string // backend name -> expected filter names in order
+		verify          func(t *testing.T, configs map[string]*anypb.Any)
 	}{
 		{
 			name:     "no policies targeting backend",
@@ -363,7 +491,6 @@ func TestBuildBackendLevelRBACOverrides(t *testing.T) {
 			backendsToCheck: map[string][]string{
 				beName: {
 					fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, 1),
-					fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, 2),
 				},
 			},
 		},
@@ -399,6 +526,139 @@ func TestBuildBackendLevelRBACOverrides(t *testing.T) {
 				"other-backend": {fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, 1)},
 			},
 		},
+		{
+			name: "merged policies",
+			policies: []runtime.Object{
+				func() *agenticv0alpha0.XAccessPolicy {
+					p := newTestAccessPolicy("be-policy-1", ns, beName, "XBackend", "spiffe://cluster.local/ns/ns1/sa/sa1")
+					p.Spec.Rules[0].Authorization = &agenticv0alpha0.AuthorizationRule{
+						Type:  agenticv0alpha0.AuthorizationRuleTypeInlineTools,
+						Tools: []string{"tool-1"},
+					}
+					return p
+				}(),
+				func() *agenticv0alpha0.XAccessPolicy {
+					p := newTestAccessPolicy("be-policy-2", ns, beName, "XBackend", "spiffe://cluster.local/ns/ns2/sa/sa2")
+					p.Spec.Rules[0].Authorization = &agenticv0alpha0.AuthorizationRule{
+						Type:  agenticv0alpha0.AuthorizationRuleTypeInlineTools,
+						Tools: []string{"tool-2"},
+					}
+					return p
+				}(),
+				func() *agenticv0alpha0.XAccessPolicy {
+					p := newTestAccessPolicy("be-policy-3", ns, beName, "XBackend", "spiffe://cluster.local/ns/ns3/sa/sa3")
+					p.Spec.Rules[0].Authorization = &agenticv0alpha0.AuthorizationRule{
+						Type: agenticv0alpha0.AuthorizationRuleTypeExternalAuth,
+						ExternalAuth: &gatewayv1.HTTPExternalAuthFilter{
+							ExternalAuthProtocol: gatewayv1.HTTPRouteExternalAuthGRPCProtocol,
+							BackendRef: gatewayv1.BackendObjectReference{
+								Name: "ext-auth-svc",
+							},
+						},
+					}
+					return p
+				}(),
+			},
+			backendsToCheck: map[string][]string{
+				beName: {
+					fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, 1),
+				},
+			},
+			verify: func(t *testing.T, configs map[string]*anypb.Any) {
+				f1Name := fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, 1)
+				expectedPrefixedName1 := fmt.Sprintf("%s.%s.%s", ns, "be-policy-1", "rule-1")
+				expectedPrefixedName2 := fmt.Sprintf("%s.%s.%s", ns, "be-policy-2", "rule-1")
+				verifyRBACPerRouteConfig(t, configs, 1, f1Name, nil, []string{expectedPrefixedName1, expectedPrefixedName2, "rule-1"}, 6)
+			},
+		},
+		{
+			name: "mixed inline and external auth rules",
+			policies: []runtime.Object{
+				func() *agenticv0alpha0.XAccessPolicy {
+					mixedPolicy := newTestAccessPolicy("mixed-policy", ns, beName, "XBackend", "spiffe://cluster.local/ns/ns1/sa/sa1")
+					mixedPolicy.Spec.Rules[0].Name = "inline-rule"
+					mixedPolicy.Spec.Rules[0].Authorization = &agenticv0alpha0.AuthorizationRule{
+						Type:  agenticv0alpha0.AuthorizationRuleTypeInlineTools,
+						Tools: []string{"tool-1"},
+					}
+					mixedPolicy.Spec.Rules = append(mixedPolicy.Spec.Rules, agenticv0alpha0.AccessRule{
+						Name: "ext-auth-rule",
+						Source: agenticv0alpha0.Source{
+							Type:   agenticv0alpha0.AuthorizationSourceTypeSPIFFE,
+							SPIFFE: (*agenticv0alpha0.AuthorizationSourceSPIFFE)(ptr.To("spiffe://cluster.local/ns/ns2/sa/sa2")),
+						},
+						Authorization: &agenticv0alpha0.AuthorizationRule{
+							Type: agenticv0alpha0.AuthorizationRuleTypeExternalAuth,
+							ExternalAuth: &gatewayv1.HTTPExternalAuthFilter{
+								ExternalAuthProtocol: gatewayv1.HTTPRouteExternalAuthGRPCProtocol,
+								BackendRef: gatewayv1.BackendObjectReference{
+									Name: "ext-auth-svc",
+								},
+							},
+						},
+					})
+					return mixedPolicy
+				}(),
+			},
+			backendsToCheck: map[string][]string{
+				beName: {
+					fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, 1),
+				},
+			},
+			verify: func(t *testing.T, configs map[string]*anypb.Any) {
+				f1Name := fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, 1)
+				expectedPrefixedName := fmt.Sprintf("%s.%s.%s", ns, "mixed-policy", "inline-rule")
+				verifyRBACPerRouteConfig(t, configs, 1, f1Name, []string{"ext-auth-rule"}, []string{expectedPrefixedName, "ext-auth-rule"}, 5)
+			},
+		},
+		{
+			name: "multiple mixed inline and external auth rules",
+			policies: []runtime.Object{
+				func() *agenticv0alpha0.XAccessPolicy {
+					p := newTestAccessPolicy("be-policy-1", ns, beName, "XBackend", "spiffe://cluster.local/ns/ns1/sa/sa1")
+					p.Spec.Rules[0].Name = "inline-rule-1"
+					p.Spec.Rules[0].Authorization = &agenticv0alpha0.AuthorizationRule{
+						Type:  agenticv0alpha0.AuthorizationRuleTypeInlineTools,
+						Tools: []string{"tool-1"},
+					}
+					return p
+				}(),
+				func() *agenticv0alpha0.XAccessPolicy {
+					p := newTestAccessPolicy("be-policy-2", ns, beName, "XBackend", "spiffe://cluster.local/ns/ns2/sa/sa2")
+					p.Spec.Rules[0].Name = "ext-auth-rule-1"
+					p.Spec.Rules[0].Authorization = &agenticv0alpha0.AuthorizationRule{
+						Type: agenticv0alpha0.AuthorizationRuleTypeExternalAuth,
+						ExternalAuth: &gatewayv1.HTTPExternalAuthFilter{
+							ExternalAuthProtocol: gatewayv1.HTTPRouteExternalAuthGRPCProtocol,
+							BackendRef: gatewayv1.BackendObjectReference{
+								Name: "ext-auth-svc-1",
+							},
+						},
+					}
+					return p
+				}(),
+				func() *agenticv0alpha0.XAccessPolicy {
+					p := newTestAccessPolicy("be-policy-3", ns, beName, "XBackend", "spiffe://cluster.local/ns/ns3/sa/sa3")
+					p.Spec.Rules[0].Name = "inline-rule-2"
+					p.Spec.Rules[0].Authorization = &agenticv0alpha0.AuthorizationRule{
+						Type:  agenticv0alpha0.AuthorizationRuleTypeInlineTools,
+						Tools: []string{"tool-2"},
+					}
+					return p
+				}(),
+			},
+			backendsToCheck: map[string][]string{
+				beName: {
+					fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, 1),
+				},
+			},
+			verify: func(t *testing.T, configs map[string]*anypb.Any) {
+				f1Name := fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, 1)
+				expectedPrefixedName1 := fmt.Sprintf("%s.%s.%s", ns, "be-policy-1", "inline-rule-1")
+				expectedPrefixedName3 := fmt.Sprintf("%s.%s.%s", ns, "be-policy-3", "inline-rule-2")
+				verifyRBACPerRouteConfig(t, configs, 1, f1Name, []string{"ext-auth-rule-1"}, []string{expectedPrefixedName1, expectedPrefixedName3, "ext-auth-rule-1"}, 6)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -429,6 +689,11 @@ func TestBuildBackendLevelRBACOverrides(t *testing.T) {
 					if _, ok := configs[expectedName]; !ok {
 						t.Errorf("Backend %s: Expected config for filter %s not found", ben, expectedName)
 					}
+				}
+
+				// Call custom verify if specified
+				if tt.verify != nil {
+					tt.verify(t, configs)
 				}
 			}
 		})
@@ -973,6 +1238,88 @@ func verifyPolicy(t *testing.T, rbacPolicy *rbacconfigv3.Policy, expected expect
 			if !actualTools[expectedTool] {
 				t.Errorf("expected tool %q not found in OrMatch", expectedTool)
 			}
+		}
+	}
+}
+
+func verifyRBACConfig(t *testing.T, filters []*hcm.HttpFilter, expectedFiltersCount int, expectedShadowRules []string, expectedRules []string, expectedRulesCount int) {
+	t.Helper()
+	if len(filters) != expectedFiltersCount {
+		t.Fatalf("Expected %d filters, got %d", expectedFiltersCount, len(filters))
+	}
+	if expectedFiltersCount == 0 {
+		return
+	}
+	f := filters[0]
+	rbac := &rbacv3.RBAC{}
+	if err := f.GetTypedConfig().UnmarshalTo(rbac); err != nil {
+		t.Fatalf("Failed to unmarshal to RBAC: %v", err)
+	}
+
+	if len(expectedShadowRules) > 0 {
+		if rbac.GetShadowRules() == nil {
+			t.Errorf("Expected shadow rules, got nil")
+		} else {
+			shadowPolicies := rbac.GetShadowRules().GetPolicies()
+			for _, name := range expectedShadowRules {
+				if _, ok := shadowPolicies[name]; !ok {
+					t.Errorf("Expected shadow rule %s not found", name)
+				}
+			}
+		}
+	}
+
+	policies := rbac.GetRules().GetPolicies()
+	if expectedRulesCount >= 0 && len(policies) != expectedRulesCount {
+		t.Errorf("Expected %d policies in Rules, got %d", expectedRulesCount, len(policies))
+	}
+
+	for _, name := range expectedRules {
+		if _, ok := policies[name]; !ok {
+			t.Errorf("Expected policy %s not found in Rules", name)
+		}
+	}
+}
+
+func verifyRBACPerRouteConfig(t *testing.T, configs map[string]*anypb.Any, expectedConfigsCount int, filterName string, expectedShadowRules []string, expectedRules []string, expectedRulesCount int) {
+	t.Helper()
+	if len(configs) != expectedConfigsCount {
+		t.Fatalf("Expected %d configs, got %d", expectedConfigsCount, len(configs))
+	}
+	if expectedConfigsCount == 0 {
+		return
+	}
+	rbacPerRoute := &rbacv3.RBACPerRoute{}
+	if err := configs[filterName].UnmarshalTo(rbacPerRoute); err != nil {
+		t.Fatalf("Failed to unmarshal to RBACPerRoute: %v", err)
+	}
+
+	rbac := rbacPerRoute.GetRbac()
+	if rbac == nil {
+		t.Fatalf("RBAC in RBACPerRoute is nil")
+	}
+
+	if len(expectedShadowRules) > 0 {
+		if rbac.GetShadowRules() == nil {
+			t.Errorf("Expected shadow rules, got nil")
+		} else {
+			shadowPolicies := rbac.GetShadowRules().GetPolicies()
+			for _, name := range expectedShadowRules {
+				if _, ok := shadowPolicies[name]; !ok {
+					t.Errorf("Expected shadow rule %s not found", name)
+				}
+			}
+		}
+	}
+
+	policies := rbac.GetRules().GetPolicies()
+	if expectedRulesCount >= 0 && len(policies) != expectedRulesCount {
+		t.Errorf("Expected %d policies in Rules, got %d", expectedRulesCount, len(policies))
+	}
+
+	for _, name := range expectedRules {
+		if _, ok := policies[name]; !ok {
+			t.Errorf("Expected policy %s not found in Rules", name)
 		}
 	}
 }

--- a/pkg/translator/listener_test.go
+++ b/pkg/translator/listener_test.go
@@ -172,10 +172,10 @@ func TestBuildHTTPFilters(t *testing.T) {
 			expected: []string{
 				"envoy.filters.http.mcp",
 				fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, 1),
-				fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, 2),
 				"envoy.filters.http.router",
 			},
 		},
+
 		{
 			name: "0 Gateway-level Policies, 2 Backend-level policies, 0 external auth policies",
 			routes: []*gatewayv1.HTTPRoute{
@@ -188,7 +188,6 @@ func TestBuildHTTPFilters(t *testing.T) {
 			expected: []string{
 				"envoy.filters.http.mcp",
 				fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, 1),
-				fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, 2),
 				"envoy.filters.http.router",
 			},
 		},
@@ -286,13 +285,9 @@ func TestBuildHTTPFilters(t *testing.T) {
 			},
 			expected: []string{
 				"envoy.filters.http.mcp",
-				fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, 1),
-				fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, 2),
-				fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, 3), // ext-auth-policy-1
-				fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, 4), // ext-auth-policy-2
-				fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, 1),
-				fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, 2),
-				fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, 3), // ext-auth-policy-3
+				fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, 1), // ext-auth-policy-1
+				fmt.Sprintf("%s%d", constants.GatewayRBACFilterNamePrefix, 2), // ext-auth-policy-2
+				fmt.Sprintf("%s%d", constants.BackendRBACFilterNamePrefix, 1), // ext-auth-policy-3
 				"envoy.filters.http.ext_authz",                                // ext-auth-policy-1, ext-auth-policy-3
 				"envoy.filters.http.ext_authz",                                // ext-auth-policy-2
 				"envoy.filters.http.router",

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -137,11 +137,11 @@ func TestControllerE2E(t *testing.T) {
 			},
 		},
 	)
+	deleteFromNamespace(t, "testdata/backend-policy.yaml", namespace)
 
 	// Case 3: Only gateway policy
 	t.Log("--------------------------------------------------------------------------------")
 	t.Log("Case 3: Only gateway policy (allows echo)")
-	deleteFromNamespace(t, "testdata/backend-policy.yaml", namespace)
 	applyToNamespace(t, "testdata/gateway-policy.yaml", namespace)
 	// Wait for xDS propagation
 	time.Sleep(xdsUpdateWaitTime)
@@ -232,6 +232,184 @@ func TestControllerE2E(t *testing.T) {
 			},
 		},
 	)
+
+	// Delete policy from Case 4 and 5 to have a clean state
+	deleteFromNamespace(t, "testdata/gateway-policy.yaml", namespace)
+	deleteFromNamespace(t, "testdata/backend-policy.yaml", namespace)
+	// Case 6: Multiple gateway policies targeting the same Gateway
+	t.Log("--------------------------------------------------------------------------------")
+	t.Log("Case 6: Multiple gateway policies (OR semantics)")
+
+	applyToNamespace(t, "testdata/gateway-policy-echo.yaml", namespace)
+	applyToNamespace(t, "testdata/gateway-policy-get-sum.yaml", namespace)
+
+	// Wait for xDS propagation
+	time.Sleep(xdsUpdateWaitTime)
+
+	// Verify echo is allowed
+	mcp.assertToolCall(t, "echo", `{"message":"hello"}`,
+		mcpResponse{
+			StatusCode: 200,
+			Body: respBody{
+				JSONRPC: "2.0",
+				Result: &mcpResult{
+					IsError: false,
+					Content: []mcpContent{
+						{
+							Type: "text",
+							Text: "Echo: hello",
+						},
+					},
+				},
+			},
+		})
+
+	// Verify get-sum is allowed
+	mcp.assertToolCall(t, "get-sum", `{"a":2,"b":3}`,
+		mcpResponse{
+			StatusCode: 200,
+			Body: respBody{
+				JSONRPC: "2.0",
+				Result: &mcpResult{
+					IsError: false,
+					Content: []mcpContent{
+						{
+							Type: "text",
+							Text: "The sum of 2 and 3 is 5.",
+						},
+					},
+				},
+			},
+		})
+
+	// Remove one policy and verify restriction
+	t.Log("Removing echo tool and verifying get-sum is still allowed")
+	deleteFromNamespace(t, "testdata/gateway-policy-echo.yaml", namespace)
+
+	// Wait for xDS propagation
+	time.Sleep(xdsUpdateWaitTime)
+
+	// Verify echo is restricted
+	mcp.assertToolCall(t, "echo", `{"message":"hello"}`,
+		mcpResponse{
+			StatusCode: 200,
+			Body: respBody{
+				JSONRPC: "2.0",
+				Error: &mcpError{
+					Code:    403,
+					Message: "Access to this tool is forbidden.",
+				},
+			},
+		})
+
+	// Verify get-sum is still allowed
+	mcp.assertToolCall(t, "get-sum", `{"a":2,"b":3}`,
+		mcpResponse{
+			StatusCode: 200,
+			Body: respBody{
+				JSONRPC: "2.0",
+				Result: &mcpResult{
+					IsError: false,
+					Content: []mcpContent{
+						{
+							Type: "text",
+							Text: "The sum of 2 and 3 is 5.",
+						},
+					},
+				},
+			},
+		})
+
+	// Cleanup remaining policy
+	deleteFromNamespace(t, "testdata/gateway-policy-get-sum.yaml", namespace)
+
+	// Case 7: Multiple backend policies targeting the same Backend
+	t.Log("--------------------------------------------------------------------------------")
+	t.Log("Case 7: Multiple backend policies (OR semantics)")
+
+	// Apply backend policies
+	applyToNamespace(t, "testdata/backend-policy-echo.yaml", namespace)
+	applyToNamespace(t, "testdata/backend-policy-get-sum.yaml", namespace)
+
+	// Wait for xDS propagation
+	time.Sleep(xdsUpdateWaitTime)
+
+	// Verify echo is allowed
+	mcp.assertToolCall(t, "echo", `{"message":"hello"}`,
+		mcpResponse{
+			StatusCode: 200,
+			Body: respBody{
+				JSONRPC: "2.0",
+				Result: &mcpResult{
+					IsError: false,
+					Content: []mcpContent{
+						{
+							Type: "text",
+							Text: "Echo: hello",
+						},
+					},
+				},
+			},
+		})
+
+	// Verify get-sum is allowed
+	mcp.assertToolCall(t, "get-sum", `{"a":2,"b":3}`,
+		mcpResponse{
+			StatusCode: 200,
+			Body: respBody{
+				JSONRPC: "2.0",
+				Result: &mcpResult{
+					IsError: false,
+					Content: []mcpContent{
+						{
+							Type: "text",
+							Text: "The sum of 2 and 3 is 5.",
+						},
+					},
+				},
+			},
+		})
+
+	// Remove one policy and verify restriction
+	t.Log("Removing echo tool and verifying get-sum is still allowed")
+	deleteFromNamespace(t, "testdata/backend-policy-echo.yaml", namespace)
+
+	// Wait for xDS propagation
+	time.Sleep(xdsUpdateWaitTime)
+
+	// Verify echo is restricted
+	mcp.assertToolCall(t, "echo", `{"message":"hello"}`,
+		mcpResponse{
+			StatusCode: 200,
+			Body: respBody{
+				JSONRPC: "2.0",
+				Error: &mcpError{
+					Code:    403,
+					Message: "Access to this tool is forbidden.",
+				},
+			},
+		})
+
+	// Verify get-sum is still allowed
+	mcp.assertToolCall(t, "get-sum", `{"a":2,"b":3}`,
+		mcpResponse{
+			StatusCode: 200,
+			Body: respBody{
+				JSONRPC: "2.0",
+				Result: &mcpResult{
+					IsError: false,
+					Content: []mcpContent{
+						{
+							Type: "text",
+							Text: "The sum of 2 and 3 is 5.",
+						},
+					},
+				},
+			},
+		})
+
+	// Cleanup remaining policies applied in this case
+	deleteFromNamespace(t, "testdata/backend-policy-get-sum.yaml", namespace)
 	t.Log("--------------------------------------------------------------------------------")
 }
 

--- a/tests/e2e/testdata/backend-policy-echo.yaml
+++ b/tests/e2e/testdata/backend-policy-echo.yaml
@@ -1,0 +1,21 @@
+apiVersion: agentic.prototype.x-k8s.io/v0alpha0
+kind: XAccessPolicy
+metadata:
+  name: e2e-backend-policy-echo
+  namespace: e2e-test-ns
+spec:
+  targetRefs:
+    - group: agentic.prototype.x-k8s.io
+      kind: XBackend
+      name: e2e-mcp-backend
+  rules:
+    - name: allow-echo
+      source:
+        type: ServiceAccount
+        serviceAccount:
+          name: e2e-tester-sa
+          namespace: e2e-test-ns
+      authorization:
+        type: InlineTools
+        tools:
+          - "echo"

--- a/tests/e2e/testdata/backend-policy-get-sum.yaml
+++ b/tests/e2e/testdata/backend-policy-get-sum.yaml
@@ -1,0 +1,21 @@
+apiVersion: agentic.prototype.x-k8s.io/v0alpha0
+kind: XAccessPolicy
+metadata:
+  name: e2e-backend-policy-get-sum
+  namespace: e2e-test-ns
+spec:
+  targetRefs:
+    - group: agentic.prototype.x-k8s.io
+      kind: XBackend
+      name: e2e-mcp-backend
+  rules:
+    - name: allow-get-sum
+      source:
+        type: ServiceAccount
+        serviceAccount:
+          name: e2e-tester-sa
+          namespace: e2e-test-ns
+      authorization:
+        type: InlineTools
+        tools:
+          - "get-sum"

--- a/tests/e2e/testdata/gateway-policy-echo.yaml
+++ b/tests/e2e/testdata/gateway-policy-echo.yaml
@@ -1,0 +1,21 @@
+apiVersion: agentic.prototype.x-k8s.io/v0alpha0
+kind: XAccessPolicy
+metadata:
+  name: e2e-gateway-policy-echo
+  namespace: e2e-test-ns
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: e2e-gateway
+  rules:
+    - name: allow-echo
+      source:
+        type: ServiceAccount
+        serviceAccount:
+          name: e2e-tester-sa
+          namespace: e2e-test-ns
+      authorization:
+        type: InlineTools
+        tools:
+          - "echo"

--- a/tests/e2e/testdata/gateway-policy-get-sum.yaml
+++ b/tests/e2e/testdata/gateway-policy-get-sum.yaml
@@ -1,0 +1,21 @@
+apiVersion: agentic.prototype.x-k8s.io/v0alpha0
+kind: XAccessPolicy
+metadata:
+  name: e2e-gateway-policy-get-sum
+  namespace: e2e-test-ns
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: e2e-gateway
+  rules:
+    - name: allow-get-sum
+      source:
+        type: ServiceAccount
+        serviceAccount:
+          name: e2e-tester-sa
+          namespace: e2e-test-ns
+      authorization:
+        type: InlineTools
+        tools:
+          - "get-sum"


### PR DESCRIPTION


**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
## Description
This PR implements logic **OR** semantics for `XAccessPolicy` rules targeting the same resource (Gateway or Backend). Previously, overlapping policies could result in sequential filters that blocked authorized traffic. 
Now, `InlineTools` rules from multiple policies are merged into a single Envoy RBAC filter. If `ExternalAuth` rules are also present, the merged `InlineTools` rules are copied into each `ExternalAuth` filter, ensuring that traffic is allowed if it satisfies *any* of the authorization conditions.
## Key Changes
### Core Logic (`pkg/translator/`)
*   **Merged RBAC Filters**: Added `buildRBACConfigsForPolicies` in `accesspolicy.go` to handle the merging of `InlineTools` rules and their injection into `ExternalAuth` filters.
*   **Corrected Filter Counting**: Refactored `calculateMaxBackendRBACFilters` to compute the actual number of required filters after merging, preventing overestimation.
*   **Refactored Translation**: Extracted `translateAccessRuleToRBACPolicy` to handle mapping individual access rules to Envoy policies, improving code maintainability.
### Unit Tests (`pkg/translator/`)
*   **Reduced Filter Expectations**: Updated existing tests in `accesspolicy_test.go` and `listener_test.go` to account for the reduced filter count (policies are now grouped rather than generating one filter each).
*   **New Test Coverage**: Added new table tests covering mixed scenarios (inline + external auth) to ensure rules are properly merged across policies.
*   **Greened Verification Helpers**: Introduced `verifyRBACConfig` and `verifyRBACPerRouteConfig` to deduplicate assertion logic in tests.
### E2E Tests (`tests/e2e/`)
*   **Added Multi-Policy Cases**: Added "Case 6" (Gateways) and "Case 7" (Backends) to verify that creating multiple policies correctly results in accessible tools without blocking.
*   **New Test Artefacts**: Added 4 new YAML test data files to drive these specific test cases.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #237 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Accesspolicies are OR'ed if they have the same target.
```
