### PR TITLE
envoy: server-side apply, skip unchanged applies, and ConfigMap checksum for pod rollouts

### DIFF
--- a/pkg/constants/envoynames.go
+++ b/pkg/constants/envoynames.go
@@ -41,6 +41,10 @@ const (
 	// This label was formally introduced in https://gateway-api.sigs.k8s.io/geps/gep-1762/#automated-deployments.
 	GatewayNameLabel = "gateway.networking.k8s.io/gateway-name"
 
+	// EnvoyInfraConfigChecksumAnnotation is applied to the Envoy Deployment pod template so updates to
+	// rendered bootstrap/SDS ConfigMap data roll pods (ConfigMap volume updates alone do not restart containers).
+	EnvoyInfraConfigChecksumAnnotation = ProjectName + "/envoy-infra-config-checksum"
+
 	// GatewayExtAuthRBACFilterName is the name for Envoy RBAC filter for Gateway ExternalAuth shadowRules.
 	GatewayExtAuthRBACFilterName = "envoy.filters.http.rbac.gateway_extauth"
 	// BackendExtAuthRBACFilterName is the name for Envoy RBAC filter for Backend ExternalAuth shadowRules.

--- a/pkg/infra/envoy/apply.go
+++ b/pkg/infra/envoy/apply.go
@@ -1,0 +1,281 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envoy
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	applyappsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+)
+
+// envoyInfraFieldManager is the server-side apply field manager for Envoy proxy
+// ServiceAccount, ConfigMap, Deployment, and Service objects.
+const envoyInfraFieldManager = "agentic-networking.sigs.k8s.io/envoy-proxy"
+
+func envoyInfraApplyOptions() metav1.ApplyOptions {
+	return metav1.ApplyOptions{
+		FieldManager: envoyInfraFieldManager,
+		Force:        true,
+	}
+}
+
+func ownerReferencesApply(refs []metav1.OwnerReference) []*applymetav1.OwnerReferenceApplyConfiguration {
+	out := make([]*applymetav1.OwnerReferenceApplyConfiguration, 0, len(refs))
+	for _, ref := range refs {
+		r := applymetav1.OwnerReference().
+			WithAPIVersion(ref.APIVersion).
+			WithKind(ref.Kind).
+			WithName(ref.Name).
+			WithUID(ref.UID)
+		if ref.Controller != nil {
+			r.WithController(*ref.Controller)
+		}
+		if ref.BlockOwnerDeletion != nil {
+			r.WithBlockOwnerDeletion(*ref.BlockOwnerDeletion)
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func serviceAccountApply(sa *corev1.ServiceAccount) *applycorev1.ServiceAccountApplyConfiguration {
+	b := applycorev1.ServiceAccount(sa.Name, sa.Namespace)
+	if len(sa.Labels) > 0 {
+		b.WithLabels(sa.Labels)
+	}
+	if len(sa.Annotations) > 0 {
+		b.WithAnnotations(sa.Annotations)
+	}
+	if len(sa.OwnerReferences) > 0 {
+		b.WithOwnerReferences(ownerReferencesApply(sa.OwnerReferences)...)
+	}
+	return b
+}
+
+func configMapApply(cm *corev1.ConfigMap) *applycorev1.ConfigMapApplyConfiguration {
+	b := applycorev1.ConfigMap(cm.Name, cm.Namespace)
+	if len(cm.Labels) > 0 {
+		b.WithLabels(cm.Labels)
+	}
+	if len(cm.Annotations) > 0 {
+		b.WithAnnotations(cm.Annotations)
+	}
+	if len(cm.OwnerReferences) > 0 {
+		b.WithOwnerReferences(ownerReferencesApply(cm.OwnerReferences)...)
+	}
+	if cm.Immutable != nil {
+		b.WithImmutable(*cm.Immutable)
+	}
+	b.Data = cm.Data
+	b.BinaryData = cm.BinaryData
+	return b
+}
+
+func serviceApply(svc *corev1.Service) *applycorev1.ServiceApplyConfiguration {
+	b := applycorev1.Service(svc.Name, svc.Namespace)
+	if len(svc.Labels) > 0 {
+		b.WithLabels(svc.Labels)
+	}
+	if len(svc.Annotations) > 0 {
+		b.WithAnnotations(svc.Annotations)
+	}
+	if len(svc.OwnerReferences) > 0 {
+		b.WithOwnerReferences(ownerReferencesApply(svc.OwnerReferences)...)
+	}
+	spec := applycorev1.ServiceSpec().WithType(svc.Spec.Type).WithSelector(svc.Spec.Selector)
+	ports := make([]*applycorev1.ServicePortApplyConfiguration, 0, len(svc.Spec.Ports))
+	for i := range svc.Spec.Ports {
+		p := &svc.Spec.Ports[i]
+		sp := applycorev1.ServicePort().
+			WithName(p.Name).
+			WithPort(p.Port).
+			WithProtocol(p.Protocol)
+		ports = append(ports, sp)
+	}
+	spec.WithPorts(ports...)
+	b.WithSpec(spec)
+	return b
+}
+
+func deploymentApply(d *appsv1.Deployment) *applyappsv1.DeploymentApplyConfiguration {
+	dep := applyappsv1.Deployment(d.Name, d.Namespace)
+	if len(d.Labels) > 0 {
+		dep.WithLabels(d.Labels)
+	}
+	if len(d.Annotations) > 0 {
+		dep.WithAnnotations(d.Annotations)
+	}
+	if len(d.OwnerReferences) > 0 {
+		dep.WithOwnerReferences(ownerReferencesApply(d.OwnerReferences)...)
+	}
+	spec := applyappsv1.DeploymentSpec()
+	if d.Spec.Replicas != nil {
+		spec.WithReplicas(*d.Spec.Replicas)
+	}
+	if d.Spec.Selector != nil {
+		spec.WithSelector(applymetav1.LabelSelector().WithMatchLabels(d.Spec.Selector.MatchLabels))
+	}
+	tpl := applycorev1.PodTemplateSpec()
+	if len(d.Spec.Template.Labels) > 0 {
+		tpl.WithLabels(d.Spec.Template.Labels)
+	}
+	if len(d.Spec.Template.Annotations) > 0 {
+		tpl.WithAnnotations(d.Spec.Template.Annotations)
+	}
+	tpl.WithSpec(podSpecApply(&d.Spec.Template.Spec))
+	spec.WithTemplate(tpl)
+	dep.WithSpec(spec)
+	return dep
+}
+
+func podSpecApply(ps *corev1.PodSpec) *applycorev1.PodSpecApplyConfiguration {
+	out := applycorev1.PodSpec().WithServiceAccountName(ps.ServiceAccountName)
+	vols := make([]*applycorev1.VolumeApplyConfiguration, 0, len(ps.Volumes))
+	for i := range ps.Volumes {
+		vols = append(vols, volumeApply(&ps.Volumes[i]))
+	}
+	if len(vols) > 0 {
+		out.WithVolumes(vols...)
+	}
+	ctrs := make([]*applycorev1.ContainerApplyConfiguration, 0, len(ps.Containers))
+	for i := range ps.Containers {
+		ctrs = append(ctrs, containerApply(&ps.Containers[i]))
+	}
+	if len(ctrs) > 0 {
+		out.WithContainers(ctrs...)
+	}
+	return out
+}
+
+func containerApply(c *corev1.Container) *applycorev1.ContainerApplyConfiguration {
+	out := applycorev1.Container().WithName(c.Name).WithImage(c.Image)
+	for _, s := range c.Command {
+		out.WithCommand(s)
+	}
+	for _, s := range c.Args {
+		out.WithArgs(s)
+	}
+	for i := range c.VolumeMounts {
+		out.WithVolumeMounts(volumeMountApply(&c.VolumeMounts[i]))
+	}
+	return out
+}
+
+func volumeMountApply(vm *corev1.VolumeMount) *applycorev1.VolumeMountApplyConfiguration {
+	m := applycorev1.VolumeMount().WithName(vm.Name).WithMountPath(vm.MountPath)
+	if vm.ReadOnly {
+		m.WithReadOnly(true)
+	}
+	if vm.SubPath != "" {
+		m.WithSubPath(vm.SubPath)
+	}
+	if vm.MountPropagation != nil {
+		m.WithMountPropagation(*vm.MountPropagation)
+	}
+	if vm.RecursiveReadOnly != nil {
+		m.WithRecursiveReadOnly(*vm.RecursiveReadOnly)
+	}
+	if vm.SubPathExpr != "" {
+		m.WithSubPathExpr(vm.SubPathExpr)
+	}
+	return m
+}
+
+func volumeApply(v *corev1.Volume) *applycorev1.VolumeApplyConfiguration {
+	va := applycorev1.Volume().WithName(v.Name)
+	if v.ConfigMap != nil {
+		cm := applycorev1.ConfigMapVolumeSource().WithName(v.ConfigMap.Name)
+		if v.ConfigMap.DefaultMode != nil {
+			cm.WithDefaultMode(*v.ConfigMap.DefaultMode)
+		}
+		for i := range v.ConfigMap.Items {
+			cm.WithItems(keyToPathApply(&v.ConfigMap.Items[i]))
+		}
+		if v.ConfigMap.Optional != nil {
+			cm.WithOptional(*v.ConfigMap.Optional)
+		}
+		return va.WithConfigMap(cm)
+	}
+	if v.Projected != nil {
+		pj := applycorev1.ProjectedVolumeSource()
+		if v.Projected.DefaultMode != nil {
+			pj.WithDefaultMode(*v.Projected.DefaultMode)
+		}
+		for i := range v.Projected.Sources {
+			pj.WithSources(volumeProjectionApply(&v.Projected.Sources[i]))
+		}
+		return va.WithProjected(pj)
+	}
+	return va
+}
+
+func keyToPathApply(k *corev1.KeyToPath) *applycorev1.KeyToPathApplyConfiguration {
+	kp := applycorev1.KeyToPath().WithKey(k.Key).WithPath(k.Path)
+	if k.Mode != nil {
+		kp.WithMode(*k.Mode)
+	}
+	return kp
+}
+
+func volumeProjectionApply(p *corev1.VolumeProjection) *applycorev1.VolumeProjectionApplyConfiguration {
+	vp := applycorev1.VolumeProjection()
+	if p.ClusterTrustBundle != nil {
+		ctb := applycorev1.ClusterTrustBundleProjection().WithPath(p.ClusterTrustBundle.Path)
+		if p.ClusterTrustBundle.Name != nil {
+			ctb.WithName(*p.ClusterTrustBundle.Name)
+		}
+		if p.ClusterTrustBundle.SignerName != nil {
+			ctb.WithSignerName(*p.ClusterTrustBundle.SignerName)
+		}
+		if p.ClusterTrustBundle.LabelSelector != nil {
+			ls := applymetav1.LabelSelector()
+			if len(p.ClusterTrustBundle.LabelSelector.MatchLabels) > 0 {
+				ls.WithMatchLabels(p.ClusterTrustBundle.LabelSelector.MatchLabels)
+			}
+			ctb.WithLabelSelector(ls)
+		}
+		if p.ClusterTrustBundle.Optional != nil {
+			ctb.WithOptional(*p.ClusterTrustBundle.Optional)
+		}
+		vp.WithClusterTrustBundle(ctb)
+	}
+	if p.PodCertificate != nil {
+		pc := applycorev1.PodCertificateProjection().
+			WithSignerName(p.PodCertificate.SignerName).
+			WithKeyType(p.PodCertificate.KeyType)
+		if p.PodCertificate.MaxExpirationSeconds != nil {
+			pc.WithMaxExpirationSeconds(*p.PodCertificate.MaxExpirationSeconds)
+		}
+		if p.PodCertificate.CredentialBundlePath != "" {
+			pc.WithCredentialBundlePath(p.PodCertificate.CredentialBundlePath)
+		}
+		if p.PodCertificate.KeyPath != "" {
+			pc.WithKeyPath(p.PodCertificate.KeyPath)
+		}
+		if p.PodCertificate.CertificateChainPath != "" {
+			pc.WithCertificateChainPath(p.PodCertificate.CertificateChainPath)
+		}
+		if len(p.PodCertificate.UserAnnotations) > 0 {
+			pc.WithUserAnnotations(p.PodCertificate.UserAnnotations)
+		}
+		vp.WithPodCertificate(pc)
+	}
+	return vp
+}

--- a/pkg/infra/envoy/proxy.go
+++ b/pkg/infra/envoy/proxy.go
@@ -22,8 +22,8 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -68,8 +68,8 @@ func proxyName(namespace, name string) string {
 	return fmt.Sprintf(constants.ProxyNameFormat, hex.EncodeToString(hash[:6]))
 }
 
-// EnsureProxyExist ensures that the Envoy proxy deployment, service, and other resources exist and are ready.
-// It returns the LoadBalancer address (IP or Hostname) of the proxy service.
+// EnsureProxyExist ensures that the Envoy proxy deployment, service, and other resources exist and match desired state.
+// It returns the LoadBalancer address (IP or Hostname) of the proxy service when assigned.
 func (r *ResourceManager) EnsureProxyExist(ctx context.Context) (string, error) {
 	logger := klog.FromContext(ctx).WithValues("resourceName", klog.KRef(r.namespace, r.nodeID))
 	ctx = klog.NewContext(ctx, logger)
@@ -101,116 +101,118 @@ func (r *ResourceManager) NodeID() string {
 	return r.nodeID
 }
 
-// ensureSA ensures that the ServiceAccount for the Envoy proxy exists.
+// ensureSA applies the ServiceAccount for the Envoy proxy (server-side apply).
+//
+// When the object already exists, we compare desired vs live and skip Apply if there is no drift
+// on the fields listed under serviceAccountDesiredMatchesExisting (see that function's doc for
+// managed vs unmanaged fields and review tradeoffs).
 func (r *ResourceManager) ensureSA(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
+	want := r.renderServiceAccount()
 
-	sa := r.renderServiceAccount()
-	_, err := r.client.CoreV1().ServiceAccounts(sa.Namespace).Get(ctx, sa.Name, metav1.GetOptions{})
+	got, err := r.client.CoreV1().ServiceAccounts(want.Namespace).Get(ctx, want.Name, metav1.GetOptions{})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			logger.Info("Creating Envoy proxy serviceaccount", "name", sa.Name, "namespace", sa.Namespace)
-			_, err = r.client.CoreV1().ServiceAccounts(sa.Namespace).Create(ctx, sa, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("failed to create envoy serviceaccount: %w", err)
-			}
-		} else {
+		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to get envoy serviceaccount: %w", err)
 		}
+	} else if serviceAccountDesiredMatchesExisting(want, got) {
+		logger.V(4).Info("Envoy proxy serviceaccount unchanged, skipping apply", "name", want.Name, "namespace", want.Namespace)
+		return nil
 	}
-	logger.Info("Envoy proxy serviceaccount is ready!")
+
+	if _, err := r.client.CoreV1().ServiceAccounts(want.Namespace).Apply(ctx, serviceAccountApply(want), envoyInfraApplyOptions()); err != nil {
+		return fmt.Errorf("failed to apply envoy serviceaccount: %w", err)
+	}
+	logger.Info("Envoy proxy serviceaccount applied", "name", want.Name, "namespace", want.Namespace)
 	return nil
 }
 
-// ensureConfigMap ensures that the ConfigMap for the Envoy proxy exists.
+// serviceAccountDesiredMatchesExisting reports whether the live ServiceAccount already matches
+// what we would send on server-side apply (serviceAccountApply), so we can skip a redundant Apply.
+//
+// Managed fields (must match want for this function to return true):
+//   - metadata.labels: from getLabels (Gateway name label plus Gateway infrastructure labels).
+//   - metadata.annotations: from getAnnotations (Gateway infrastructure annotations only).
+//   - metadata.ownerReferences: controller ref to the owning Gateway.
+//
+// Unmanaged / intentionally ignored (not compared; live values may differ without triggering Apply):
+//   - metadata.name, metadata.namespace: fixed by the request path; not semantic drift.
+//   - metadata.uid, resourceVersion, creationTimestamp, managedFields, etc.: apiserver-owned.
+//   - secrets, imagePullSecrets, automountServiceAccountToken: not set by serviceAccountApply;
+//     secrets in particular are filled by controllers after creation.
+//   - Any extra labels or annotations added by admission, defaults, or other actors: if present
+//     on the live object but absent from want, we treat that as drift and re-Apply (may fight
+//     mutating webhooks that always inject metadata; narrow the comparison if that becomes an issue).
+func serviceAccountDesiredMatchesExisting(want, got *corev1.ServiceAccount) bool {
+	return apiequality.Semantic.DeepEqual(want.Labels, got.Labels) &&
+		apiequality.Semantic.DeepEqual(want.Annotations, got.Annotations) &&
+		apiequality.Semantic.DeepEqual(want.OwnerReferences, got.OwnerReferences)
+}
+
+// ensureConfigMap applies the ConfigMap for the Envoy proxy (server-side apply).
 func (r *ResourceManager) ensureConfigMap(ctx context.Context) error {
+	logger := klog.FromContext(ctx)
+	want, err := r.renderConfigMap()
+	if err != nil {
+		return err
+	}
+	if _, err = r.client.CoreV1().ConfigMaps(want.Namespace).Apply(ctx, configMapApply(want), envoyInfraApplyOptions()); err != nil {
+		return fmt.Errorf("failed to apply envoy configmap: %w", err)
+	}
+	logger.Info("Envoy bootstrap configmap applied", "name", want.Name, "namespace", want.Namespace)
+	return nil
+}
+
+// ensureDeployment applies the Envoy Deployment (server-side apply). It does not wait for the
+// Deployment Available condition so the controller is not blocked from reconciling other Gateways
+// while a rollout is in progress.
+func (r *ResourceManager) ensureDeployment(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
 	cm, err := r.renderConfigMap()
 	if err != nil {
 		return err
 	}
-
-	_, err = r.client.CoreV1().ConfigMaps(cm.Namespace).Get(ctx, cm.Name, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			logger.Info("Creating Envoy bootstrap configmap", "name", cm.Name, "namespace", cm.Namespace)
-			_, err = r.client.CoreV1().ConfigMaps(cm.Namespace).Create(ctx, cm, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("failed to create envoy configmap: %w", err)
-			}
-		} else {
-			return fmt.Errorf("failed to get envoy configmap: %w", err)
-		}
+	want := r.renderDeployment()
+	if want.Spec.Template.Annotations == nil {
+		want.Spec.Template.Annotations = map[string]string{}
 	}
+	want.Spec.Template.Annotations[constants.EnvoyInfraConfigChecksumAnnotation] = configMapDataChecksum(cm)
 
-	logger.Info("Envoy bootstrap configmap is ready!")
+	if _, err = r.client.AppsV1().Deployments(want.Namespace).Apply(ctx, deploymentApply(want), envoyInfraApplyOptions()); err != nil {
+		return fmt.Errorf("failed to apply envoy deployment: %w", err)
+	}
+	logger.Info("Envoy proxy deployment applied (rollout may still be in progress)", "name", want.Name, "namespace", want.Namespace)
 	return nil
 }
 
-// ensureDeployment ensures that the Envoy deployment exists and is available.
-func (r *ResourceManager) ensureDeployment(ctx context.Context) error {
-	logger := klog.FromContext(ctx)
-
-	deployment := r.renderDeployment()
-	dep, err := r.client.AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			logger.Info("Creating Envoy proxy deployment", "name", deployment.Name, "namespace", deployment.Namespace)
-			dep, err = r.client.AppsV1().Deployments(deployment.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("failed to create envoy deployment: %w", err)
-			}
-		} else {
-			return fmt.Errorf("failed to get envoy deployment: %w", err)
-		}
-	}
-
-	// If the Deployment was just created, we will highly likely immediately fail
-	// here and return.
-	for _, cond := range dep.Status.Conditions {
-		if cond.Type == appsv1.DeploymentAvailable && cond.Status == corev1.ConditionTrue {
-			logger.Info("Envoy proxy deployment is ready!")
-			return nil
-		}
-	}
-
-	return fmt.Errorf("envoy deployment %s is not available yet", deployment.Name)
-}
-
-// ensureServiceExists ensures that the Service for the Envoy proxy exists.
+// ensureServiceExists applies the Service for the Envoy proxy (server-side apply) so LoadBalancer
+// provisioning can start before the Deployment is ready. Callers should use ensureService to wait
+// until an address is assigned.
 func (r *ResourceManager) ensureServiceExists(ctx context.Context) (*corev1.Service, error) {
 	logger := klog.FromContext(ctx)
-	service := r.renderService()
-
-	svc, err := r.client.CoreV1().Services(service.Namespace).Get(ctx, service.Name, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			logger.Info("Creating Envoy proxy service", "name", service.Name, "namespace", service.Namespace)
-			svc, err = r.client.CoreV1().Services(service.Namespace).Create(ctx, service, metav1.CreateOptions{})
-			if err != nil {
-				return nil, fmt.Errorf("failed to create envoy service: %w", err)
-			}
-			return svc, nil
-		}
-		return nil, fmt.Errorf("failed to get envoy service: %w", err)
+	want := r.renderService()
+	if _, err := r.client.CoreV1().Services(want.Namespace).Apply(ctx, serviceApply(want), envoyInfraApplyOptions()); err != nil {
+		return nil, fmt.Errorf("failed to apply envoy service: %w", err)
 	}
-	return svc, nil
+	logger.Info("Envoy proxy service applied", "name", want.Name, "namespace", want.Namespace)
+	return r.client.CoreV1().Services(want.Namespace).Get(ctx, want.Name, metav1.GetOptions{})
 }
 
