### PR TITLE
Complete the support for ReferenceGrant

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -84,8 +84,9 @@ type gatewayResources struct {
 	gatewayClassLister gatewaylisters.GatewayClassLister
 	gatewayClassSynced cache.InformerSynced
 
-	gatewayLister gatewaylisters.GatewayLister
-	gatewaySynced cache.InformerSynced
+	gatewayLister  gatewaylisters.GatewayLister
+	gatewayIndexer cache.Indexer
+	gatewaySynced  cache.InformerSynced
 
 	httprouteLister      gatewaylisters.HTTPRouteLister
 	httprouteIndexer     cache.Indexer
@@ -143,6 +144,14 @@ func New(
 		return nil, fmt.Errorf("add AccessPolicy targetRef index: %w", err)
 	}
 
+	if err := httprouteInformer.Informer().AddIndexers(cache.Indexers{HTTPRouteBackendRefNamespaceIndex: HTTPRouteBackendRefNamespaceIndexFunc}); err != nil {
+		return nil, fmt.Errorf("add HTTPRoute backend reference namespace index: %w", err)
+	}
+
+	if err := gatewayInformer.Informer().AddIndexers(cache.Indexers{GatewaySecretRefNamespaceIndex: GatewaySecretRefNamespaceIndexFunc}); err != nil {
+		return nil, fmt.Errorf("add Gateway secret reference namespace index: %w", err)
+	}
+
 	c := &Controller{
 		core: coreResources{
 			client:       kubeClientSet,
@@ -158,6 +167,7 @@ func New(
 			gatewayClassLister:   gatewayClassInformer.Lister(),
 			gatewayClassSynced:   gatewayClassInformer.Informer().HasSynced,
 			gatewayLister:        gatewayInformer.Lister(),
+			gatewayIndexer:       gatewayInformer.Informer().GetIndexer(),
 			gatewaySynced:        gatewayInformer.Informer().HasSynced,
 			httprouteLister:      httprouteInformer.Lister(),
 			httprouteIndexer:     httprouteInformer.Informer().GetIndexer(),
@@ -208,6 +218,9 @@ func New(
 		return nil, err
 	}
 	if err := c.setupHTTPRouteEventHandlers(httprouteInformer); err != nil {
+		return nil, err
+	}
+	if err := c.setupReferenceGrantEventHandlers(referenceGrantInformer); err != nil {
 		return nil, err
 	}
 	if err := c.setupBackendEventHandlers(backendInformer); err != nil {

--- a/pkg/controller/gateway.go
+++ b/pkg/controller/gateway.go
@@ -34,6 +34,34 @@ import (
 	gatewayinformers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1"
 )
 
+// GatewaySecretRefNamespaceIndex is the name of the index that maps target namespaces to Gateways
+// that reference Secrets in those namespaces in their TLS configuration.
+const GatewaySecretRefNamespaceIndex = "gatewaySecretRefNamespace"
+
+// GatewaySecretRefNamespaceIndexFunc returns the target namespaces for each secret reference
+// in a Gateway's listeners.
+func GatewaySecretRefNamespaceIndexFunc(obj interface{}) ([]string, error) {
+	gw, ok := obj.(*gatewayv1.Gateway)
+	if !ok {
+		return nil, nil
+	}
+	var keys []string
+	for _, listener := range gw.Spec.Listeners {
+		if listener.TLS != nil {
+			for _, ref := range listener.TLS.CertificateRefs {
+				ns := gw.Namespace
+				if ref.Namespace != nil {
+					ns = string(*ref.Namespace)
+				}
+				keys = append(keys, ns)
+			}
+		}
+	}
+	// Deduplicate namespaces
+	keys = deduplicateStrings(keys)
+	return keys, nil
+}
+
 var semanticIgnoreLastTransitionTime = conversion.EqualitiesOrDie(
 	func(a, b metav1.Condition) bool {
 		a.LastTransitionTime = metav1.Time{}

--- a/pkg/controller/gateway_test.go
+++ b/pkg/controller/gateway_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -113,4 +114,95 @@ func TestSetGatewayConditions(t *testing.T) {
 			t.Errorf("expected programmed condition to be false")
 		}
 	})
+}
+
+func TestGatewaySecretRefNamespaceIndexFunc(t *testing.T) {
+	ns1 := "ns1"
+	ns2 := "ns2"
+	gwNS := "gw-ns"
+
+	tests := []struct {
+		name     string
+		obj      interface{}
+		expected []string
+	}{
+		{
+			name:     "not a Gateway",
+			obj:      "not a gateway",
+			expected: nil,
+		},
+		{
+			name: "gateway with no listeners",
+			obj: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Namespace: gwNS},
+				Spec:       gatewayv1.GatewaySpec{},
+			},
+			expected: []string{},
+		},
+		{
+			name: "gateway with listeners but no TLS",
+			obj: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Namespace: gwNS},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{{}},
+				},
+			},
+			expected: []string{},
+		},
+		{
+			name: "gateway with certificateRefs (same and cross namespace)",
+			obj: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Namespace: gwNS},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{
+						{
+							TLS: &gatewayv1.ListenerTLSConfig{
+								CertificateRefs: []gatewayv1.SecretObjectReference{
+									{
+										Name: "secret1",
+									},
+									{
+										Name:      "secret2",
+										Namespace: ptr.To(gatewayv1.Namespace(ns1)),
+									},
+								},
+							},
+						},
+						{
+							TLS: &gatewayv1.ListenerTLSConfig{
+								CertificateRefs: []gatewayv1.SecretObjectReference{
+									{
+										Name:      "secret3",
+										Namespace: ptr.To(gatewayv1.Namespace(ns2)),
+									},
+									{
+										Name:      "secret4",
+										Namespace: ptr.To(gatewayv1.Namespace(ns1)), // Duplicate ns1
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{gwNS, ns1, ns2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keys, err := GatewaySecretRefNamespaceIndexFunc(tt.obj)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(keys) != len(tt.expected) {
+				t.Fatalf("expected len %d, got %d. keys: %v", len(tt.expected), len(keys), keys)
+			}
+			for i, v := range keys {
+				if v != tt.expected[i] {
+					t.Errorf("expected key at index %d to be %q, got %q", i, tt.expected[i], v)
+				}
+			}
+		})
+	}
 }

--- a/pkg/controller/referencegrant.go
+++ b/pkg/controller/referencegrant.go
@@ -1,0 +1,181 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayinformersv1beta1 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1beta1"
+)
+
+func (c *Controller) setupReferenceGrantEventHandlers(referenceGrantInformer gatewayinformersv1beta1.ReferenceGrantInformer) error {
+	_, err := referenceGrantInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.onReferenceGrantAdd,
+		UpdateFunc: c.onReferenceGrantUpdate,
+		DeleteFunc: c.onReferenceGrantDelete,
+	})
+	return err
+}
+
+func (c *Controller) onReferenceGrantAdd(obj interface{}) {
+	rg := obj.(*gatewayv1beta1.ReferenceGrant)
+	klog.V(4).InfoS("Adding ReferenceGrant", "referencegrant", klog.KObj(rg))
+	c.enqueueGatewaysForReferenceGrant(rg)
+}
+
+func (c *Controller) onReferenceGrantUpdate(old, newObj interface{}) {
+	oldRG := old.(*gatewayv1beta1.ReferenceGrant)
+	newRG := newObj.(*gatewayv1beta1.ReferenceGrant)
+	if !reflect.DeepEqual(oldRG.Spec, newRG.Spec) {
+		klog.V(4).InfoS("Updating ReferenceGrant", "referencegrant", klog.KObj(newRG))
+		c.enqueueGatewaysForReferenceGrant(newRG)
+	}
+}
+
+func (c *Controller) onReferenceGrantDelete(obj interface{}) {
+	rg, ok := obj.(*gatewayv1beta1.ReferenceGrant)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			runtime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		rg, ok = tombstone.Obj.(*gatewayv1beta1.ReferenceGrant)
+		if !ok {
+			runtime.HandleError(fmt.Errorf("tombstone contained object that is not a ReferenceGrant %#v", obj))
+			return
+		}
+	}
+	klog.V(4).InfoS("Deleting ReferenceGrant", "referencegrant", klog.KObj(rg))
+	c.enqueueGatewaysForReferenceGrant(rg)
+}
+
+// enqueueGatewaysForReferenceGrant finds all Gateways affected by a ReferenceGrant change.
+// This includes Gateways referenced by HTTPRoutes that target the ReferenceGrant's namespace,
+// and Gateways that reference Secrets in the ReferenceGrant's namespace.
+func (c *Controller) enqueueGatewaysForReferenceGrant(rg *gatewayv1beta1.ReferenceGrant) {
+	gatewaysToEnqueue := make(map[string]struct{})
+
+	// 1. Process HTTPRoutes
+	var routeObjs []interface{}
+	fallbackToListingAllHTTPRoutes := false
+	if c.gateway.httprouteIndexer != nil {
+		var err error
+		routeObjs, err = c.gateway.httprouteIndexer.ByIndex(HTTPRouteBackendRefNamespaceIndex, rg.Namespace)
+		if err != nil {
+			klog.Errorf("failed to get HTTPRoutes by index: %v", err)
+			fallbackToListingAllHTTPRoutes = true
+		}
+	} else {
+		fallbackToListingAllHTTPRoutes = true
+	}
+
+	if fallbackToListingAllHTTPRoutes {
+		// Fallback to listing all HTTPRoutes
+		routes, err := c.gateway.httprouteLister.List(labels.Everything())
+		if err != nil {
+			klog.Errorf("failed to list HTTPRoutes: %v", err)
+			return
+		}
+		for _, r := range routes {
+			routeObjs = append(routeObjs, r)
+		}
+	}
+
+	for _, obj := range routeObjs {
+		route := obj.(*gatewayv1.HTTPRoute)
+		for _, rule := range route.Spec.Rules {
+			for _, backendRef := range rule.BackendRefs {
+				ns := route.Namespace
+				if backendRef.Namespace != nil {
+					ns = string(*backendRef.Namespace)
+				}
+				if ns != rg.Namespace {
+					continue
+				}
+
+				for _, ref := range route.Spec.ParentRefs {
+					if !isGatewayParentRef(ref) {
+						continue
+					}
+					namespace := route.Namespace
+					if ref.Namespace != nil {
+						namespace = string(*ref.Namespace)
+					}
+					key := namespace + "/" + string(ref.Name)
+					gatewaysToEnqueue[key] = struct{}{}
+				}
+			}
+		}
+	}
+
+	// 2. Process Gateways referencing Secrets
+	var gwObjs []interface{}
+	fallbackToListingAllGateways := false
+	if c.gateway.gatewayIndexer != nil {
+		var err error
+		gwObjs, err = c.gateway.gatewayIndexer.ByIndex(GatewaySecretRefNamespaceIndex, rg.Namespace)
+		if err != nil {
+			klog.Errorf("failed to get Gateways by index: %v", err)
+			fallbackToListingAllGateways = true
+		}
+	} else {
+		fallbackToListingAllGateways = true
+	}
+
+	if fallbackToListingAllGateways {
+		// Fallback to listing all Gateways
+		gws, err := c.gateway.gatewayLister.List(labels.Everything())
+		if err != nil {
+			klog.Errorf("failed to list Gateways: %v", err)
+			return
+		}
+		for _, gw := range gws {
+			gwObjs = append(gwObjs, gw)
+		}
+	}
+
+	for _, obj := range gwObjs {
+		gw := obj.(*gatewayv1.Gateway)
+		for _, listener := range gw.Spec.Listeners {
+			if listener.TLS != nil {
+				for _, ref := range listener.TLS.CertificateRefs {
+					ns := gw.Namespace
+					if ref.Namespace != nil {
+						ns = string(*ref.Namespace)
+					}
+					if ns == rg.Namespace {
+						key := gw.Namespace + "/" + gw.Name
+						gatewaysToEnqueue[key] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+
+	for key := range gatewaysToEnqueue {
+		c.gatewayqueue.Add(key)
+	}
+}

--- a/pkg/controller/referencegrant_test.go
+++ b/pkg/controller/referencegrant_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewaylisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1"
+)
+
+func testControllerForEnqueueGatewaysForReferenceGrant(
+	httpRouteIndexer cache.Indexer,
+	gatewayIndexer cache.Indexer,
+) *Controller {
+	return &Controller{
+		gateway: gatewayResources{
+			httprouteLister:  gatewaylisters.NewHTTPRouteLister(httpRouteIndexer),
+			httprouteIndexer: httpRouteIndexer,
+			gatewayLister:    gatewaylisters.NewGatewayLister(gatewayIndexer),
+			gatewayIndexer:   gatewayIndexer,
+		},
+		gatewayqueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "gateway"},
+		),
+	}
+}
+
+func TestEnqueueGatewaysForReferenceGrant_HTTPRouteRef(t *testing.T) {
+	routeNS := "foo"
+	backendNS := "bar"
+	otherNS := "baz"
+	gwName := "my-gateway"
+
+	tests := []struct {
+		name         string
+		route        *gatewayv1.HTTPRoute
+		expectedKeys []string
+	}{
+		{
+			name: "route references backend in RG namespace",
+			route: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: routeNS},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{Name: gatewayv1.ObjectName(gwName)},
+						},
+					},
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name:      "some-svc",
+											Namespace: ptr.To(gatewayv1.Namespace(backendNS)),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedKeys: []string{routeNS + "/" + gwName},
+		},
+		{
+			name: "route does not reference backend in RG namespace",
+			route: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Name: "route2", Namespace: routeNS},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{Name: gatewayv1.ObjectName(gwName)},
+						},
+					},
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name:      "other-svc",
+											Namespace: ptr.To(gatewayv1.Namespace(otherNS)),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedKeys: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			httpRouteIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{HTTPRouteBackendRefNamespaceIndex: HTTPRouteBackendRefNamespaceIndexFunc})
+			gatewayIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{GatewaySecretRefNamespaceIndex: GatewaySecretRefNamespaceIndexFunc})
+
+			_ = httpRouteIndexer.Add(tt.route)
+
+			c := testControllerForEnqueueGatewaysForReferenceGrant(httpRouteIndexer, gatewayIndexer)
+			rg := &gatewayv1beta1.ReferenceGrant{
+				ObjectMeta: metav1.ObjectMeta{Name: "allow-foo", Namespace: backendNS},
+			}
+
+			c.enqueueGatewaysForReferenceGrant(rg)
+			keys := drainGatewayQueue(c)
+
+			if len(keys) != len(tt.expectedKeys) {
+				t.Fatalf("expected %d keys, got %v", len(tt.expectedKeys), keys)
+			}
+			for i, v := range keys {
+				if v != tt.expectedKeys[i] {
+					t.Errorf("expected key at index %d to be %q, got %q", i, tt.expectedKeys[i], v)
+				}
+			}
+		})
+	}
+}
+
+func TestEnqueueGatewaysForReferenceGrant_GatewaySecretRef(t *testing.T) {
+	gwNS := "foo"
+	secretNS := "bar"
+	otherNS := "baz"
+	gwName := "my-gateway"
+
+	tests := []struct {
+		name         string
+		gateway      *gatewayv1.Gateway
+		expectedKeys []string
+	}{
+		{
+			name: "gateway references secret in RG namespace",
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: gwNS},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{
+						{
+							TLS: &gatewayv1.ListenerTLSConfig{
+								CertificateRefs: []gatewayv1.SecretObjectReference{
+									{
+										Name:      "my-secret",
+										Namespace: ptr.To(gatewayv1.Namespace(secretNS)),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedKeys: []string{gwNS + "/" + gwName},
+		},
+		{
+			name: "gateway does not reference secret in RG namespace",
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "other-gateway", Namespace: gwNS},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{
+						{
+							TLS: &gatewayv1.ListenerTLSConfig{
+								CertificateRefs: []gatewayv1.SecretObjectReference{
+									{
+										Name:      "other-secret",
+										Namespace: ptr.To(gatewayv1.Namespace(otherNS)),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedKeys: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			httpRouteIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{HTTPRouteBackendRefNamespaceIndex: HTTPRouteBackendRefNamespaceIndexFunc})
+			gatewayIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{GatewaySecretRefNamespaceIndex: GatewaySecretRefNamespaceIndexFunc})
+
+			_ = gatewayIndexer.Add(tt.gateway)
+
+			c := testControllerForEnqueueGatewaysForReferenceGrant(httpRouteIndexer, gatewayIndexer)
+			rg := &gatewayv1beta1.ReferenceGrant{
+				ObjectMeta: metav1.ObjectMeta{Name: "allow-secret", Namespace: secretNS},
+			}
+
+			c.enqueueGatewaysForReferenceGrant(rg)
+			keys := drainGatewayQueue(c)
+
+			if len(keys) != len(tt.expectedKeys) {
+				t.Fatalf("expected %d keys, got %v", len(tt.expectedKeys), keys)
+			}
+			for i, v := range keys {
+				if v != tt.expectedKeys[i] {
+					t.Errorf("expected key at index %d to be %q, got %q", i, tt.expectedKeys[i], v)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -59,6 +59,44 @@ func HTTPRouteServiceRefIndexFunc(obj interface{}) ([]string, error) {
 	return keys, nil
 }
 
+// HTTPRouteBackendRefNamespaceIndex is the name of the index that maps target namespaces to HTTPRoutes
+// that reference resources in those namespaces in their backendRefs.
+const HTTPRouteBackendRefNamespaceIndex = "httpRouteBackendRefNamespace"
+
+// HTTPRouteBackendRefNamespaceIndexFunc returns the target namespaces for each backend reference
+// in an HTTPRoute's rules.
+func HTTPRouteBackendRefNamespaceIndexFunc(obj interface{}) ([]string, error) {
+	route, ok := obj.(*gatewayv1.HTTPRoute)
+	if !ok {
+		return nil, nil
+	}
+	var keys []string
+	for _, rule := range route.Spec.Rules {
+		for _, backend := range rule.BackendRefs {
+			backendNS := route.Namespace
+			if backend.Namespace != nil {
+				backendNS = string(*backend.Namespace)
+			}
+			keys = append(keys, backendNS)
+		}
+	}
+	// Deduplicate namespaces
+	keys = deduplicateStrings(keys)
+	return keys, nil
+}
+
+func deduplicateStrings(input []string) []string {
+	keys := make(map[string]bool)
+	list := []string{}
+	for _, entry := range input {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	return list
+}
+
 func (c *Controller) setupServiceEventHandlers(informer corev1informers.ServiceInformer) error {
 	_, err := informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onServiceAdd,
@@ -131,7 +169,7 @@ func (c *Controller) enqueueGatewaysForServiceDirectHTTPRouteRefs(svc *corev1.Se
 	for _, obj := range objs {
 		route := obj.(*gatewayv1.HTTPRoute)
 		// Cross-namespace refs require a ReferenceGrant in the backend namespace.
-		if !translator.AllowedByReferenceGrant(route.Namespace, svc.Namespace, c.gateway.referenceGrantLister) {
+		if !translator.AllowedByReferenceGrant(route.Namespace, gatewayv1.GroupName, "HTTPRoute", svc.Namespace, "", "Service", svc.Name, c.gateway.referenceGrantLister) {
 			continue
 		}
 		klog.V(4).InfoS(
@@ -163,7 +201,7 @@ func (c *Controller) enqueueGatewaysForServiceDirectHTTPRouteRefsList(svc *corev
 					backendNS = string(*backend.Namespace)
 				}
 				if backendNS == svc.Namespace && string(backend.Name) == svc.Name {
-					if !translator.AllowedByReferenceGrant(route.Namespace, backendNS, c.gateway.referenceGrantLister) {
+					if !translator.AllowedByReferenceGrant(route.Namespace, gatewayv1.GroupName, "HTTPRoute", backendNS, "", "Service", string(backend.Name), c.gateway.referenceGrantLister) {
 						continue
 					}
 					matched = true

--- a/pkg/controller/service_test.go
+++ b/pkg/controller/service_test.go
@@ -357,3 +357,149 @@ func TestEnqueueGatewaysForService_CrossNamespaceRef_WithoutReferenceGrant_Enque
 		t.Errorf("expected no gateway keys when cross-namespace ref has no ReferenceGrant, got %v", keys)
 	}
 }
+
+func TestDeduplicateStrings(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "empty input",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "no duplicates",
+			input:    []string{"a", "b", "c"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "duplicates",
+			input:    []string{"a", "b", "a", "c", "b"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "all duplicates",
+			input:    []string{"a", "a", "a"},
+			expected: []string{"a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := deduplicateStrings(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Fatalf("expected len %d, got %d", len(tt.expected), len(result))
+			}
+			for i, v := range result {
+				if v != tt.expected[i] {
+					t.Errorf("expected at index %d to be %q, got %q", i, tt.expected[i], v)
+				}
+			}
+		})
+	}
+}
+
+func TestHTTPRouteBackendRefNamespaceIndexFunc(t *testing.T) {
+	ns1 := "ns1"
+	ns2 := "ns2"
+	routeNS := "route-ns"
+
+	tests := []struct {
+		name     string
+		obj      interface{}
+		expected []string
+	}{
+		{
+			name:     "not an HTTPRoute",
+			obj:      "not a route",
+			expected: nil,
+		},
+		{
+			name: "route with no rules",
+			obj: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: routeNS},
+				Spec:       gatewayv1.HTTPRouteSpec{},
+			},
+			expected: []string{},
+		},
+		{
+			name: "route with rules but no backendRefs",
+			obj: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: routeNS},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{{}},
+				},
+			},
+			expected: []string{},
+		},
+		{
+			name: "route with backendRefs (same and cross namespace)",
+			obj: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: routeNS},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: "svc1",
+										},
+									},
+								},
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name:      "svc2",
+											Namespace: ptr.To(gatewayv1.Namespace(ns1)),
+										},
+									},
+								},
+							},
+						},
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name:      "svc3",
+											Namespace: ptr.To(gatewayv1.Namespace(ns2)),
+										},
+									},
+								},
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name:      "svc4",
+											Namespace: ptr.To(gatewayv1.Namespace(ns1)), // Duplicate ns1
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{routeNS, ns1, ns2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keys, err := HTTPRouteBackendRefNamespaceIndexFunc(tt.obj)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(keys) != len(tt.expected) {
+				t.Fatalf("expected len %d, got %d. keys: %v", len(tt.expected), len(keys), keys)
+			}
+			for i, v := range keys {
+				if v != tt.expected[i] {
+					t.Errorf("expected key at index %d to be %q, got %q", i, tt.expected[i], v)
+				}
+			}
+		})
+	}
+}

