### PR TITLE
Change Envoy proxy Service type to LoadBalancer and add MetalLB to E2E test

### DIFF
--- a/dev/ci/run-e2e.sh
+++ b/dev/ci/run-e2e.sh
@@ -34,6 +34,54 @@ main() {
   kind delete cluster --name "${CLUSTER_NAME}" || true
   kind create cluster --name "${CLUSTER_NAME}" --config dev/ci/kind-config.yaml --wait 5m
 
+  # MetalLB enables Kind clusters to provide external IPs for LoadBalancer services.
+  # Kind (Kubernetes in Docker) does not come with a native LoadBalancer provider.
+  # Without MetalLB (or a similar tool), any Kubernetes Service of type LoadBalancer (which
+  # is typically used to expose the Gateway) would remain in a <pending> state forever, and
+  # the tests would fail.
+  header "Installing MetalLB"
+  local metallb_version="v0.13.10"
+  kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/"${metallb_version}"/config/manifests/metallb-native.yaml
+
+  needCreate="$(kubectl get secret -n metallb-system memberlist --no-headers --ignore-not-found -o custom-columns=NAME:.metadata.name)"
+  if [ -z "$needCreate" ]; then
+      kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+  fi
+
+  # Wait for MetalLB to become available
+  kubectl rollout status -n metallb-system deployment/controller --timeout 5m
+  kubectl rollout status -n metallb-system daemonset/speaker --timeout 5m
+
+  # Configure MetalLB with an IP address pool derived from the Docker network used by Kind.
+  # We inspect the 'kind' network to find the subnet, and take the range .200 to .250.
+  # This range is safe to use because it is at the high end of the subnet, well outside
+  # the range Docker typically uses when dynamically assigning IPs to containers (Kind nodes).
+  # For example, if the subnet is 192.168.8.0/24, address_first_three_octets will
+  # be 192.168.8 and the range will be 192.168.8.200-192.168.8.250.
+  subnet=$(docker network inspect kind | jq -r '.[].IPAM.Config[].Subnet | select(contains(":") | not)')
+  address_first_three_octets=$(echo "${subnet}" | awk -F. '{printf "%s.%s.%s",$1,$2,$3}')
+  address_range="${address_first_three_octets}.200-${address_first_three_octets}.250"
+
+  kubectl apply -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: kube-services
+spec:
+  addresses:
+  - ${address_range}
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: kube-services
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - kube-services
+EOF
+
   header "Building controller image"
   # These must match the image used in k8s/deploy/deployment.yaml
   REGISTRY="us-central1-docker.pkg.dev/k8s-staging-images/agentic-net"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -60,7 +60,7 @@ import (
 
 // maxGatewaySyncRetries is the maximum number of rate-limited requeues for a
 // single Gateway key before the worker drops it (avoids infinite hot loops).
-const maxGatewaySyncRetries = 15
+const maxGatewaySyncRetries = 30
 
 // maxBackendFinalizerRetries is the same cap for the XBackend finalizer queue.
 const maxBackendFinalizerRetries = 15
@@ -411,7 +411,7 @@ func (c *Controller) syncGateway(ctx context.Context, key string) error {
 
 	// Ensure Envoy proxy deployment and service exist.
 	rm := envoy.NewResourceManager(c.core.client, gateway, c.envoyImage, c.agenticIdentityTrustDomain)
-	proxyIP, err := rm.EnsureProxyExist(ctx)
+	proxyAddress, err := rm.EnsureProxyExist(ctx)
 	if err != nil {
 		updateErr := updateGatewayStatus(ctx, c, gateway, newGW, nil, err)
 		return errors.Join(err, updateErr)
@@ -419,15 +419,23 @@ func (c *Controller) syncGateway(ctx context.Context, key string) error {
 
 	// TODO: Add support for IPv6?
 	newGW.Status.Addresses = []gatewayv1.GatewayStatusAddress{}
-	if net.ParseIP(proxyIP) != nil {
+	if net.ParseIP(proxyAddress) != nil {
+		// proxyAddress is an IP address
 		newGW.Status.Addresses = append(newGW.Status.Addresses,
 			gatewayv1.GatewayStatusAddress{
 				Type:  ptr.To(gatewayv1.IPAddressType),
-				Value: proxyIP,
+				Value: proxyAddress,
+			})
+	} else {
+		// proxyAddress is a hostname
+		newGW.Status.Addresses = append(newGW.Status.Addresses,
+			gatewayv1.GatewayStatusAddress{
+				Type:  ptr.To(gatewayv1.HostnameAddressType),
+				Value: proxyAddress,
 			})
 	}
 
-	logger.Info("Ensured Envoy proxy for gateway exists", "nodeID", rm.NodeID(), "proxyIP", proxyIP)
+	logger.Info("Ensured Envoy proxy for gateway exists", "nodeID", rm.NodeID(), "proxyAddress", proxyAddress)
 
 	// Translate Gateway to xDS resources (includes only current HTTPRoutes/XAccessPolicies; stale rules are omitted).
 	resources, listenerStatuses, httpRouteStatuses, _, err := c.translator.TranslateGatewayToXDS(ctx, gateway)

--- a/pkg/infra/envoy/proxy.go
+++ b/pkg/infra/envoy/proxy.go
@@ -69,7 +69,7 @@ func proxyName(namespace, name string) string {
 }
 
 // EnsureProxyExist ensures that the Envoy proxy deployment, service, and other resources exist and are ready.
-// It returns the ClusterIP of the proxy service.
+// It returns the LoadBalancer address (IP or Hostname) of the proxy service.
 func (r *ResourceManager) EnsureProxyExist(ctx context.Context) (string, error) {
 	logger := klog.FromContext(ctx).WithValues("resourceName", klog.KRef(r.namespace, r.nodeID))
 	ctx = klog.NewContext(ctx, logger)
@@ -169,10 +169,11 @@ func (r *ResourceManager) ensureDeployment(ctx context.Context) error {
 	return fmt.Errorf("envoy deployment %s is not available yet", deployment.Name)
 }
 
-// ensureService ensures that the Service for the Envoy proxy exists and has a ClusterIP assigned.
+// ensureService ensures that the Service for the Envoy proxy exists and has a LoadBalancer address (IP or Hostname) assigned.
 func (r *ResourceManager) ensureService(ctx context.Context) (string, error) {
 	logger := klog.FromContext(ctx)
 	service := r.renderService()
+
 	svc, err := r.client.CoreV1().Services(service.Namespace).Get(ctx, service.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -186,19 +187,30 @@ func (r *ResourceManager) ensureService(ctx context.Context) (string, error) {
 		}
 	}
 
-	if svc.Spec.ClusterIP == "" {
-		svc, err = r.client.CoreV1().Services(service.Namespace).Get(ctx, service.Name, metav1.GetOptions{})
-		if err != nil {
-			return "", fmt.Errorf("failed to refresh envoy service: %w", err)
-		}
+	svc, err = r.client.CoreV1().Services(service.Namespace).Get(ctx, service.Name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to refresh envoy service: %w", err)
 	}
 
-	if svc.Spec.ClusterIP == "" {
-		return "", fmt.Errorf("envoy service %s is not ready yet", service.Name)
+	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return "", fmt.Errorf("envoy service %s type is %s, expected %s", service.Name, svc.Spec.Type, corev1.ServiceTypeLoadBalancer)
 	}
 
-	logger.Info("Envoy proxy service is ready!")
-	return svc.Spec.ClusterIP, nil
+	if len(svc.Status.LoadBalancer.Ingress) == 0 {
+		return "", fmt.Errorf("loadbalancer address is not assigned yet for service %s", service.Name)
+	}
+
+	ingress := svc.Status.LoadBalancer.Ingress[0]
+	address := ingress.IP
+	if address == "" {
+		address = ingress.Hostname
+	}
+	if address == "" {
+		return "", fmt.Errorf("loadbalancer IP or Hostname is not assigned yet for service %s", service.Name)
+	}
+
+	logger.Info("Envoy proxy service is ready with LoadBalancer address!", "address", address)
+	return address, nil
 }
 
 func DeleteProxy(ctx context.Context, client kubernetes.Interface, namespace, name string) error {

--- a/pkg/infra/envoy/proxy_test.go
+++ b/pkg/infra/envoy/proxy_test.go
@@ -110,13 +110,13 @@ func TestEnsureService(t *testing.T) {
 	}
 	nodeID := proxyName(gw.Namespace, gw.Name)
 
-	t.Run("service not found, creates and returns error (no ClusterIP)", func(t *testing.T) {
+	t.Run("service not found, creates and returns error (no LoadBalancer address)", func(t *testing.T) {
 		client := fake.NewClientset()
 		rm := NewResourceManager(client, gw, "envoy-image", "cluster.local")
 
 		_, err := rm.ensureService(context.Background())
 		if err == nil {
-			t.Fatal("expected error as service has no ClusterIP")
+			t.Fatal("expected error as service has no LoadBalancer address")
 		}
 
 		// Verify service was created
@@ -126,14 +126,14 @@ func TestEnsureService(t *testing.T) {
 		}
 	})
 
-	t.Run("service exists but no ClusterIP, returns error", func(t *testing.T) {
+	t.Run("service exists but no LoadBalancer address, returns error", func(t *testing.T) {
 		svc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nodeID,
 				Namespace: "test-ns",
 			},
 			Spec: corev1.ServiceSpec{
-				ClusterIP: "",
+				Type: corev1.ServiceTypeLoadBalancer,
 			},
 		}
 		client := fake.NewClientset(svc)
@@ -141,18 +141,25 @@ func TestEnsureService(t *testing.T) {
 
 		_, err := rm.ensureService(context.Background())
 		if err == nil {
-			t.Fatal("expected error as service has no ClusterIP")
+			t.Fatal("expected error as service has no LoadBalancer address")
 		}
 	})
 
-	t.Run("service exists and has ClusterIP, returns IP", func(t *testing.T) {
+	t.Run("service exists and has LoadBalancer IP, returns IP", func(t *testing.T) {
 		svc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nodeID,
 				Namespace: "test-ns",
 			},
 			Spec: corev1.ServiceSpec{
-				ClusterIP: "10.0.0.1",
+				Type: corev1.ServiceTypeLoadBalancer,
+			},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{IP: "10.0.0.1"},
+					},
+				},
 			},
 		}
 		client := fake.NewClientset(svc)
@@ -164,6 +171,35 @@ func TestEnsureService(t *testing.T) {
 		}
 		if ip != "10.0.0.1" {
 			t.Errorf("ensureService() = %s, want %s", ip, "10.0.0.1")
+		}
+	})
+
+	t.Run("service exists and has LoadBalancer Hostname, returns Hostname", func(t *testing.T) {
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeID,
+				Namespace: "test-ns",
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+			},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{Hostname: "envoy.example.com"},
+					},
+				},
+			},
+		}
+		client := fake.NewClientset(svc)
+		rm := NewResourceManager(client, gw, "envoy-image", "cluster.local")
+
+		address, err := rm.ensureService(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if address != "envoy.example.com" {
+			t.Errorf("ensureService() = %s, want %s", address, "envoy.example.com")
 		}
 	})
 }

--- a/pkg/infra/envoy/resourcerender.go
+++ b/pkg/infra/envoy/resourcerender.go
@@ -340,7 +340,7 @@ func (r *ResourceManager) renderService() *corev1.Service {
 			OwnerReferences: ownerRef(r.gw),
 		},
 		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeClusterIP,
+			Type: corev1.ServiceTypeLoadBalancer,
 			Selector: map[string]string{
 				"app": r.nodeID,
 			},

--- a/site-src/guides/quickstart/run-quickstart.sh
+++ b/site-src/guides/quickstart/run-quickstart.sh
@@ -178,6 +178,9 @@ create_kind_cluster() {
   kubectl config use-context "kind-${CLUSTER_NAME}"
 }
 
+# TODO: install MetalLB after us-central1-docker.pkg.dev/k8s-staging-images/agentic-net/agentic-networking-controller:main
+# includes the changes in https://github.com/kubernetes-sigs/kube-agentic-networking/pull/244
+
 # --- Step 2: Install Gateway API CRDs ---
 
 install_gateway_api_crds() {

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -502,7 +502,7 @@ func deployCommonTestResources(t *testing.T) (namespace, gatewayIP string, clean
 
 	// Return the Gateway IP
 	t.Log("Obtain Gateway Address from status")
-	err = retry(20, 2*time.Second, func() error {
+	err = retry(50, 10*time.Second, func() error {
 		out := runKubectlOutput(t, "get", "gateway", "e2e-gateway", "-n", namespace, "-o", "jsonpath={.status.addresses[*].value}")
 		values := strings.Fields(strings.TrimSpace(out))
 		if len(values) == 0 {


### PR DESCRIPTION
    Fix translator status reporting and add Hostname support for LoadBalancer
    
    - Fix translator status reporting for listeners and routes.
    - Extend ensureService and Gateway status to handle LoadBalancer Hostnames in addition to IPs.
    - Increased controller retries to 30 to prevent it from giving up on LoadBalancer assignment too early.
    - Increased test-side retries in controller_test.go to 50 times with 10s interval to prevent the test runner from timing out while the controller was still retrying.
    - Update unit tests in proxy_test.go to cover both IP and Hostname cases.
    - Add detailed comments about MetalLB configuration in run-e2e.sh.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind feature

**What this PR does / why we need it**:
With the Envoy proxy type `ClusterIP`, the Gateway Address is a cluster-internal IP and not reachable from outside the cluster. 
Gateway API conformance tests are typically executed from the host machine (your laptop or the CI runner), not from within a pod in the cluster.




**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