-// ensureService ensures that the Service for the Envoy proxy exists and has a LoadBalancer address (IP or Hostname) assigned.
+// ensureService reads Service status until a LoadBalancer address (IP or Hostname) is assigned.
 func (r *ResourceManager) ensureService(ctx context.Context) (string, error) {
 	logger := klog.FromContext(ctx)
-	svc, err := r.ensureServiceExists(ctx)
+	want := r.renderService()
+	svc, err := r.client.CoreV1().Services(want.Namespace).Get(ctx, want.Name, metav1.GetOptions{})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to refresh envoy service: %w", err)
 	}
 
 	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
-		return "", fmt.Errorf("envoy service %s type is %s, expected %s", svc.Name, svc.Spec.Type, corev1.ServiceTypeLoadBalancer)
+		return "", fmt.Errorf("envoy service %s type is %s, expected %s", want.Name, svc.Spec.Type, corev1.ServiceTypeLoadBalancer)
 	}
 
 	if len(svc.Status.LoadBalancer.Ingress) == 0 {
-		return "", fmt.Errorf("loadbalancer address is not assigned yet for service %s", svc.Name)
+		return "", fmt.Errorf("loadbalancer address is not assigned yet for service %s", want.Name)
 	}
 
 	ingress := svc.Status.LoadBalancer.Ingress[0]