--- a/pkg/translator/backend.go
+++ b/pkg/translator/backend.go
@@ -124,7 +124,7 @@ func (t *Translator) fetchServiceBackend(routeNamespace string, backendRef gatew
 		ns = string(*backendRef.Namespace)
 	}
 	if t.referenceGrantLister != nil && ns != routeNamespace {
-		if !AllowedByReferenceGrant(routeNamespace, ns, t.referenceGrantLister) {
+		if !AllowedByReferenceGrant(routeNamespace, gatewayv1.GroupName, "HTTPRoute", ns, "", "Service", string(backendRef.Name), t.referenceGrantLister) {
 			return nil, &ControllerError{
 				Reason:  string(gatewayv1.RouteReasonRefNotPermitted),
 				Message: fmt.Sprintf("cross-namespace reference to Service %s/%s not permitted by ReferenceGrant", ns, backendRef.Name),

--- a/pkg/translator/referencegrant.go
+++ b/pkg/translator/referencegrant.go
@@ -18,42 +18,49 @@ package translator
 
 import (
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
 
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewaylistersv1beta1 "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1beta1"
 )
 
-// AllowedByReferenceGrant returns true if an HTTPRoute in routeNamespace is allowed
-// to reference a Service in backendNamespace per the Gateway API ReferenceGrant spec.
+// AllowedByReferenceGrant returns true if a resource of fromGroup/fromKind in fromNamespace is allowed
+// to reference a resource of toGroup/toKind in toNamespace per the Gateway API ReferenceGrant spec.
 // See https://gateway-api.sigs.k8s.io/api-types/referencegrant/
 func AllowedByReferenceGrant(
-	routeNamespace, backendNamespace string,
+	fromNamespace, fromGroup, fromKind string,
+	toNamespace, toGroup, toKind, toName string,
 	referenceGrantLister gatewaylistersv1beta1.ReferenceGrantLister,
 ) bool {
-	if routeNamespace == backendNamespace {
+	if fromNamespace == toNamespace {
 		return true
 	}
-	grants, err := referenceGrantLister.ReferenceGrants(backendNamespace).List(labels.Everything())
+
+	grants, err := referenceGrantLister.ReferenceGrants(toNamespace).List(labels.Everything())
 	if err != nil {
+		klog.V(4).ErrorS(err, "Failed to list ReferenceGrants", "toNamespace", toNamespace)
 		return false
 	}
+
 	for _, g := range grants {
 		for _, from := range g.Spec.From {
-			if string(from.Namespace) != routeNamespace {
+			if string(from.Namespace) != fromNamespace {
 				continue
 			}
-			if string(from.Group) != gatewayv1.GroupName {
+			if string(from.Group) != fromGroup {
 				continue
 			}
-			if string(from.Kind) != "HTTPRoute" {
+			if string(from.Kind) != fromKind {
 				continue
 			}
+
 			for _, to := range g.Spec.To {
-				// Core Services: empty group
-				if string(to.Group) != "" {
+				if string(to.Group) != toGroup {
 					continue
 				}
-				if string(to.Kind) != "Service" {
+				if string(to.Kind) != toKind {
+					continue
+				}
+				if to.Name != nil && string(*to.Name) != toName {
 					continue
 				}
 				return true

--- a/pkg/translator/referencegrant_test.go
+++ b/pkg/translator/referencegrant_test.go
@@ -1,0 +1,339 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translator
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
+	gatewayinformers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
+)
+
+func TestAllowedByReferenceGrant(t *testing.T) {
+	tests := []struct {
+		name          string
+		fromNamespace string
+		fromGroup     string
+		fromKind      string
+		toNamespace   string
+		toGroup       string
+		toKind        string
+		toName        string
+		grants        []*gatewayv1beta1.ReferenceGrant
+		expected      bool
+	}{
+		{
+			name:          "same namespace",
+			fromNamespace: "ns1",
+			toNamespace:   "ns1",
+			expected:      true,
+		},
+		{
+			name:          "allowed cross-namespace",
+			fromNamespace: "ns1",
+			fromGroup:     gatewayv1.GroupName,
+			fromKind:      "HTTPRoute",
+			toNamespace:   "ns2",
+			toGroup:       "",
+			toKind:        "Service",
+			toName:        "svc1",
+			grants: []*gatewayv1beta1.ReferenceGrant{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "rg1", Namespace: "ns2"},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Namespace: "ns1",
+								Group:     gatewayv1.Group(gatewayv1.GroupName),
+								Kind:      "HTTPRoute",
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "",
+								Kind:  "Service",
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:          "allowed cross-namespace with name specific",
+			fromNamespace: "ns1",
+			fromGroup:     gatewayv1.GroupName,
+			fromKind:      "HTTPRoute",
+			toNamespace:   "ns2",
+			toGroup:       "",
+			toKind:        "Service",
+			toName:        "svc1",
+			grants: []*gatewayv1beta1.ReferenceGrant{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "rg1", Namespace: "ns2"},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Namespace: "ns1",
+								Group:     gatewayv1.Group(gatewayv1.GroupName),
+								Kind:      "HTTPRoute",
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "",
+								Kind:  "Service",
+								Name:  ptr.To(gatewayv1.ObjectName("svc1")),
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:          "not allowed cross-namespace - no grant",
+			fromNamespace: "ns1",
+			fromGroup:     gatewayv1.GroupName,
+			fromKind:      "HTTPRoute",
+			toNamespace:   "ns2",
+			toGroup:       "",
+			toKind:        "Service",
+			toName:        "svc1",
+			expected:      false,
+		},
+		{
+			name:          "not allowed cross-namespace - from namespace mismatch",
+			fromNamespace: "ns_other",
+			fromGroup:     gatewayv1.GroupName,
+			fromKind:      "HTTPRoute",
+			toNamespace:   "ns2",
+			toGroup:       "",
+			toKind:        "Service",
+			toName:        "svc1",
+			grants: []*gatewayv1beta1.ReferenceGrant{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "rg1", Namespace: "ns2"},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Namespace: "ns1",
+								Group:     gatewayv1.Group(gatewayv1.GroupName),
+								Kind:      "HTTPRoute",
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "",
+								Kind:  "Service",
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:          "not allowed cross-namespace - from group mismatch",
+			fromNamespace: "ns1",
+			fromGroup:     "other.group",
+			fromKind:      "HTTPRoute",
+			toNamespace:   "ns2",
+			toGroup:       "",
+			toKind:        "Service",
+			toName:        "svc1",
+			grants: []*gatewayv1beta1.ReferenceGrant{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "rg1", Namespace: "ns2"},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Namespace: "ns1",
+								Group:     gatewayv1.Group(gatewayv1.GroupName),
+								Kind:      "HTTPRoute",
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "",
+								Kind:  "Service",
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:          "not allowed cross-namespace - from kind mismatch",
+			fromNamespace: "ns1",
+			fromGroup:     gatewayv1.GroupName,
+			fromKind:      "OtherRoute",
+			toNamespace:   "ns2",
+			toGroup:       "",
+			toKind:        "Service",
+			toName:        "svc1",
+			grants: []*gatewayv1beta1.ReferenceGrant{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "rg1", Namespace: "ns2"},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Namespace: "ns1",
+								Group:     gatewayv1.Group(gatewayv1.GroupName),
+								Kind:      "HTTPRoute",
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "",
+								Kind:  "Service",
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:          "not allowed cross-namespace - to group mismatch",
+			fromNamespace: "ns1",
+			fromGroup:     gatewayv1.GroupName,
+			fromKind:      "HTTPRoute",
+			toNamespace:   "ns2",
+			toGroup:       "other.group",
+			toKind:        "Service",
+			toName:        "svc1",
+			grants: []*gatewayv1beta1.ReferenceGrant{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "rg1", Namespace: "ns2"},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Namespace: "ns1",
+								Group:     gatewayv1.Group(gatewayv1.GroupName),
+								Kind:      "HTTPRoute",
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "",
+								Kind:  "Service",
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:          "not allowed cross-namespace - to kind mismatch",
+			fromNamespace: "ns1",
+			fromGroup:     gatewayv1.GroupName,
+			fromKind:      "HTTPRoute",
+			toNamespace:   "ns2",
+			toGroup:       "",
+			toKind:        "OtherResource",
+			toName:        "svc1",
+			grants: []*gatewayv1beta1.ReferenceGrant{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "rg1", Namespace: "ns2"},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Namespace: "ns1",
+								Group:     gatewayv1.Group(gatewayv1.GroupName),
+								Kind:      "HTTPRoute",
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "",
+								Kind:  "Service",
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:          "not allowed cross-namespace - to name mismatch",
+			fromNamespace: "ns1",
+			fromGroup:     gatewayv1.GroupName,
+			fromKind:      "HTTPRoute",
+			toNamespace:   "ns2",
+			toGroup:       "",
+			toKind:        "Service",
+			toName:        "svc_other",
+			grants: []*gatewayv1beta1.ReferenceGrant{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "rg1", Namespace: "ns2"},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Namespace: "ns1",
+								Group:     gatewayv1.Group(gatewayv1.GroupName),
+								Kind:      "HTTPRoute",
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "",
+								Kind:  "Service",
+								Name:  ptr.To(gatewayv1.ObjectName("svc1")),
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var objs []runtime.Object
+			for _, g := range tc.grants {
+				objs = append(objs, g)
+			}
+			fakeClient := gatewayclient.NewClientset(objs...)
+			informerFactory := gatewayinformers.NewSharedInformerFactory(fakeClient, 0)
+			lister := informerFactory.Gateway().V1beta1().ReferenceGrants().Lister()
+
+			// Populate cache
+			for _, g := range tc.grants {
+				_ = informerFactory.Gateway().V1beta1().ReferenceGrants().Informer().GetIndexer().Add(g)
+			}
+
+			got := AllowedByReferenceGrant(
+				tc.fromNamespace, tc.fromGroup, tc.fromKind,
+				tc.toNamespace, tc.toGroup, tc.toKind, tc.toName,
+				lister,
+			)
+
+			if got != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add event handlers for ReferenceGrant in controller to trigger Gateway reconciliation.
- Make AllowedByReferenceGrant in translator generic to accept from/to group and kind.
- Update call sites in backend.go and service.go to use the new signature.
- Implement HTTPRouteBackendRefNamespaceIndex and GatewaySecretRefNamespaceIndex to optimize lookups.
- Restructure enqueueGatewaysForReferenceGrant to use indexers with list fallbacks.
- Replace hardcoded group name strings with gatewayv1.GroupName constant.
- Add comprehensive unit tests for AllowedByReferenceGrant and indexer functions.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind feature

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
