### PR TITLE
Validate cert refs in gateway listener and add test coverage

### DIFF
--- a/pkg/translator/listener.go
+++ b/pkg/translator/listener.go
@@ -58,30 +58,28 @@ const (
 	wellknownJWTAuthnFilter = "envoy.filters.http.jwt_authn"
 )
 
-// setListenerCondition is a helper to safely set a condition on a listener's status
-// in a map of conditions.
-func setListenerCondition(
-	conditionsMap map[gatewayv1.SectionName][]metav1.Condition,
-	listenerName gatewayv1.SectionName,
-	condition metav1.Condition,
-) {
-	// This "get, modify, set" pattern is the standard way to
-	// work around the Go constraint that map values are not addressable.
-	conditions := conditionsMap[listenerName]
+type listenerConditions map[gatewayv1.SectionName][]metav1.Condition
+
+func (lc listenerConditions) setCondition(listenerName gatewayv1.SectionName, condition metav1.Condition) {
+	conditions := lc[listenerName]
 	if conditions == nil {
 		conditions = []metav1.Condition{}
 	}
 	meta.SetStatusCondition(&conditions, condition)
-	conditionsMap[listenerName] = conditions
+	lc[listenerName] = conditions
+}
+
+func (lc listenerConditions) isConditionTrue(listenerName gatewayv1.SectionName, conditionType string) bool {
+	return meta.IsStatusConditionTrue(lc[listenerName], conditionType)
 }
 
 // validateListeners checks for conflicts among all listeners on a Gateway as per the spec.
 // It returns a map of conflicted listener conditions and a Gateway-level condition if any conflicts exist.
-func (t *Translator) validateListeners(gateway *gatewayv1.Gateway) map[gatewayv1.SectionName][]metav1.Condition {
-	listenerConditions := make(map[gatewayv1.SectionName][]metav1.Condition)
+func (t *Translator) validateListeners(gateway *gatewayv1.Gateway) listenerConditions {
+	conds := make(listenerConditions)
 	for _, listener := range gateway.Spec.Listeners {
 		// Initialize with a fresh slice.
-		listenerConditions[listener.Name] = []metav1.Condition{}
+		conds[listener.Name] = []metav1.Condition{}
 	}
 
 	// Check for Port and Hostname Conflicts
@@ -105,7 +103,7 @@ func (t *Translator) validateListeners(gateway *gatewayv1.Gateway) map[gatewayv1
 
 		if hasTCP && hasHTTPTLS {
 			for _, listener := range listenersOnPort {
-				setListenerCondition(listenerConditions, listener.Name, metav1.Condition{
+				conds.setCondition(listener.Name, metav1.Condition{
 					Type:    string(gatewayv1.ListenerConditionConflicted),
 					Status:  metav1.ConditionTrue,
 					Reason:  string(gatewayv1.ListenerReasonProtocolConflict),
@@ -132,8 +130,8 @@ func (t *Translator) validateListeners(gateway *gatewayv1.Gateway) map[gatewayv1
 						Reason:  string(gatewayv1.ListenerReasonHostnameConflict),
 						Message: fmt.Sprintf("Hostname '%s' conflicts with another listener on the same port.", hostname),
 					}
-					setListenerCondition(listenerConditions, listener.Name, conflictedCondition)
-					setListenerCondition(listenerConditions, conflictingListenerName, conflictedCondition)
+					conds.setCondition(listener.Name, conflictedCondition)
+					conds.setCondition(conflictingListenerName, conflictedCondition)
 				} else {
 					seenHostnames[hostname] = listener.Name
 				}
@@ -143,14 +141,14 @@ func (t *Translator) validateListeners(gateway *gatewayv1.Gateway) map[gatewayv1
 
 	for _, listener := range gateway.Spec.Listeners {
 		// If a listener is already conflicted, we don't need to check its secrets.
-		if meta.IsStatusConditionTrue(listenerConditions[listener.Name], string(gatewayv1.ListenerConditionConflicted)) {
+		if conds.isConditionTrue(listener.Name, string(gatewayv1.ListenerConditionConflicted)) {
 			continue
 		}
 
 		if condition := t.validateCertificateRefs(gateway, listener); condition != nil {
-			setListenerCondition(listenerConditions, listener.Name, *condition)
+			conds.setCondition(listener.Name, *condition)
 		} else {
-			setListenerCondition(listenerConditions, listener.Name, metav1.Condition{
+			conds.setCondition(listener.Name, metav1.Condition{
 				Type:               string(gatewayv1.ListenerConditionResolvedRefs),
 				Status:             metav1.ConditionTrue,
 				Reason:             string(gatewayv1.ListenerReasonResolvedRefs),
@@ -160,7 +158,7 @@ func (t *Translator) validateListeners(gateway *gatewayv1.Gateway) map[gatewayv1
 		}
 	}
 
-	return listenerConditions
+	return conds
 }
 
 func (t *Translator) validateCertificateRefs(gateway *gatewayv1.Gateway, listener gatewayv1.Listener) *metav1.Condition {

--- a/pkg/translator/listener.go
+++ b/pkg/translator/listener.go
@@ -69,10 +69,6 @@ func (lc listenerConditions) setCondition(listenerName gatewayv1.SectionName, co
 	lc[listenerName] = conditions
 }
 
-func (lc listenerConditions) isConditionTrue(listenerName gatewayv1.SectionName, conditionType string) bool {
-	return meta.IsStatusConditionTrue(lc[listenerName], conditionType)
-}
-
 // validateListeners checks for conflicts among all listeners on a Gateway as per the spec.
 // It returns a map of conflicted listener conditions and a Gateway-level condition if any conflicts exist.
 func (t *Translator) validateListeners(gateway *gatewayv1.Gateway) listenerConditions {
@@ -141,7 +137,7 @@ func (t *Translator) validateListeners(gateway *gatewayv1.Gateway) listenerCondi
 
 	for _, listener := range gateway.Spec.Listeners {
 		// If a listener is already conflicted, we don't need to check its secrets.
-		if conds.isConditionTrue(listener.Name, string(gatewayv1.ListenerConditionConflicted)) {
+		if meta.IsStatusConditionTrue(conds[listener.Name], string(gatewayv1.ListenerConditionConflicted)) {
 			continue
 		}
 

--- a/pkg/translator/listener.go
+++ b/pkg/translator/listener.go
@@ -40,6 +40,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -146,16 +147,90 @@ func (t *Translator) validateListeners(gateway *gatewayv1.Gateway) map[gatewayv1
 			continue
 		}
 
-		setListenerCondition(listenerConditions, listener.Name, metav1.Condition{
-			Type:               string(gatewayv1.ListenerConditionResolvedRefs),
-			Status:             metav1.ConditionTrue,
-			Reason:             string(gatewayv1.ListenerReasonResolvedRefs),
-			Message:            "All references resolved",
-			ObservedGeneration: gateway.Generation,
-		})
+		if condition := t.validateCertificateRefs(gateway, listener); condition != nil {
+			setListenerCondition(listenerConditions, listener.Name, *condition)
+		} else {
+			setListenerCondition(listenerConditions, listener.Name, metav1.Condition{
+				Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+				Status:             metav1.ConditionTrue,
+				Reason:             string(gatewayv1.ListenerReasonResolvedRefs),
+				Message:            "All references resolved",
+				ObservedGeneration: gateway.Generation,
+			})
+		}
 	}
 
 	return listenerConditions
+}
+
+func (t *Translator) validateCertificateRefs(gateway *gatewayv1.Gateway, listener gatewayv1.Listener) *metav1.Condition {
+	if listener.TLS == nil {
+		return nil
+	}
+
+	for _, ref := range listener.TLS.CertificateRefs {
+		group := ""
+		if ref.Group != nil {
+			group = string(*ref.Group)
+		}
+		kind := "Secret"
+		if ref.Kind != nil {
+			kind = string(*ref.Kind)
+		}
+
+		if (group != "" && group != "core") || kind != "Secret" {
+			return &metav1.Condition{
+				Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+				Status:             metav1.ConditionFalse,
+				Reason:             string(gatewayv1.ListenerReasonInvalidCertificateRef),
+				Message:            fmt.Sprintf("Unsupported certificate reference group %q kind %q. Only core/Secret is supported.", group, kind),
+				ObservedGeneration: gateway.Generation,
+			}
+		}
+
+		ns := gateway.Namespace
+		if ref.Namespace != nil {
+			ns = string(*ref.Namespace)
+		}
+
+		// Check if secret exists
+		_, err := t.secretLister.Secrets(ns).Get(string(ref.Name))
+		if err != nil {
+			reason := string(gatewayv1.ListenerReasonInvalidCertificateRef)
+			message := fmt.Sprintf("Failed to get Secret %s/%s: %v", ns, ref.Name, err)
+			if apierrors.IsNotFound(err) {
+				message = fmt.Sprintf("Secret %s/%s not found", ns, ref.Name)
+			}
+			return &metav1.Condition{
+				Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+				Status:             metav1.ConditionFalse,
+				Reason:             reason,
+				Message:            message,
+				ObservedGeneration: gateway.Generation,
+			}
+		}
+
+		// Check if cross-namespace reference is allowed by ReferenceGrant
+		if ns == gateway.Namespace {
+			continue
+		}
+
+		if !AllowedByReferenceGrant(
+			gateway.Namespace, "gateway.networking.k8s.io", "Gateway",
+			ns, "", "Secret", string(ref.Name),
+			t.referenceGrantLister,
+		) {
+			return &metav1.Condition{
+				Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+				Status:             metav1.ConditionFalse,
+				Reason:             string(gatewayv1.ListenerReasonRefNotPermitted),
+				Message:            fmt.Sprintf("Reference to Secret %s/%s not permitted by ReferenceGrant", ns, ref.Name),
+				ObservedGeneration: gateway.Generation,
+			}
+		}
+	}
+
+	return nil
 }
 
 func (t *Translator) translateListenerToFilterChain(lis gatewayv1.Listener, routeName string, gateway *gatewayv1.Gateway) (*listener.FilterChain, error) {

--- a/pkg/translator/listener_test.go
+++ b/pkg/translator/listener_test.go
@@ -22,10 +22,14 @@ import (
 	"testing"
 
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 	gatewayinformers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
 
@@ -339,6 +343,254 @@ func TestBuildHTTPFilters(t *testing.T) {
 			for i, f := range filters {
 				if f.GetName() != tt.expected[i] {
 					t.Errorf("Filter %d: expected %s, got %s", i, tt.expected[i], f.GetName())
+				}
+			}
+		})
+	}
+}
+
+func TestValidateListeners(t *testing.T) {
+	ns := "test-ns"
+	gwName := "test-gw"
+
+	tests := []struct {
+		name               string
+		gateway            *gatewayv1.Gateway
+		secrets            []runtime.Object
+		referenceGrants    []runtime.Object
+		expectedConditions map[gatewayv1.SectionName][]metav1.Condition
+	}{
+		{
+			name: "Valid Secret in same namespace",
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns, Generation: 1},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{
+						{
+							Name:     "https",
+							Protocol: gatewayv1.HTTPSProtocolType,
+							TLS: &gatewayv1.ListenerTLSConfig{
+								CertificateRefs: []gatewayv1.SecretObjectReference{
+									{
+										Name: "my-secret",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: ns},
+				},
+			},
+			expectedConditions: map[gatewayv1.SectionName][]metav1.Condition{
+				"https": {
+					{
+						Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+						Status: metav1.ConditionTrue,
+						Reason: string(gatewayv1.ListenerReasonResolvedRefs),
+					},
+				},
+			},
+		},
+		{
+			name: "Missing Secret in same namespace",
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns, Generation: 1},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{
+						{
+							Name:     "https",
+							Protocol: gatewayv1.HTTPSProtocolType,
+							TLS: &gatewayv1.ListenerTLSConfig{
+								CertificateRefs: []gatewayv1.SecretObjectReference{
+									{
+										Name: "missing-secret",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedConditions: map[gatewayv1.SectionName][]metav1.Condition{
+				"https": {
+					{
+						Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+						Status: metav1.ConditionFalse,
+						Reason: string(gatewayv1.ListenerReasonInvalidCertificateRef),
+					},
+				},
+			},
+		},
+		{
+			name: "Unsupported reference type",
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns, Generation: 1},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{
+						{
+							Name:     "https",
+							Protocol: gatewayv1.HTTPSProtocolType,
+							TLS: &gatewayv1.ListenerTLSConfig{
+								CertificateRefs: []gatewayv1.SecretObjectReference{
+									{
+										Group: ptr.To(gatewayv1.Group("custom.group")),
+										Kind:  ptr.To(gatewayv1.Kind("CustomCert")),
+										Name:  "custom-cert",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedConditions: map[gatewayv1.SectionName][]metav1.Condition{
+				"https": {
+					{
+						Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+						Status: metav1.ConditionFalse,
+						Reason: string(gatewayv1.ListenerReasonInvalidCertificateRef),
+					},
+				},
+			},
+		},
+		{
+			name: "Cross-Namespace allowed by ReferenceGrant",
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns, Generation: 1},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{
+						{
+							Name:     "https",
+							Protocol: gatewayv1.HTTPSProtocolType,
+							TLS: &gatewayv1.ListenerTLSConfig{
+								CertificateRefs: []gatewayv1.SecretObjectReference{
+									{
+										Namespace: ptr.To(gatewayv1.Namespace("other-ns")),
+										Name:      "other-secret",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "other-secret", Namespace: "other-ns"},
+				},
+			},
+			referenceGrants: []runtime.Object{
+				&gatewayv1beta1.ReferenceGrant{
+					ObjectMeta: metav1.ObjectMeta{Name: "grant", Namespace: "other-ns"},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{
+							{
+								Group:     gatewayv1.GroupName,
+								Kind:      "Gateway",
+								Namespace: gatewayv1.Namespace(ns),
+							},
+						},
+						To: []gatewayv1beta1.ReferenceGrantTo{
+							{
+								Group: "",
+								Kind:  "Secret",
+								Name:  ptr.To(gatewayv1.ObjectName("other-secret")),
+							},
+						},
+					},
+				},
+			},
+			expectedConditions: map[gatewayv1.SectionName][]metav1.Condition{
+				"https": {
+					{
+						Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+						Status: metav1.ConditionTrue,
+						Reason: string(gatewayv1.ListenerReasonResolvedRefs),
+					},
+				},
+			},
+		},
+		{
+			name: "Cross-Namespace denied by missing ReferenceGrant",
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns, Generation: 1},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{
+						{
+							Name:     "https",
+							Protocol: gatewayv1.HTTPSProtocolType,
+							TLS: &gatewayv1.ListenerTLSConfig{
+								CertificateRefs: []gatewayv1.SecretObjectReference{
+									{
+										Namespace: ptr.To(gatewayv1.Namespace("other-ns")),
+										Name:      "other-secret",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "other-secret", Namespace: "other-ns"},
+				},
+			},
+			expectedConditions: map[gatewayv1.SectionName][]metav1.Condition{
+				"https": {
+					{
+						Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+						Status: metav1.ConditionFalse,
+						Reason: string(gatewayv1.ListenerReasonRefNotPermitted),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := k8sfake.NewClientset(tt.secrets...)
+			k8sInformerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+			for _, s := range tt.secrets {
+				_ = k8sInformerFactory.Core().V1().Secrets().Informer().GetIndexer().Add(s)
+			}
+
+			gwClient := gatewayclient.NewClientset(tt.referenceGrants...)
+			gwInformerFactory := gatewayinformers.NewSharedInformerFactory(gwClient, 0)
+			for _, rg := range tt.referenceGrants {
+				_ = gwInformerFactory.Gateway().V1beta1().ReferenceGrants().Informer().GetIndexer().Add(rg)
+			}
+
+			translator := &Translator{
+				secretLister:         k8sInformerFactory.Core().V1().Secrets().Lister(),
+				referenceGrantLister: gwInformerFactory.Gateway().V1beta1().ReferenceGrants().Lister(),
+			}
+
+			conditions := translator.validateListeners(tt.gateway)
+
+			for listenerName, expectedConds := range tt.expectedConditions {
+				actualConds := conditions[listenerName]
+				for _, expCond := range expectedConds {
+					found := false
+					for _, actCond := range actualConds {
+						if actCond.Type == expCond.Type {
+							found = true
+							if actCond.Status != expCond.Status {
+								t.Errorf("Listener %s, condition %s: expected status %v, got %v", listenerName, expCond.Type, expCond.Status, actCond.Status)
+							}
+							if actCond.Reason != expCond.Reason {
+								t.Errorf("Listener %s, condition %s: expected reason %v, got %v", listenerName, expCond.Type, expCond.Reason, actCond.Reason)
+							}
+						}
+					}
+					if !found {
+						t.Errorf("Listener %s: expected condition %s not found", listenerName, expCond.Type)
+					}
 				}
 			}
 		})


### PR DESCRIPTION
- Implemented proper validation for CertificateRefs in TLS listeners, checking for secret existence and verifying cross-namespace references against ReferenceGrant.

- Added unit tests in listener_test.go covering various valid and invalid scenarios for listener references.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind cleanup

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