@@ -219,7 +221,7 @@ func (r *ResourceManager) ensureService(ctx context.Context) (string, error) {
 		address = ingress.Hostname
 	}
 	if address == "" {
-		return "", fmt.Errorf("loadbalancer IP or Hostname is not assigned yet for service %s", svc.Name)
+		return "", fmt.Errorf("loadbalancer IP or Hostname is not assigned yet for service %s", want.Name)
 	}
 
 	logger.Info("Envoy proxy service is ready with LoadBalancer address!", "address", address)

--- a/pkg/infra/envoy/proxy.go
+++ b/pkg/infra/envoy/proxy.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -101,62 +100,46 @@ func (r *ResourceManager) NodeID() string {
 	return r.nodeID
 }
 
-// ensureSA applies the ServiceAccount for the Envoy proxy (server-side apply).
+// ensureSA applies the Envoy proxy ServiceAccount (server-side apply).
 //
-// When the object already exists, we compare desired vs live and skip Apply if there is no drift
-// on the fields listed under serviceAccountDesiredMatchesExisting (see that function's doc for
-// managed vs unmanaged fields and review tradeoffs).
+// The proxy ServiceAccount is controller-owned infrastructure (hashed name, Gateway ownerRef,
+// used only by the proxy Deployment). The only supported customization is Gateway
+// spec.infrastructure labels/annotations. We always Apply so desired metadata converges without
+// a separate drift comparison; serviceAccountApply only sets labels, annotations, and
+// ownerReferences so apiserver-populated fields (e.g. secrets) are left unchanged.
 func (r *ResourceManager) ensureSA(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
 	want := r.renderServiceAccount()
 
-	got, err := r.client.CoreV1().ServiceAccounts(want.Namespace).Get(ctx, want.Name, metav1.GetOptions{})
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to get envoy serviceaccount: %w", err)
-		}
-	} else if serviceAccountDesiredMatchesExisting(want, got) {
-		logger.V(4).Info("Envoy proxy serviceaccount unchanged, skipping apply", "name", want.Name, "namespace", want.Namespace)
-		return nil
-	}
-
 	if _, err := r.client.CoreV1().ServiceAccounts(want.Namespace).Apply(ctx, serviceAccountApply(want), envoyInfraApplyOptions()); err != nil {
 		return fmt.Errorf("failed to apply envoy serviceaccount: %w", err)
 	}
