### PR TITLE
Install MetalLB in quickstart and fix envoy proxy label

### DIFF
--- a/dev/ci/lib.sh
+++ b/dev/ci/lib.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Install MetalLB on a kind cluster
+install_metallb() {
+  local metallb_version="v0.13.10"
+  kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/"${metallb_version}"/config/manifests/metallb-native.yaml
+
+  needCreate="$(kubectl get secret -n metallb-system memberlist --no-headers --ignore-not-found -o custom-columns=NAME:.metadata.name)"
+  if [ -z "$needCreate" ]; then
+      kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+  fi
+
+  # Wait for MetalLB to become available
+  kubectl rollout status -n metallb-system deployment/controller --timeout 5m
+  kubectl rollout status -n metallb-system daemonset/speaker --timeout 5m
+
+  # Configure MetalLB with an IP address pool derived from the Docker network used by Kind.
+  # We inspect the 'kind' network to find the subnet, and take the range .200 to .250.
+  # This range is safe to use because it is at the high end of the subnet, well outside
+  # the range a container engine typically uses when dynamically assigning IPs
+  # to containers (Kind nodes).
+  # For example, if the subnet is 192.168.8.0/24, address_first_three_octets will
+  # be 192.168.8 and the range will be 192.168.8.200-192.168.8.250.
+  local engine="${CONTAINER_ENGINE:-docker}"
+  if [[ "${engine}" == "podman" ]]; then
+    subnet=$(podman network inspect kind | jq -r '.[].subnets.[].subnet | select(contains(":") | not)')
+  else
+    subnet=$(docker network inspect kind | jq -r '.[].IPAM.Config[].Subnet | select(contains(":") | not)')
+  fi
+  if [[ -z "${subnet}" ]]; then
+      echo "Error: Could not find subnet for network kind"
+      return 1
+  fi
+  address_first_three_octets=$(echo "${subnet}" | awk -F. '{printf "%s.%s.%s",$1,$2,$3}')
+  address_range="${address_first_three_octets}.200-${address_first_three_octets}.250"
+
+  kubectl apply -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: kube-services
+spec:
+  addresses:
+  - ${address_range}
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: kube-services
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - kube-services
+EOF
+}