-	logger.Info("Envoy proxy serviceaccount applied", "name", want.Name, "namespace", want.Namespace)
+	logger.V(4).Info("Envoy proxy serviceaccount applied", "name", want.Name, "namespace", want.Namespace)
 	return nil
 }
 
-// serviceAccountDesiredMatchesExisting reports whether the live ServiceAccount already matches
-// what we would send on server-side apply (serviceAccountApply), so we can skip a redundant Apply.
-//
-// Managed fields (must match want for this function to return true):
-//   - metadata.labels: from getLabels (Gateway name label plus Gateway infrastructure labels).
-//   - metadata.annotations: from getAnnotations (Gateway infrastructure annotations only).
-//   - metadata.ownerReferences: controller ref to the owning Gateway.
-//
-// Unmanaged / intentionally ignored (not compared; live values may differ without triggering Apply):
-//   - metadata.name, metadata.namespace: fixed by the request path; not semantic drift.
-//   - metadata.uid, resourceVersion, creationTimestamp, managedFields, etc.: apiserver-owned.
-//   - secrets, imagePullSecrets, automountServiceAccountToken: not set by serviceAccountApply;
-//     secrets in particular are filled by controllers after creation.
-//   - Any extra labels or annotations added by admission, defaults, or other actors: if present
-//     on the live object but absent from want, we treat that as drift and re-Apply (may fight
-//     mutating webhooks that always inject metadata; narrow the comparison if that becomes an issue).
-func serviceAccountDesiredMatchesExisting(want, got *corev1.ServiceAccount) bool {
-	return apiequality.Semantic.DeepEqual(want.Labels, got.Labels) &&
-		apiequality.Semantic.DeepEqual(want.Annotations, got.Annotations) &&
-		apiequality.Semantic.DeepEqual(want.OwnerReferences, got.OwnerReferences)
-}
-
 // ensureConfigMap applies the ConfigMap for the Envoy proxy (server-side apply).
+//
+// When the object already exists, we compare desired vs live and skip Apply if there is no drift
+// on the fields listed under configMapDesiredMatchesExisting (see that function's doc).
 func (r *ResourceManager) ensureConfigMap(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
 	want, err := r.renderConfigMap()
 	if err != nil {
 		return err
 	}
-	if _, err = r.client.CoreV1().ConfigMaps(want.Namespace).Apply(ctx, configMapApply(want), envoyInfraApplyOptions()); err != nil {
+
+	got, err := r.client.CoreV1().ConfigMaps(want.Namespace).Get(ctx, want.Name, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get envoy configmap: %w", err)
+		}
+	} else if configMapDesiredMatchesExisting(want, got) {
+		logger.V(4).Info("Envoy proxy configmap unchanged, skipping apply", "name", want.Name, "namespace", want.Namespace)
+		return nil
+	}
+
+	if _, err := r.client.CoreV1().ConfigMaps(want.Namespace).Apply(ctx, configMapApply(want), envoyInfraApplyOptions()); err != nil {
 		return fmt.Errorf("failed to apply envoy configmap: %w", err)
 	}
 	logger.Info("Envoy bootstrap configmap applied", "name", want.Name, "namespace", want.Namespace)
@@ -166,6 +149,10 @@ func (r *ResourceManager) ensureConfigMap(ctx context.Context) error {
 // ensureDeployment applies the Envoy Deployment (server-side apply). It does not wait for the
 // Deployment Available condition so the controller is not blocked from reconciling other Gateways
 // while a rollout is in progress.
+//
+// When the object already exists, we compare desired vs live and skip Apply if there is no drift
+// on the fields listed under deploymentDesiredMatchesExisting (see that function's doc), including
+// the pod-template checksum derived from the rendered ConfigMap.
 func (r *ResourceManager) ensureDeployment(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
 	cm, err := r.renderConfigMap()
@@ -178,7 +165,17 @@ func (r *ResourceManager) ensureDeployment(ctx context.Context) error {
 	}
 	want.Spec.Template.Annotations[constants.EnvoyInfraConfigChecksumAnnotation] = configMapDataChecksum(cm)
 
-	if _, err = r.client.AppsV1().Deployments(want.Namespace).Apply(ctx, deploymentApply(want), envoyInfraApplyOptions()); err != nil {
+	got, err := r.client.AppsV1().Deployments(want.Namespace).Get(ctx, want.Name, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get envoy deployment: %w", err)
+		}
+	} else if deploymentDesiredMatchesExisting(want, got) {
+		logger.V(4).Info("Envoy proxy deployment unchanged, skipping apply", "name", want.Name, "namespace", want.Namespace)
+		return nil
+	}
+
+	if _, err := r.client.AppsV1().Deployments(want.Namespace).Apply(ctx, deploymentApply(want), envoyInfraApplyOptions()); err != nil {
 		return fmt.Errorf("failed to apply envoy deployment: %w", err)
 	}
 	logger.Info("Envoy proxy deployment applied (rollout may still be in progress)", "name", want.Name, "namespace", want.Namespace)
@@ -186,11 +183,22 @@ func (r *ResourceManager) ensureDeployment(ctx context.Context) error {
 }
 
 // ensureServiceExists applies the Service for the Envoy proxy (server-side apply) so LoadBalancer
-// provisioning can start before the Deployment is ready. Callers should use ensureService to wait
-// until an address is assigned.
+// provisioning can start before the Deployment is ready. When the live Service already matches the
+// desired object (see serviceDesiredMatchesExisting), Apply is skipped.
 func (r *ResourceManager) ensureServiceExists(ctx context.Context) (*corev1.Service, error) {
 	logger := klog.FromContext(ctx)
 	want := r.renderService()
+
+	got, err := r.client.CoreV1().Services(want.Namespace).Get(ctx, want.Name, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get envoy service: %w", err)
+		}
+	} else if serviceDesiredMatchesExisting(want, got) {
+		logger.V(4).Info("Envoy proxy service unchanged, skipping apply", "name", want.Name, "namespace", want.Namespace)
+		return got, nil
+	}
+
 	if _, err := r.client.CoreV1().Services(want.Namespace).Apply(ctx, serviceApply(want), envoyInfraApplyOptions()); err != nil {
 		return nil, fmt.Errorf("failed to apply envoy service: %w", err)
 	}

--- a/pkg/infra/envoy/proxy_desired_match.go
+++ b/pkg/infra/envoy/proxy_desired_match.go
@@ -1,0 +1,187 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envoy
+
+import (
+	"sort"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+// configMapDesiredMatchesExisting reports whether the live ConfigMap already matches what we
+// would send on server-side apply (see configMapApply), so we can skip a redundant Apply.
+//
+// Managed fields (must match want for this function to return true):
+//   - metadata.labels, metadata.annotations
+//   - metadata.ownerReferences
+//   - immutable (when set on want)
+//   - data, binaryData
+//
+// Unmanaged / intentionally ignored:
+//   - metadata.uid, resourceVersion, creationTimestamp, managedFields, etc.
+//   - Extra keys in live data not present in want count as drift (we re-Apply).
+func configMapDesiredMatchesExisting(want, got *corev1.ConfigMap) bool {
+	if !apiequality.Semantic.DeepEqual(want.Labels, got.Labels) ||
+		!apiequality.Semantic.DeepEqual(want.Annotations, got.Annotations) ||
+		!apiequality.Semantic.DeepEqual(want.OwnerReferences, got.OwnerReferences) {
+		return false
+	}
+	if (want.Immutable == nil) != (got.Immutable == nil) {
+		return false
+	}
+	if want.Immutable != nil && got.Immutable != nil && *want.Immutable != *got.Immutable {
+		return false
+	}
+	return apiequality.Semantic.DeepEqual(want.Data, got.Data) &&
+		apiequality.Semantic.DeepEqual(want.BinaryData, got.BinaryData)
+}
+
+// serviceDesiredMatchesExisting reports whether the live Service already matches what we would
+// send on server-side apply (see serviceApply), so we can skip a redundant Apply.
+//
+// Managed fields (must match want for this function to return true):
+//   - metadata.labels, metadata.annotations, metadata.ownerReferences
+//   - spec.type, spec.selector
+//   - spec.ports (name, port, protocol), order-independent
+//
+// Unmanaged / intentionally ignored:
+//   - spec.clusterIP, clusterIPs, nodePort, sessionAffinity, traffic distribution, ipFamilies, etc.
+//   - status (including loadBalancer ingress)
+//   - Extra labels/annotations on live objects vs want count as drift (same caveat as ServiceAccount).
+func serviceDesiredMatchesExisting(want, got *corev1.Service) bool {
+	if !apiequality.Semantic.DeepEqual(want.Labels, got.Labels) ||
+		!apiequality.Semantic.DeepEqual(want.Annotations, got.Annotations) ||
+		!apiequality.Semantic.DeepEqual(want.OwnerReferences, got.OwnerReferences) {
+		return false
+	}
+	if want.Spec.Type != got.Spec.Type {
+		return false
+	}
+	if !apiequality.Semantic.DeepEqual(want.Spec.Selector, got.Spec.Selector) {
+		return false
+	}
+	return servicePortsManagedMatch(want.Spec.Ports, got.Spec.Ports)
+}
+
+func servicePortsManagedMatch(want, got []corev1.ServicePort) bool {
+	if len(want) != len(got) {
+		return false
+	}
+	type portKey struct {
+		Name     string
+		Port     int32
+		Protocol corev1.Protocol
+	}
+	toKeys := func(ports []corev1.ServicePort) []portKey {
+		out := make([]portKey, 0, len(ports))
+		for i := range ports {
+			p := ports[i]
+			proto := p.Protocol
+			if proto == "" {
+				proto = corev1.ProtocolTCP
+			}
+			out = append(out, portKey{Name: p.Name, Port: p.Port, Protocol: proto})
+		}
+		sort.Slice(out, func(i, j int) bool {
+			if out[i].Port != out[j].Port {
+				return out[i].Port < out[j].Port
+			}
+			if out[i].Name != out[j].Name {
+				return out[i].Name < out[j].Name
+			}
+			return out[i].Protocol < out[j].Protocol
+		})
+		return out
+	}
+	return apiequality.Semantic.DeepEqual(toKeys(want), toKeys(got))
+}
+
+// deploymentDesiredMatchesExisting reports whether the live Deployment already matches what we
+// would send on server-side apply (see deploymentApply), including the pod template checksum
+// annotation set in ensureDeployment before Apply.
+//
+// Managed fields (must match want for this function to return true):
+//   - metadata.labels, metadata.annotations, metadata.ownerReferences
+//   - spec.replicas, spec.selector
+//   - spec.template metadata (labels, annotations), including infra config checksum annotation
+//   - spec.template.spec after normalizing API defaults on pod fields we declare
+//
+// Unmanaged / intentionally ignored:
+//   - status, generation, observedGeneration, collisionCount, etc.
+//   - spec.strategy, minReadySeconds, revisionHistoryLimit, progressDeadlineSeconds (not set by deploymentApply)
+//   - Pod fields we do not set in render; extra live-only fields count as drift.
+func deploymentDesiredMatchesExisting(want, got *appsv1.Deployment) bool {
+	if !apiequality.Semantic.DeepEqual(want.Labels, got.Labels) ||
+		!apiequality.Semantic.DeepEqual(want.Annotations, got.Annotations) ||
+		!apiequality.Semantic.DeepEqual(want.OwnerReferences, got.OwnerReferences) {
+		return false
+	}
+	if (want.Spec.Replicas == nil) != (got.Spec.Replicas == nil) {
+		return false
+	}
+	if want.Spec.Replicas != nil && got.Spec.Replicas != nil && *want.Spec.Replicas != *got.Spec.Replicas {
+		return false
+	}
+	if !apiequality.Semantic.DeepEqual(want.Spec.Selector, got.Spec.Selector) {
+		return false
+	}
+	if !apiequality.Semantic.DeepEqual(want.Spec.Template.Labels, got.Spec.Template.Labels) ||
+		!apiequality.Semantic.DeepEqual(want.Spec.Template.Annotations, got.Spec.Template.Annotations) {
+		return false
+	}
+	wantPS := want.Spec.Template.Spec.DeepCopy()
+	gotPS := got.Spec.Template.Spec.DeepCopy()
+	normalizePodSpecForCompare(wantPS)
+	normalizePodSpecForCompare(gotPS)
+	return apiequality.Semantic.DeepEqual(wantPS, gotPS)
+}
+
+func normalizePodSpecForCompare(ps *corev1.PodSpec) {
+	if ps.RestartPolicy == "" {
+		ps.RestartPolicy = corev1.RestartPolicyAlways
+	}
+	if ps.DNSPolicy == "" {
+		ps.DNSPolicy = corev1.DNSClusterFirst
+	}
+	if ps.EnableServiceLinks == nil {
+		t := true
+		ps.EnableServiceLinks = &t
+	}
+	if ps.ShareProcessNamespace == nil {
+		f := false
+		ps.ShareProcessNamespace = &f
+	}
+	for i := range ps.Containers {
+		c := &ps.Containers[i]
+		if c.TerminationMessagePath == "" {
+			c.TerminationMessagePath = "/dev/termination-log"
+		}
+		if c.TerminationMessagePolicy == "" {
+			c.TerminationMessagePolicy = corev1.TerminationMessageReadFile
+		}
+		if c.ImagePullPolicy == "" {
+			if strings.Contains(c.Image, ":") && !strings.HasSuffix(c.Image, ":latest") {
+				c.ImagePullPolicy = corev1.PullIfNotPresent
+			} else {
+				c.ImagePullPolicy = corev1.PullAlways
+			}
+		}
+	}
+}

--- a/pkg/infra/envoy/proxy_desired_match_test.go
+++ b/pkg/infra/envoy/proxy_desired_match_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envoy
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConfigMapDesiredMatchesExisting(t *testing.T) {
+	base := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "cm1",
+			Namespace:       "ns",
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "v1", Kind: "Gateway", Name: "gw", UID: "uid"}},
+		},
+		Data: map[string]string{"k": "v"},
+	}
+	got := base.DeepCopy()
+	got.ResourceVersion = "7"
+	got.UID = "abc"
+	if !configMapDesiredMatchesExisting(base, got) {
+		t.Fatal("expected match when only apiserver metadata differs")
+	}
+	got2 := base.DeepCopy()
+	got2.Data["k"] = "other"
+	if configMapDesiredMatchesExisting(base, got2) {
+		t.Fatal("expected mismatch when data changes")
+	}
+}
+
+func TestServicePortsManagedMatch(t *testing.T) {
+	a := []corev1.ServicePort{
+		{Name: "b", Port: 2, Protocol: corev1.ProtocolTCP},
+		{Name: "a", Port: 1, Protocol: corev1.ProtocolTCP},
+	}
+	b := []corev1.ServicePort{
+		{Name: "a", Port: 1},
+		{Name: "b", Port: 2, Protocol: corev1.ProtocolTCP},
+	}
+	if !servicePortsManagedMatch(a, b) {
+		t.Fatal("expected order-independent match with default protocol normalization")
+	}
+	if servicePortsManagedMatch(a, []corev1.ServicePort{{Name: "a", Port: 1}}) {
+		t.Fatal("expected mismatch when port count differs")
+	}
+}