--- a/dev/ci/run-e2e.sh
+++ b/dev/ci/run-e2e.sh
@@ -40,47 +40,8 @@ main() {
   # is typically used to expose the Gateway) would remain in a <pending> state forever, and
   # the tests would fail.
   header "Installing MetalLB"
-  local metallb_version="v0.13.10"
-  kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/"${metallb_version}"/config/manifests/metallb-native.yaml
-
-  needCreate="$(kubectl get secret -n metallb-system memberlist --no-headers --ignore-not-found -o custom-columns=NAME:.metadata.name)"
-  if [ -z "$needCreate" ]; then
-      kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
-  fi
-
-  # Wait for MetalLB to become available
-  kubectl rollout status -n metallb-system deployment/controller --timeout 5m
-  kubectl rollout status -n metallb-system daemonset/speaker --timeout 5m
-
-  # Configure MetalLB with an IP address pool derived from the Docker network used by Kind.
-  # We inspect the 'kind' network to find the subnet, and take the range .200 to .250.
-  # This range is safe to use because it is at the high end of the subnet, well outside
-  # the range Docker typically uses when dynamically assigning IPs to containers (Kind nodes).
-  # For example, if the subnet is 192.168.8.0/24, address_first_three_octets will
-  # be 192.168.8 and the range will be 192.168.8.200-192.168.8.250.
-  subnet=$(docker network inspect kind | jq -r '.[].IPAM.Config[].Subnet | select(contains(":") | not)')
-  address_first_three_octets=$(echo "${subnet}" | awk -F. '{printf "%s.%s.%s",$1,$2,$3}')
-  address_range="${address_first_three_octets}.200-${address_first_three_octets}.250"
-
-  kubectl apply -f - <<EOF
-apiVersion: metallb.io/v1beta1
-kind: IPAddressPool
-metadata:
-  namespace: metallb-system
-  name: kube-services
-spec:
-  addresses:
-  - ${address_range}
----
-apiVersion: metallb.io/v1beta1
-kind: L2Advertisement
-metadata:
-  name: kube-services
-  namespace: metallb-system
-spec:
-  ipAddressPools:
-  - kube-services
-EOF
+  source dev/ci/lib.sh
+  install_metallb
 
   header "Building controller image"
   # These must match the image used in k8s/deploy/deployment.yaml
@@ -176,7 +137,7 @@ cleanup() {
     kubectl logs -n "${E2E_NAMESPACE}" -l app=mcp-everything --tail=100 || true
 
     header "Envoy Proxy Logs"
-    kubectl logs -n "${E2E_NAMESPACE}" -l "kube-agentic-networking.sigs.k8s.io/gateway-name=e2e-gateway" --all-containers --tail=100 || true
+    kubectl logs -n "${E2E_NAMESPACE}" -l "gateway.networking.k8s.io/gateway-name=e2e-gateway" --all-containers --tail=100 || true
   fi
   exit "${status}"
 }

--- a/site-src/guides/quickstart/run-quickstart.sh
+++ b/site-src/guides/quickstart/run-quickstart.sh
@@ -178,8 +178,14 @@ create_kind_cluster() {
   kubectl config use-context "kind-${CLUSTER_NAME}"
 }
 
-# TODO: install MetalLB after us-central1-docker.pkg.dev/k8s-staging-images/agentic-net/agentic-networking-controller:main
-# includes the changes in https://github.com/kubernetes-sigs/kube-agentic-networking/pull/244
+# --- Step 1.5: Install MetalLB ---
+
+install_metallb_step() {
+  info "Step 1.5/9: Installing MetalLB..."
+  source dev/ci/lib.sh
+  install_metallb
+}
+
 
 # --- Step 2: Install Gateway API CRDs ---
 
@@ -243,7 +249,7 @@ apply_policies() {
   local retries=0
   local max_retries=30
   while ! kubectl get deployment -n "${NAMESPACE}" \
-    -l "kube-agentic-networking.sigs.k8s.io/gateway-name=agentic-net-gateway" \
+    -l "gateway.networking.k8s.io/gateway-name=agentic-net-gateway" \
     -o name 2>/dev/null | grep -q .; do
     retries=$((retries + 1))
     if [[ ${retries} -ge ${max_retries} ]]; then
@@ -255,7 +261,7 @@ apply_policies() {
 
   info "Waiting for Envoy proxy to be ready..."
   kubectl wait --timeout=5m -n "${NAMESPACE}" deployment \
-    -l "kube-agentic-networking.sigs.k8s.io/gateway-name=agentic-net-gateway" \
+    -l "gateway.networking.k8s.io/gateway-name=agentic-net-gateway" \
     --for=condition=Available
 }
 
@@ -268,7 +274,7 @@ deploy_agent() {
   info "Waiting for Gateway address to be assigned..."
   local gateway_address=""
   local retries=0
-  local max_retries=30
+  local max_retries=60
   while [[ -z "${gateway_address}" ]]; do
     gateway_address=$(kubectl get gateway agentic-net-gateway -n "${NAMESPACE}" -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || true)
     if [[ -n "${gateway_address}" ]]; then
@@ -284,7 +290,7 @@ deploy_agent() {
 
   # Discover service account for the gateway.
   local gateway_sa
-  gateway_sa=$(kubectl get sa -n "${NAMESPACE}" -l "kube-agentic-networking.sigs.k8s.io/gateway-name=agentic-net-gateway" -o jsonpath='{.items[0].metadata.name}')
+  gateway_sa=$(kubectl get sa -n "${NAMESPACE}" -l "gateway.networking.k8s.io/gateway-name=agentic-net-gateway" -o jsonpath='{.items[0].metadata.name}')
   if [[ -z "${gateway_sa}" ]]; then
     error "Could not find service account for the gateway."
     exit 1
@@ -367,6 +373,7 @@ setup_port_forward() {
 # --- Main ---
 
 create_kind_cluster
+install_metallb_step
 install_gateway_api_crds
 install_agentic_networking_crds
 create_namespaces


### PR DESCRIPTION
- Move MetalLB installation logic from dev/ci/run-e2e.sh to dev/ci/lib.sh, and update both run-e2e.sh and run-quickstart.sh to use it.
- Use the correct label to check the existence/readiness of envoy deployment and SA.

The reason for installing MetalLB in quickstart is that https://github.com/kubernetes-sigs/kube-agentic-networking/pull/244 switched the Envoy Proxy Service type from `ClusterIP` to `LoadBalancer`.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind bug

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