--- a/pkg/infra/envoy/proxy_test.go
+++ b/pkg/infra/envoy/proxy_test.go
@@ -36,23 +36,22 @@ func TestEnsureDeployment(t *testing.T) {
 	}
 	nodeID := proxyName(gw.Namespace, gw.Name)
 
-	t.Run("deployment not found, creates and returns error (not ready)", func(t *testing.T) {
+	t.Run("deployment not found, creates without waiting for Available", func(t *testing.T) {
 		client := fake.NewClientset()
 		rm := NewResourceManager(client, gw, "envoy-image", "cluster.local")
 
 		err := rm.ensureDeployment(context.Background())
-		if err == nil {
-			t.Fatal("expected error as deployment is not available yet")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 
-		// Verify deployment was created
 		_, err = client.AppsV1().Deployments("test-ns").Get(context.Background(), nodeID, metav1.GetOptions{})
 		if err != nil {
 			t.Errorf("failed to get created deployment: %v", err)
 		}
 	})
 
-	t.Run("deployment exists but not available, returns error", func(t *testing.T) {
+	t.Run("deployment exists but not Available, still succeeds without blocking", func(t *testing.T) {
 		dep := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nodeID,
@@ -71,8 +70,8 @@ func TestEnsureDeployment(t *testing.T) {
 		rm := NewResourceManager(client, gw, "envoy-image", "cluster.local")
 
 		err := rm.ensureDeployment(context.Background())
-		if err == nil {
-			t.Fatal("expected error as deployment is not available")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
@@ -110,19 +109,13 @@ func TestEnsureService(t *testing.T) {
 	}
 	nodeID := proxyName(gw.Namespace, gw.Name)
 
-	t.Run("service not found, creates and returns error (no LoadBalancer address)", func(t *testing.T) {
+	t.Run("service not found, returns error (call ensureServiceExists first)", func(t *testing.T) {
 		client := fake.NewClientset()
 		rm := NewResourceManager(client, gw, "envoy-image", "cluster.local")
 
 		_, err := rm.ensureService(context.Background())
 		if err == nil {
-			t.Fatal("expected error as service has no LoadBalancer address")
-		}
-
-		// Verify service was created
-		_, err = client.CoreV1().Services("test-ns").Get(context.Background(), nodeID, metav1.GetOptions{})
-		if err != nil {
-			t.Errorf("failed to get created service: %v", err)
+			t.Fatal("expected error when service is missing")
 		}
 	})
 

--- a/pkg/infra/envoy/reconcile.go
+++ b/pkg/infra/envoy/reconcile.go
@@ -1,0 +1,42 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envoy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// configMapDataChecksum returns a stable SHA-256 hex digest of string ConfigMap entries (sorted by key).
+func configMapDataChecksum(cm *corev1.ConfigMap) string {
+	h := sha256.New()
+	keys := make([]string, 0, len(cm.Data))
+	for k := range cm.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte{0})
+		h.Write([]byte(cm.Data[k]))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/pkg/infra/envoy/reconcile_test.go
+++ b/pkg/infra/envoy/reconcile_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envoy
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestConfigMapDataChecksum(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		Data: map[string]string{"b": "2", "a": "1"},
+	}
+	h1 := configMapDataChecksum(cm)
+	cm.Data["a"] = "changed"
+	h2 := configMapDataChecksum(cm)
+	if h1 == h2 {
+		t.Fatal("expected digest to change when data changes")
+	}
+	cm2 := &corev1.ConfigMap{Data: map[string]string{"a": "1", "b": "2"}}
+	if configMapDataChecksum(cm2) != h1 {
+		t.Fatal("expected stable digest for same key/value pairs regardless of map iteration order")
+	}
+}

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -809,6 +809,59 @@ func retry(attempts int, sleep time.Duration, f func() error) error {
 	return fmt.Errorf("after %d attempts, last error: %w", attempts, lastErr)
 }
 
+// waitForGatewayProgrammed blocks until the Gateway status reflects the latest spec generation
+// and the https-listener is programmed. TLS subtests must call this after patching Gateway TLS
+// so Envoy receives the updated client-validation configuration before MCP initialization.
+func waitForGatewayProgrammed(t *testing.T, namespace string) {
+	t.Helper()
+	err := retry(30, 2*time.Second, func() error {
+		genOut, err := runKubectlOutput(t, "get", "gateway", "e2e-gateway", "-n", namespace, "-o", "jsonpath={.metadata.generation}")
+		if err != nil {
+			return err
+		}
+		generation := strings.TrimSpace(genOut)
+		if generation == "" {
+			return fmt.Errorf("gateway generation not found")
+		}
+
+		progOut, err := runKubectlOutput(t, "get", "gateway", "e2e-gateway", "-n", namespace,
+			"-o", `jsonpath={.status.conditions[?(@.type=="Programmed")].status}{"\n"}{.status.conditions[?(@.type=="Programmed")].observedGeneration}`)
+		if err != nil {
+			return err
+		}
+		lines := strings.Split(strings.TrimSpace(progOut), "\n")
+		if len(lines) < 2 || lines[0] != "True" {
+			return fmt.Errorf("gateway Programmed status not True yet: %q", progOut)
+		}
+		if lines[1] != generation {
+			return fmt.Errorf("gateway observedGeneration=%q, want %q", lines[1], generation)
+		}
+
+		listenerProgOut, err := runKubectlOutput(t, "get", "gateway", "e2e-gateway", "-n", namespace,
+			"-o", `jsonpath={.status.listeners[?(@.name=="https-listener")].conditions[?(@.type=="Programmed")].status}`)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(listenerProgOut) != "True" {
+			return fmt.Errorf("https-listener Programmed status not True yet: %q", listenerProgOut)
+		}
+
+		listenerResolvedOut, err := runKubectlOutput(t, "get", "gateway", "e2e-gateway", "-n", namespace,
+			"-o", `jsonpath={.status.listeners[?(@.name=="https-listener")].conditions[?(@.type=="ResolvedRefs")].status}`)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(listenerResolvedOut) != "True" {
+			return fmt.Errorf("https-listener ResolvedRefs status not True yet: %q", listenerResolvedOut)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Gateway did not become programmed in namespace %s: %v", namespace, err)
+	}
+}
+
 type mcpTestSession struct {
 	t         *testing.T
 	gatewayIP string
@@ -836,7 +889,7 @@ func tryInitializeMCPWithCerts(t *testing.T, gatewayIP string, pod types.Namespa
 	t.Logf("Initialize MCP session for pod %s at %s", pod, mcpPath)
 
 	mcpSessionID := ""
-	err := retry(5, 10*time.Second, func() error {
+	err := retry(10, 5*time.Second, func() error {
 		out, err := execMCPCurl(t, gatewayIP, pod, mcpPath, certPath, keyPath, caPath)
 		if err != nil {
 			return err
@@ -1193,6 +1246,7 @@ func TestGatewayTLS(t *testing.T) {
 		// Test case 1: client cert signed by trusted CA without gateway CA configuration (should succeed)
 		applyToNamespace(t, "testdata/gateway-no-ca.yaml", namespace)
 		applyToNamespace(t, "testdata/gateway-policy.yaml", namespace)
+		waitForGatewayProgrammed(t, namespace)
 
 		// Write files to pod
 		writePodFile(t, namespace, podName, testClientCertPath, clientCertDefault)
@@ -1236,10 +1290,22 @@ func TestGatewayTLS(t *testing.T) {
 	t.Run("TrustedCA_WithGatewayCA", func(t *testing.T) {
 		// Test case 2: Client cert signed by trusted CA with gateway CA configuration (should succeed)
 		applyToNamespace(t, "testdata/gateway-tls.yaml", namespace)
+		applyToNamespace(t, "testdata/gateway-policy.yaml", namespace)
+		waitForGatewayProgrammed(t, namespace)
 
-		// Override certs in the pod
+		caRefOut, err := runKubectlOutput(t, "get", "gateway", "e2e-gateway", "-n", namespace,
+			"-o", "jsonpath={.spec.tls.frontend.default.validation.caCertificateRefs[0].name}")
+		if err != nil {
+			t.Fatalf("failed to read gateway CA reference: %v", err)
+		}
+		if strings.TrimSpace(caRefOut) != "gateway-client-ca" {
+			t.Fatalf("gateway frontend CA reference not applied (got %q, want gateway-client-ca)", caRefOut)
+		}
+
+		// Override certs in the pod to match the gateway-configured client CA.
 		writePodFile(t, namespace, podName, testClientCertPath, clientCert1)
 		writePodFile(t, namespace, podName, testClientKeyPath, clientKey1)
+		writePodFile(t, namespace, podName, testClientCAPath, caCertPEM1)
 
 		mcp := initializeMCPWithCerts(t, gatewayIP, types.NamespacedName{Namespace: namespace, Name: podName}, defaultMCPPath,
 			testClientCertPath, testClientKeyPath, testClientCAPath)

--- a/tests/e2e/tls_helpers.go
+++ b/tests/e2e/tls_helpers.go
@@ -18,10 +18,8 @@ package e2e
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/ed25519"
-	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -37,14 +35,53 @@ import (
 	"sigs.k8s.io/kube-agentic-networking/pkg/infra/agentidentity/localca"
 )
 
-// generateCA creates a new CA for testing.
+// generateCA creates a new RSA CA for testing. RSA is used instead of Ed25519 so the custom
+// gateway CA validation path exercised by TestGatewayTLS is compatible with Envoy and curl.
 func generateCA(caID string) (*localca.CA, error) {
-	return localca.GenerateED25519CA(caID)
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate CA key: %w", err)
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(365 * 24 * time.Hour)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	rootTemplate := &x509.Certificate{
+		SerialNumber:          serialNumber,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		Subject:               pkix.Name{CommonName: caID},
+	}
+
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTemplate, rootTemplate, &key.PublicKey, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CA certificate: %w", err)
+	}
+
+	rootCert, err := x509.ParseCertificate(rootDER)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CA certificate: %w", err)
+	}
+
+	return &localca.CA{
+		ID:              caID,
+		SigningKey:      key,
+		RootCertificate: rootCert,
+	}, nil
 }
 
 // generateServerCert generates a server leaf certificate signed by the provided CA.
 func generateServerCert(ca *localca.CA, dnsNames []string) (certPEM, keyPEM []byte, err error) {
-	serverPubKey, serverPrivKey, err := ed25519.GenerateKey(rand.Reader)
+	serverPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate server key: %w", err)
 	}
@@ -70,7 +107,7 @@ func generateServerCert(ca *localca.CA, dnsNames []string) (certPEM, keyPEM []by
 		DNSNames:              dnsNames,
 	}
 
-	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, ca.RootCertificate, serverPubKey, ca.SigningKey)
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, ca.RootCertificate, &serverPrivKey.PublicKey, ca.SigningKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create server certificate: %w", err)
 	}
@@ -88,11 +125,10 @@ func generateServerCert(ca *localca.CA, dnsNames []string) (certPEM, keyPEM []by
 
 // generateClientCert generates a client certificate signed by the provided CA.
 func generateClientCert(ca *localca.CA, spiffeID string) (certPEM, keyPEM []byte, err error) {
-	clientPrivKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	clientPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate client key: %w", err)
 	}
-	clientPubKey := &clientPrivKey.PublicKey
 
 	notBefore := time.Now()
 	notAfter := notBefore.Add(365 * 24 * time.Hour)
@@ -120,15 +156,12 @@ func generateClientCert(ca *localca.CA, spiffeID string) (certPEM, keyPEM []byte
 		URIs:                  []*url.URL{uri},
 	}
 
-	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, ca.RootCertificate, clientPubKey, ca.SigningKey)
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, ca.RootCertificate, &clientPrivKey.PublicKey, ca.SigningKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create client certificate: %w", err)
 	}
 
 	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER})
-	// Append CA cert to client cert chain
-	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.RootCertificate.Raw})
-	certPEM = append(certPEM, caCertPEM...)
 
 	privKeyBytes, err := x509.MarshalPKCS8PrivateKey(clientPrivKey)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does **:
The Envoy ResourceManager used to only create the proxy ServiceAccount, ConfigMap, Deployment, and Service when they were missing. This PR reconciles those objects on every sync so changes (Envoy image, bootstrap/SDS content, manual edits) converge without deleting the Gateway.
Infra updates use server-side apply ([docs](https://kubernetes.io/docs/reference/using-api/server-side-apply/)) with a single field manager and Force, instead of field-by-field comparison in reconcile.go. reconcile.go now only holds configMapDataChecksum for the pod-template annotation. Because updating a mounted ConfigMap alone does not restart pods, the Deployment pod template keeps a checksum annotation derived from rendered ConfigMap data so bootstrap/SDS changes still trigger a rollout. The controller does not wait for the Envoy Deployment Available condition, so it does not block reconciliation of other Gateways ([#198](https://github.com/kubernetes-sigs/kube-agentic-networking/pull/198)).
Proxy resources use the standard Gateway label gateway.networking.k8s.io/gateway-name ([GEP-1762](https://gateway-api.sigs.k8s.io/geps/gep-1762/#automated-deployments)).


**Which issue(s) this PR fixes**:
Fixes #238 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
