### PR TITLE
refactor: Extract Envoy helpers and centralize shared constants

### DIFF
--- a/pkg/constants/translator.go
+++ b/pkg/constants/translator.go
@@ -1,0 +1,70 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+import "time"
+
+const (
+	// DefaultExternalAuthPort is the default port for external authorization services if not specified in the BackendRef.
+	DefaultExternalAuthPort = 5000
+
+	// URITimeout is the timeout for URI requests.
+	URITimeout = 5 * time.Second
+
+	// WellknownJWTAuthnFilter is the name of the well-known JWT authentication filter.
+	WellknownJWTAuthnFilter = "envoy.filters.http.jwt_authn"
+
+	// ExternalAuthzShadowRulePrefix is the prefix for stat names of shadow rules generated from AccessPolicies with ExternalAuthz.
+	ExternalAuthzShadowRulePrefix = "access_policy_ext_authz"
+
+	// DefaultConnectTimeout is the timeout for new network connections to hosts in the cluster.
+	DefaultConnectTimeout = 5 * time.Second
+
+	// MCPSessionIDHeader is the header name for MCP session ID.
+	MCPSessionIDHeader = "mcp-session-id"
+
+	// ToolsCallMethod is the method name for calling tools.
+	ToolsCallMethod = "tools/call"
+
+	// MCPProxyFilterName is the name of the MCP proxy filter.
+	MCPProxyFilterName = "mcp_proxy"
+
+	// InitializeMethod is the method name for session initialization.
+	InitializeMethod = "initialize"
+
+	// InitializedMethod is the method name for session initialized notification.
+	InitializedMethod = "notifications/initialized"
+
+	// ToolsListMethod is the method name for listing tools.
+	ToolsListMethod = "tools/list"
+
+	// DefaultServicePort is the default service port when BackendRef.Port is not set.
+	DefaultServicePort = 80
+
+	// AllowMCPSessionClosePolicyName is the name of the RBAC policy that allows agents to close MCP sessions.
+	AllowMCPSessionClosePolicyName = "allow-mcp-session-close"
+
+	// AllowAnyoneToInitializeAndListToolsPolicyName is the name of the RBAC policy that allows anyone to initialize a session and list available tools.
+	AllowAnyoneToInitializeAndListToolsPolicyName = "allow-anyone-to-initialize-and-list-tools"
+
+	// AllowHTTPGetPolicyName is the name of the RBAC policy that allows an HTTP GET to the MCP endpoint for SSE stream.
+	AllowHTTPGetPolicyName = "allow-http-get"
+
+	// SpiffeIDFormat is the standard SPIFFE ID format for Kubernetes workloads.
+	// Format: spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>
+	SpiffeIDFormat = "spiffe://%s/ns/%s/sa/%s"
+)

--- a/pkg/translator/accesspolicy.go
+++ b/pkg/translator/accesspolicy.go
@@ -35,32 +35,6 @@ import (
 	"sigs.k8s.io/kube-agentic-networking/pkg/constants"
 )
 
-const (
-	// allowMCPSessionClosePolicyName is the name of the RBAC policy that allows agents to close MCP sessions.
-	allowMCPSessionClosePolicyName = "allow-mcp-session-close"
-
-	// allowAnyoneToInitializeAndListToolsPolicyName is the name of the RBAC policy that allows anyone to initialize a session and list available tools.
-	allowAnyoneToInitializeAndListToolsPolicyName = "allow-anyone-to-initialize-and-list-tools"
-	initializeMethod                              = "initialize"
-	initializedMethod                             = "notifications/initialized"
-	toolsListMethod                               = "tools/list"
-
-	// allowHTTPGet is the name of the RBAC policy that allows an HTTP GET to the MCP endpoint for SSE stream.
-	allowHTTPGet = "allow-http-get"
-
-	mcpSessionIDHeader = "mcp-session-id"
-	toolsCallMethod    = "tools/call"
-	mcpProxyFilterName = "mcp_proxy"
-
-	// spiffeIDFormat is the standard SPIFFE ID format for Kubernetes workloads.
-	// Format: spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>
-	spiffeIDFormat = "spiffe://%s/ns/%s/sa/%s"
-
-	// externalAuthzShadowRulePrefix is the prefix for stat names of shadow rules generated from AccessPolicies with ExternalAuthz.
-	// This allows us to monitor the presence of RBAC rules that are evaluated (though not enforced), with the purpose of signaling the need to call an ext_authz service.
-	externalAuthzShadowRulePrefix = "access_policy_ext_authz"
-)
-
 // buildGatewayLevelRBACFilters finds all AccessPolicies targeting the Gateway and translates them into HTTP filters.
 func (t *Translator) buildGatewayLevelRBACFilters(gateway *gatewayv1.Gateway) ([]*hcm.HttpFilter, error) {
 	gwPolicies, err := t.findAccessPoliciesForTarget(gatewayv1.GroupName, "Gateway", gateway.Namespace, gateway.Name)
@@ -186,9 +160,9 @@ func (t *Translator) buildRBACConfigWithCommonPolicies(accessPolicy *agenticv0al
 
 	// Add common policies to avoid blocking basic MCP operations.
 	// These are added to the 'Rules' section which is where allowed traffic is defined.
-	addPolicyToRBACRules(rbacConfig, allowMCPSessionClosePolicyName, buildAllowMCPSessionClosePolicy())
-	addPolicyToRBACRules(rbacConfig, allowAnyoneToInitializeAndListToolsPolicyName, buildAllowAnyoneToInitializeAndListToolsPolicy())
-	addPolicyToRBACRules(rbacConfig, allowHTTPGet, buildAllowHTTPGetPolicy())
+	addPolicyToRBACRules(rbacConfig, constants.AllowMCPSessionClosePolicyName, buildAllowMCPSessionClosePolicy())
+	addPolicyToRBACRules(rbacConfig, constants.AllowAnyoneToInitializeAndListToolsPolicyName, buildAllowAnyoneToInitializeAndListToolsPolicy())
+	addPolicyToRBACRules(rbacConfig, constants.AllowHTTPGetPolicyName, buildAllowHTTPGetPolicy())
 
 	return rbacConfig
 }
@@ -225,7 +199,7 @@ func (t *Translator) findAccessPoliciesForTarget(group, kind, namespace, name st
 // convertSAtoSPIFFEID constructs a standard SPIFFE ID for a Kubernetes ServiceAccount.
 // Format: spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>
 func convertSAtoSPIFFEID(trustDomain, namespace, saName string) string {
-	return fmt.Sprintf(spiffeIDFormat, trustDomain, namespace, saName)
+	return fmt.Sprintf(constants.SpiffeIDFormat, trustDomain, namespace, saName)
 }
 
 func (t *Translator) translateAccessPolicyToRBAC(accessPolicy *agenticv0alpha0.XAccessPolicy) *rbacv3.RBAC {
@@ -271,7 +245,7 @@ func (t *Translator) translateAccessPolicyToRBAC(accessPolicy *agenticv0alpha0.X
 						klog.Errorf("Failed to generate unique ID for externalAuth config in AccessPolicy %s/%s: %v", accessPolicy.Namespace, accessPolicy.Name, err)
 						continue
 					}
-					rbacConfig.ShadowRulesStatPrefix = fmt.Sprintf("%s_%s_", externalAuthzShadowRulePrefix, hash) // a maximum of one ExternalAuth rule per policy is allowed, so we can safely set the shadow rule stat prefix at the RBAC config level
+					rbacConfig.ShadowRulesStatPrefix = fmt.Sprintf("%s_%s_", constants.ExternalAuthzShadowRulePrefix, hash) // a maximum of one ExternalAuth rule per policy is allowed, so we can safely set the shadow rule stat prefix at the RBAC config level
 					rbacPolicy.Permissions = []*rbacconfigv3.Permission{buildToolsCallMethodPermission()}
 					addPolicyToRBACShadowRules(rbacConfig, policyName, rbacPolicy)
 				}
@@ -377,7 +351,7 @@ func translateInlineToolsToRBACPermission(tools []string) *rbacconfigv3.Permissi
 						Rule: &rbacconfigv3.Permission_SourcedMetadata{
 							SourcedMetadata: &rbacconfigv3.SourcedMetadata{
 								MetadataMatcher: &matcherv3.MetadataMatcher{
-									Filter: mcpProxyFilterName,
+									Filter: constants.MCPProxyFilterName,
 									Path:   []*matcherv3.MetadataMatcher_PathSegment{{Segment: &matcherv3.MetadataMatcher_PathSegment_Key{Key: "params"}}, {Segment: &matcherv3.MetadataMatcher_PathSegment_Key{Key: "name"}}},
 									Value:  toolsMatcher,
 								},
@@ -412,7 +386,7 @@ func buildAllowMCPSessionClosePolicy() *rbacconfigv3.Policy {
 							},
 							{ // Condition 2: The 'mcp-session-id' header must exist
 								Identifier: &rbacconfigv3.Principal_Header{
-									Header: &routev3.HeaderMatcher{Name: mcpSessionIDHeader, HeaderMatchSpecifier: &routev3.HeaderMatcher_PresentMatch{PresentMatch: true}},
+									Header: &routev3.HeaderMatcher{Name: constants.MCPSessionIDHeader, HeaderMatchSpecifier: &routev3.HeaderMatcher_PresentMatch{PresentMatch: true}},
 								},
 							},
 						},
@@ -437,9 +411,9 @@ func buildToolsCallMethodPermission() *rbacconfigv3.Permission {
 		Rule: &rbacconfigv3.Permission_SourcedMetadata{
 			SourcedMetadata: &rbacconfigv3.SourcedMetadata{
 				MetadataMatcher: &matcherv3.MetadataMatcher{
-					Filter: mcpProxyFilterName,
+					Filter: constants.MCPProxyFilterName,
 					Path:   []*matcherv3.MetadataMatcher_PathSegment{{Segment: &matcherv3.MetadataMatcher_PathSegment_Key{Key: "method"}}},
-					Value:  &matcherv3.ValueMatcher{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: toolsCallMethod}}}},
+					Value:  &matcherv3.ValueMatcher{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: constants.ToolsCallMethod}}}},
 				},
 			},
 		},
@@ -468,15 +442,15 @@ func buildAllowAnyoneToInitializeAndListToolsPolicy() *rbacconfigv3.Policy {
 								Rule: &rbacconfigv3.Permission_SourcedMetadata{
 									SourcedMetadata: &rbacconfigv3.SourcedMetadata{
 										MetadataMatcher: &matcherv3.MetadataMatcher{
-											Filter: mcpProxyFilterName,
+											Filter: constants.MCPProxyFilterName,
 											Path:   []*matcherv3.MetadataMatcher_PathSegment{{Segment: &matcherv3.MetadataMatcher_PathSegment_Key{Key: "method"}}},
 											Value: &matcherv3.ValueMatcher{
 												MatchPattern: &matcherv3.ValueMatcher_OrMatch{
 													OrMatch: &matcherv3.OrMatcher{
 														ValueMatchers: []*matcherv3.ValueMatcher{
-															{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: initializeMethod}}}},
-															{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: initializedMethod}}}},
-															{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: toolsListMethod}}}},
+															{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: constants.InitializeMethod}}}},
+															{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: constants.InitializedMethod}}}},
+															{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: constants.ToolsListMethod}}}},
 														},
 													},
 												},

--- a/pkg/translator/accesspolicy_test.go
+++ b/pkg/translator/accesspolicy_test.go
@@ -447,9 +447,9 @@ func TestBuildRBACConfigWithCommonPolicies(t *testing.T) {
 
 	expectedPolicies := []string{
 		"custom-rule",
-		allowMCPSessionClosePolicyName,
-		allowAnyoneToInitializeAndListToolsPolicyName,
-		allowHTTPGet,
+		constants.AllowMCPSessionClosePolicyName,
+		constants.AllowAnyoneToInitializeAndListToolsPolicyName,
+		constants.AllowHTTPGetPolicyName,
 	}
 
 	for _, p := range expectedPolicies {
@@ -719,14 +719,14 @@ func TestTranslateAccessPolicyToRBAC(t *testing.T) {
 			expectedRules: map[string]expectedRule{
 				"rule-ext-auth": {
 					principal:      "spiffe://example.com/ns/default/sa/caller",
-					permissions:    []string{toolsCallMethod},
+					permissions:    []string{constants.ToolsCallMethod},
 					isExternalAuth: true,
 				},
 			},
 			expectedShadowRules: map[string]expectedRule{
 				"rule-ext-auth": {
 					principal:      "spiffe://example.com/ns/default/sa/caller",
-					permissions:    []string{toolsCallMethod},
+					permissions:    []string{constants.ToolsCallMethod},
 					isExternalAuth: true,
 				},
 			},
@@ -806,7 +806,7 @@ func TestBuildAllowAnyoneToInitializeAndListToolsPolicy(t *testing.T) {
 		t.Errorf("principal should be ANY")
 	}
 	matcher := policy.GetPermissions()[0].GetAndRules().GetRules()[0].GetSourcedMetadata().GetMetadataMatcher()
-	if matcher.GetFilter() != mcpProxyFilterName || matcher.GetPath()[0].GetKey() != "method" {
+	if matcher.GetFilter() != constants.MCPProxyFilterName || matcher.GetPath()[0].GetKey() != "method" {
 		t.Errorf("policy incorrectly configured")
 	}
 	orMethods := matcher.GetValue().GetOrMatch()
@@ -895,7 +895,7 @@ func verifyPolicy(t *testing.T, rbacPolicy *rbacconfigv3.Policy, expected expect
 			t.Fatal("expected NotRule for empty tools list")
 		}
 		methodRule := notRule.GetSourcedMetadata()
-		if methodRule == nil || methodRule.GetMetadataMatcher().GetValue().GetStringMatch().GetExact() != toolsCallMethod {
+		if methodRule == nil || methodRule.GetMetadataMatcher().GetValue().GetStringMatch().GetExact() != constants.ToolsCallMethod {
 			t.Errorf("expected 'disallow tools/call' permission for empty tools list")
 		}
 		return
@@ -907,7 +907,7 @@ func verifyPolicy(t *testing.T, rbacPolicy *rbacconfigv3.Policy, expected expect
 			return
 		}
 		methodRule := rbacPolicy.GetPermissions()[0].GetSourcedMetadata()
-		if methodRule == nil || methodRule.GetMetadataMatcher().GetValue().GetStringMatch().GetExact() != toolsCallMethod {
+		if methodRule == nil || methodRule.GetMetadataMatcher().GetValue().GetStringMatch().GetExact() != constants.ToolsCallMethod {
 			t.Errorf("expected tools/call method permission for external auth")
 		}
 		return
@@ -922,8 +922,8 @@ func verifyPolicy(t *testing.T, rbacPolicy *rbacconfigv3.Policy, expected expect
 
 	// Rule 1: method must be tools/call
 	methodRule := andRules.GetRules()[0].GetSourcedMetadata()
-	if methodRule == nil || methodRule.GetMetadataMatcher() == nil || methodRule.GetMetadataMatcher().GetFilter() != mcpProxyFilterName {
-		t.Errorf("first AND rule should be sourced metadata from %s", mcpProxyFilterName)
+	if methodRule == nil || methodRule.GetMetadataMatcher() == nil || methodRule.GetMetadataMatcher().GetFilter() != constants.MCPProxyFilterName {
+		t.Errorf("first AND rule should be sourced metadata from %s", constants.MCPProxyFilterName)
 		return
 	}
 	// Verify Path ["method"]
@@ -931,8 +931,8 @@ func verifyPolicy(t *testing.T, rbacPolicy *rbacconfigv3.Policy, expected expect
 		t.Errorf("tools/call matcher should have path ['method']")
 	}
 	// Verify Value "tools/call"
-	if methodRule.GetMetadataMatcher().GetValue().GetStringMatch().GetExact() != toolsCallMethod {
-		t.Errorf("tools/call matcher should match exact string %q", toolsCallMethod)
+	if methodRule.GetMetadataMatcher().GetValue().GetStringMatch().GetExact() != constants.ToolsCallMethod {
+		t.Errorf("tools/call matcher should match exact string %q", constants.ToolsCallMethod)
 	}
 
 	// Rule 2: tool names match

--- a/pkg/translator/backend.go
+++ b/pkg/translator/backend.go
@@ -18,11 +18,9 @@ package translator
 
 import (
 	"fmt"
-	"time"
 
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -32,13 +30,6 @@ import (
 
 	agenticv0alpha0 "sigs.k8s.io/kube-agentic-networking/api/v0alpha0"
 	"sigs.k8s.io/kube-agentic-networking/pkg/constants"
-)
-
-const (
-	// The timeout for new network connections to hosts in the cluster.
-	defaultConnectTimeout = 5 * time.Second
-	// Default service port when BackendRef.Port is not set.
-	defaultServicePort = 80
 )
 
 // routeBackend represents either an XBackend or a direct Service reference for HTTPRoute backendRefs.
@@ -159,7 +150,7 @@ func resolveServicePort(svc *corev1.Service, backendPort *gatewayv1.PortNumber) 
 	if len(svc.Spec.Ports) > 0 {
 		return svc.Spec.Ports[0].Port
 	}
-	return defaultServicePort
+	return constants.DefaultServicePort
 }
 
 func convertBackendToCluster(backend *agenticv0alpha0.XBackend) (*clusterv3.Cluster, error) {
@@ -168,7 +159,7 @@ func convertBackendToCluster(backend *agenticv0alpha0.XBackend) (*clusterv3.Clus
 	// Create the base cluster configuration.
 	cluster := &clusterv3.Cluster{
 		Name:           clusterName,
-		ConnectTimeout: durationpb.New(defaultConnectTimeout),
+		ConnectTimeout: durationpb.New(constants.DefaultConnectTimeout),
 	}
 
 	if backend.Spec.MCP.ServiceName != nil {
@@ -223,45 +214,4 @@ func buildClustersFromRouteBackends(backends []*routeBackend) ([]*clusterv3.Clus
 		clusters = append(clusters, cluster)
 	}
 	return clusters, nil
-}
-
-func convertServiceRefToCluster(ns, name string, port int32) *clusterv3.Cluster {
-	clusterName := fmt.Sprintf(constants.ClusterNameFormat, ns, name)
-	serviceFQDN := fmt.Sprintf("%s.%s.svc.cluster.local", name, ns)
-	cluster := &clusterv3.Cluster{
-		Name:                 clusterName,
-		ConnectTimeout:       durationpb.New(defaultConnectTimeout),
-		ClusterDiscoveryType: &clusterv3.Cluster_Type{Type: clusterv3.Cluster_STRICT_DNS},
-		//nolint:gosec // G115: port values are within valid uint32 bounds
-		LoadAssignment: createClusterLoadAssignment(clusterName, serviceFQDN, uint32(port)),
-	}
-	return cluster
-}
-
-func createClusterLoadAssignment(clusterName, serviceHost string, servicePort uint32) *endpointv3.ClusterLoadAssignment {
-	return &endpointv3.ClusterLoadAssignment{
-		ClusterName: clusterName,
-		Endpoints: []*endpointv3.LocalityLbEndpoints{
-			{
-				LbEndpoints: []*endpointv3.LbEndpoint{
-					{
-						HostIdentifier: &endpointv3.LbEndpoint_Endpoint{
-							Endpoint: &endpointv3.Endpoint{
-								Address: &corev3.Address{
-									Address: &corev3.Address_SocketAddress{
-										SocketAddress: &corev3.SocketAddress{
-											Address: serviceHost,
-											PortSpecifier: &corev3.SocketAddress_PortValue{
-												PortValue: servicePort,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
 }

--- a/pkg/translator/envoy_helpers.go
+++ b/pkg/translator/envoy_helpers.go
@@ -1,0 +1,277 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translator
+
+import (
+	"fmt"
+
+	accesslogv3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	mcpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/mcp/v3"
+	routerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
+	tlsinspector "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/tls_inspector/v3"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/kube-agentic-networking/pkg/constants"
+)
+
+// newTLSCertificateSecret creates a new Envoy TLS certificate secret.
+func newTLSCertificateSecret(name string, certBytes, keyBytes []byte) *tlsv3.Secret {
+	return &tlsv3.Secret{
+		Name: name,
+		Type: &tlsv3.Secret_TlsCertificate{
+			TlsCertificate: &tlsv3.TlsCertificate{
+				CertificateChain: &corev3.DataSource{
+					Specifier: &corev3.DataSource_InlineBytes{InlineBytes: certBytes},
+				},
+				PrivateKey: &corev3.DataSource{
+					Specifier: &corev3.DataSource_InlineBytes{InlineBytes: keyBytes},
+				},
+			},
+		},
+	}
+}
+
+// newValidationContextSecret creates a new Envoy validation context secret.
+func newValidationContextSecret(name string, caBytes []byte) *tlsv3.Secret {
+	return &tlsv3.Secret{
+		Name: name,
+		Type: &tlsv3.Secret_ValidationContext{
+			ValidationContext: &tlsv3.CertificateValidationContext{
+				TrustedCa: &corev3.DataSource{
+					Specifier: &corev3.DataSource_InlineBytes{InlineBytes: caBytes},
+				},
+			},
+		},
+	}
+}
+
+// createClusterLoadAssignment constructs a ClusterLoadAssignment for a given service.
+func createClusterLoadAssignment(clusterName, serviceHost string, servicePort uint32) *endpointv3.ClusterLoadAssignment {
+	return &endpointv3.ClusterLoadAssignment{
+		ClusterName: clusterName,
+		Endpoints: []*endpointv3.LocalityLbEndpoints{
+			{
+				LbEndpoints: []*endpointv3.LbEndpoint{
+					{
+						HostIdentifier: &endpointv3.LbEndpoint_Endpoint{
+							Endpoint: &endpointv3.Endpoint{
+								Address: &corev3.Address{
+									Address: &corev3.Address_SocketAddress{
+										SocketAddress: &corev3.SocketAddress{
+											Address: serviceHost,
+											PortSpecifier: &corev3.SocketAddress_PortValue{
+												PortValue: servicePort,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// convertServiceRefToCluster creates an Envoy cluster from a direct Service reference.
+func convertServiceRefToCluster(ns, name string, port int32) *clusterv3.Cluster {
+	clusterName := fmt.Sprintf(constants.ClusterNameFormat, ns, name)
+	serviceFQDN := fmt.Sprintf("%s.%s.svc.cluster.local", name, ns)
+	cluster := &clusterv3.Cluster{
+		Name:                 clusterName,
+		ConnectTimeout:       durationpb.New(constants.DefaultConnectTimeout),
+		ClusterDiscoveryType: &clusterv3.Cluster_Type{Type: clusterv3.Cluster_STRICT_DNS},
+		//nolint:gosec // G115: port values are within valid uint32 bounds
+		LoadAssignment: createClusterLoadAssignment(clusterName, serviceFQDN, uint32(port)),
+	}
+	return cluster
+}
+
+// createEnvoyAddress creates an Envoy Address for a given port.
+func createEnvoyAddress(port uint32) *corev3.Address {
+	return &corev3.Address{
+		Address: &corev3.Address_SocketAddress{
+			SocketAddress: &corev3.SocketAddress{
+				Protocol: corev3.SocketAddress_TCP,
+				Address:  "0.0.0.0",
+				PortSpecifier: &corev3.SocketAddress_PortValue{
+					PortValue: port,
+				},
+			},
+		},
+	}
+}
+
+// createListenerFilters returns the default listener filters.
+func createListenerFilters() []*listener.ListenerFilter {
+	tlsInspectorConfig, _ := anypb.New(&tlsinspector.TlsInspector{})
+	return []*listener.ListenerFilter{
+		{
+			Name: wellknown.TlsInspector,
+			ConfigType: &listener.ListenerFilter_TypedConfig{
+				TypedConfig: tlsInspectorConfig,
+			},
+		},
+	}
+}
+
+// toEnvoyExactStringMatchers converts a slice of strings to Exact StringMatchers.
+func toEnvoyExactStringMatchers(s []string) []*matcherv3.StringMatcher {
+	var matchers []*matcherv3.StringMatcher
+	for _, str := range s {
+		matchers = append(matchers, &matcherv3.StringMatcher{
+			MatchPattern: &matcherv3.StringMatcher_Exact{
+				Exact: str,
+			},
+		})
+	}
+	return matchers
+}
+
+// newAdsSdsSecretConfig creates an SdsSecretConfig using ADS.
+func newAdsSdsSecretConfig(secretName string) *tlsv3.SdsSecretConfig {
+	return &tlsv3.SdsSecretConfig{
+		Name: secretName,
+		SdsConfig: &corev3.ConfigSource{
+			ResourceApiVersion: corev3.ApiVersion_V3,
+			ConfigSourceSpecifier: &corev3.ConfigSource_Ads{
+				Ads: &corev3.AggregatedConfigSource{},
+			},
+		},
+	}
+}
+
+// newPathSdsSecretConfig creates an SdsSecretConfig using a local path.
+func newPathSdsSecretConfig(name, filename string) *tlsv3.SdsSecretConfig {
+	return &tlsv3.SdsSecretConfig{
+		Name: name,
+		SdsConfig: &corev3.ConfigSource{
+			ResourceApiVersion: corev3.ApiVersion_V3,
+			ConfigSourceSpecifier: &corev3.ConfigSource_PathConfigSource{
+				PathConfigSource: &corev3.PathConfigSource{
+					Path: fmt.Sprintf("%s/%s", constants.EnvoySdsMountPath, filename),
+				},
+			},
+		},
+	}
+}
+
+// buildMCPFilter constructs the MCP filter.
+func buildMCPFilter() (*hcm.HttpFilter, error) {
+	mcpProto := &mcpv3.Mcp{}
+	mcpAny, err := anypb.New(mcpProto)
+	if err != nil {
+		klog.Errorf("Failed to marshal mcp config: %v", err)
+		return nil, err
+	}
+
+	return &hcm.HttpFilter{
+		Name: "envoy.filters.http.mcp",
+		ConfigType: &hcm.HttpFilter_TypedConfig{
+			TypedConfig: mcpAny,
+		},
+	}, nil
+}
+
+// buildRouterFilter constructs the router filter.
+func buildRouterFilter() (*hcm.HttpFilter, error) {
+	routerProto := &routerv3.Router{}
+	routerAny, err := anypb.New(routerProto)
+	if err != nil {
+		klog.Errorf("Failed to marshal router config: %v", err)
+		return nil, err
+	}
+
+	return &hcm.HttpFilter{
+		Name: wellknown.Router,
+		ConfigType: &hcm.HttpFilter_TypedConfig{
+			TypedConfig: routerAny,
+		},
+	}, nil
+}
+
+// buildLocalReplyConfig constructs the local reply configuration for 403 responses
+func buildLocalReplyConfig() *hcm.LocalReplyConfig {
+	return &hcm.LocalReplyConfig{
+		Mappers: []*hcm.ResponseMapper{
+			{
+				Filter: &accesslogv3.AccessLogFilter{
+					FilterSpecifier: &accesslogv3.AccessLogFilter_AndFilter{
+						AndFilter: &accesslogv3.AndFilter{
+							Filters: []*accesslogv3.AccessLogFilter{
+								{
+									FilterSpecifier: &accesslogv3.AccessLogFilter_StatusCodeFilter{
+										StatusCodeFilter: &accesslogv3.StatusCodeFilter{
+											Comparison: &accesslogv3.ComparisonFilter{
+												Op: accesslogv3.ComparisonFilter_EQ,
+												Value: &corev3.RuntimeUInt32{
+													DefaultValue: 403,
+												},
+											},
+										},
+									},
+								},
+								{
+									FilterSpecifier: &accesslogv3.AccessLogFilter_HeaderFilter{
+										HeaderFilter: &accesslogv3.HeaderFilter{
+											Header: &routev3.HeaderMatcher{
+												Name:                 "WWW-Authenticate",
+												HeaderMatchSpecifier: &routev3.HeaderMatcher_PresentMatch{PresentMatch: false},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				StatusCode: wrapperspb.UInt32(200),
+				BodyFormatOverride: &corev3.SubstitutionFormatString{
+					Format: &corev3.SubstitutionFormatString_JsonFormat{
+						JsonFormat: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"jsonrpc": structpb.NewStringValue("2.0"),
+								"id":      structpb.NewStringValue("%DYNAMIC_METADATA(mcp_proxy:id)%"),
+								"error": structpb.NewStructValue(&structpb.Struct{
+									Fields: map[string]*structpb.Value{
+										"code":    structpb.NewNumberValue(403),
+										"message": structpb.NewStringValue("Access to this tool is forbidden."),
+									},
+								}),
+							},
+						},
+					},
+					ContentType: "application/json",
+				},
+			},
+		},
+	}
+}

--- a/pkg/translator/listener.go
+++ b/pkg/translator/listener.go
@@ -21,16 +21,10 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"time"
 
-	accesslogv3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	ext_authzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
-	mcpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/mcp/v3"
-	routerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
-	tlsinspector "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/tls_inspector/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tcpproxyv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	udpproxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/udp/udp_proxy/v3"
@@ -39,7 +33,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -52,12 +45,6 @@ import (
 
 	v0alpha0 "sigs.k8s.io/kube-agentic-networking/api/v0alpha0"
 	"sigs.k8s.io/kube-agentic-networking/pkg/constants"
-)
-
-const (
-	uriTimeout = 5 * time.Second
-
-	wellknownJWTAuthnFilter = "envoy.filters.http.jwt_authn"
 )
 
 type listenerConditions map[gatewayv1.SectionName][]metav1.Condition
@@ -365,79 +352,6 @@ func (t *Translator) translateListenerToFilterChain(lis gatewayv1.Listener, rout
 }
 
 // buildLocalReplyConfig constructs the local reply configuration for 403 responses
-func buildLocalReplyConfig() *hcm.LocalReplyConfig {
-	return &hcm.LocalReplyConfig{
-		Mappers: []*hcm.ResponseMapper{
-			{
-				// Use an access-log style filter to identify the responses we want to remap.
-				// The AND filter ensures both conditions must hold:
-				// 1) Status code equals the runtime-configurable value (default 403).
-				// 2) The "WWW-Authenticate" header is NOT present so we don't catch
-				//    upstream authentication failures (which include that header).
-				Filter: &accesslogv3.AccessLogFilter{
-					FilterSpecifier: &accesslogv3.AccessLogFilter_AndFilter{
-						AndFilter: &accesslogv3.AndFilter{
-							Filters: []*accesslogv3.AccessLogFilter{
-								{
-									FilterSpecifier: &accesslogv3.AccessLogFilter_StatusCodeFilter{
-										StatusCodeFilter: &accesslogv3.StatusCodeFilter{
-											Comparison: &accesslogv3.ComparisonFilter{
-												Op: accesslogv3.ComparisonFilter_EQ,
-												Value: &corev3.RuntimeUInt32{
-													DefaultValue: 403,
-												},
-											},
-										},
-									},
-								},
-								// MCP servers typically return 403 with a "WWW-Authenticate" header when
-								// the client fails to authenticate. We only want to remap our custom 403s,
-								// so require that header to be absent.
-								// https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#protected-resource-metadata-discovery-requirements
-								{
-									FilterSpecifier: &accesslogv3.AccessLogFilter_HeaderFilter{
-										HeaderFilter: &accesslogv3.HeaderFilter{
-											Header: &routev3.HeaderMatcher{
-												Name:                 "WWW-Authenticate",
-												HeaderMatchSpecifier: &routev3.HeaderMatcher_PresentMatch{PresentMatch: false},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				// TODO: https://github.com/kubernetes-sigs/kube-agentic-networking/issues/169
-				// NOTE: Temporary workaround: Agent SDKs incorrectly treat a 403 in a way that
-				// prevents proper client-side error handling. To remain compatible until all SDKs
-				// are fixed, set the HTTP status code to 200 and encode a JSON-RPC error body.
-				// See the linked SDK improvement below for context.
-				// https://github.com/modelcontextprotocol/python-sdk/commit/2fe56e56de2aff8fcb964ff7e26e7c6df4d14653
-				// Change the HTTP status code back to 403 when the commit above is released in all Agent SDKs.
-				StatusCode: wrapperspb.UInt32(200),
-				// Override the body format to JSON-RPC 2.0.
-				BodyFormatOverride: &corev3.SubstitutionFormatString{
-					Format: &corev3.SubstitutionFormatString_JsonFormat{
-						JsonFormat: &structpb.Struct{
-							Fields: map[string]*structpb.Value{
-								"jsonrpc": structpb.NewStringValue("2.0"),
-								"id":      structpb.NewStringValue("%DYNAMIC_METADATA(mcp_proxy:id)%"),
-								"error": structpb.NewStructValue(&structpb.Struct{
-									Fields: map[string]*structpb.Value{
-										"code":    structpb.NewNumberValue(403),
-										"message": structpb.NewStringValue("Access to this tool is forbidden."),
-									},
-								}),
-							},
-						},
-					},
-					ContentType: "application/json",
-				},
-			},
-		},
-	}
-}
 
 func (t *Translator) buildHTTPFilterChain(lis gatewayv1.Listener, routeName string, gateway *gatewayv1.Gateway) (*listener.FilterChain, error) {
 	httpFilters, err := t.buildHTTPFilters(gateway)
@@ -569,22 +483,6 @@ func (t *Translator) buildHTTPFilters(gateway *gatewayv1.Gateway) ([]*hcm.HttpFi
 	return filters, nil
 }
 
-func buildMCPFilter() (*hcm.HttpFilter, error) {
-	mcpProto := &mcpv3.Mcp{}
-	mcpAny, err := anypb.New(mcpProto)
-	if err != nil {
-		klog.Errorf("Failed to marshal mcp config: %v", err)
-		return nil, err
-	}
-
-	return &hcm.HttpFilter{
-		Name: "envoy.filters.http.mcp",
-		ConfigType: &hcm.HttpFilter_TypedConfig{
-			TypedConfig: mcpAny,
-		},
-	}, nil
-}
-
 func (t *Translator) buildExtAuthzFilters(gateway *gatewayv1.Gateway) ([]*hcm.HttpFilter, error) {
 	accessPolicies, err := t.accessPolicyLister.List(labels.Everything())
 	if err != nil {
@@ -634,7 +532,7 @@ func buildExtAuthzFilterForRBACFilter(extAuthz *gatewayv1.HTTPExternalAuthFilter
 			Path: []*matcherv3.MetadataMatcher_PathSegment{
 				{
 					Segment: &matcherv3.MetadataMatcher_PathSegment_Key{
-						Key: fmt.Sprintf("%s_%s_shadow_effective_policy_id", externalAuthzShadowRulePrefix, extAuthzUniqueID),
+						Key: fmt.Sprintf("%s_%s_shadow_effective_policy_id", constants.ExternalAuthzShadowRulePrefix, extAuthzUniqueID),
 					},
 				},
 			},
@@ -643,8 +541,8 @@ func buildExtAuthzFilterForRBACFilter(extAuthz *gatewayv1.HTTPExternalAuthFilter
 			},
 		},
 		MetadataContextNamespaces: []string{
-			mcpProxyFilterName,
-			wellknownJWTAuthnFilter, // Although we don't directly depend on the JWT authn filter, we propagate metadata that it generates for use in ext_authz, in case the filter is set by the user.
+			constants.MCPProxyFilterName,
+			constants.WellknownJWTAuthnFilter, // Although we don't directly depend on the JWT authn filter, we propagate metadata that it generates for use in ext_authz, in case the filter is set by the user.
 		},
 	}
 	backendRef := extAuthz.BackendRef
@@ -685,7 +583,7 @@ func buildExtAuthzFilterForRBACFilter(extAuthz *gatewayv1.HTTPExternalAuthFilter
 						HttpUpstreamType: &corev3.HttpUri_Cluster{
 							Cluster: clusterName,
 						},
-						Timeout: durationpb.New(uriTimeout),
+						Timeout: durationpb.New(constants.URITimeout),
 					},
 					PathPrefix: config.Path,
 				},
@@ -753,48 +651,6 @@ func (t *Translator) isAccessPolicyAttachedToGateway(ap *v0alpha0.XAccessPolicy,
 	return false
 }
 
-func buildRouterFilter() (*hcm.HttpFilter, error) {
-	routerProto := &routerv3.Router{}
-	routerAny, err := anypb.New(routerProto)
-	if err != nil {
-		klog.Errorf("Failed to marshal router config: %v", err)
-		return nil, err
-	}
-
-	return &hcm.HttpFilter{
-		Name: wellknown.Router,
-		ConfigType: &hcm.HttpFilter_TypedConfig{
-			TypedConfig: routerAny,
-		},
-	}, nil
-}
-
-func newAdsSdsSecretConfig(secretName string) *tlsv3.SdsSecretConfig {
-	return &tlsv3.SdsSecretConfig{
-		Name: secretName,
-		SdsConfig: &corev3.ConfigSource{
-			ResourceApiVersion: corev3.ApiVersion_V3,
-			ConfigSourceSpecifier: &corev3.ConfigSource_Ads{
-				Ads: &corev3.AggregatedConfigSource{},
-			},
-		},
-	}
-}
-
-func newPathSdsSecretConfig(name, filename string) *tlsv3.SdsSecretConfig {
-	return &tlsv3.SdsSecretConfig{
-		Name: name,
-		SdsConfig: &corev3.ConfigSource{
-			ResourceApiVersion: corev3.ApiVersion_V3,
-			ConfigSourceSpecifier: &corev3.ConfigSource_PathConfigSource{
-				PathConfigSource: &corev3.PathConfigSource{
-					Path: fmt.Sprintf("%s/%s", constants.EnvoySdsMountPath, filename),
-				},
-			},
-		},
-	}
-}
-
 // buildDownstreamTLSContext configures TLS for the downstream (client-to-gateway) connection.
 func buildDownstreamTLSContext(lis gatewayv1.Listener, gateway *gatewayv1.Gateway) (*anypb.Any, error) {
 	certRef, caRef, hasMultipleCerts, hasMultipleCAs := extractCertificateRefs(gateway, lis)
@@ -841,44 +697,6 @@ func buildDownstreamTLSContext(lis gatewayv1.Listener, gateway *gatewayv1.Gatewa
 		return nil, err
 	}
 	return anyObj, nil
-}
-
-func createEnvoyAddress(port uint32) *corev3.Address {
-	return &corev3.Address{
-		Address: &corev3.Address_SocketAddress{
-			SocketAddress: &corev3.SocketAddress{
-				Protocol: corev3.SocketAddress_TCP,
-				Address:  "0.0.0.0",
-				PortSpecifier: &corev3.SocketAddress_PortValue{
-					PortValue: port,
-				},
-			},
-		},
-	}
-}
-
-func createListenerFilters() []*listener.ListenerFilter {
-	tlsInspectorConfig, _ := anypb.New(&tlsinspector.TlsInspector{})
-	return []*listener.ListenerFilter{
-		{
-			Name: wellknown.TlsInspector,
-			ConfigType: &listener.ListenerFilter_TypedConfig{
-				TypedConfig: tlsInspectorConfig,
-			},
-		},
-	}
-}
-
-func toEnvoyExactStringMatchers(s []string) []*matcherv3.StringMatcher {
-	var matchers []*matcherv3.StringMatcher
-	for _, str := range s {
-		matchers = append(matchers, &matcherv3.StringMatcher{
-			MatchPattern: &matcherv3.StringMatcher_Exact{
-				Exact: str,
-			},
-		})
-	}
-	return matchers
 }
 
 func externalAuthUniqueID(externalAuth *gatewayv1.HTTPExternalAuthFilter) (string, error) {

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -25,7 +25,6 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	httpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	envoyproxytypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
@@ -48,11 +47,6 @@ import (
 
 	agenticlisters "sigs.k8s.io/kube-agentic-networking/k8s/client/listers/api/v0alpha0"
 	"sigs.k8s.io/kube-agentic-networking/pkg/constants"
-)
-
-const (
-	// The default port for external authorization services if not specified in the BackendRef.
-	defaultExternalAuthPort = 5000
 )
 
 type ControllerError struct {
@@ -515,19 +509,7 @@ func (t *Translator) resolveCertificate(
 	keyBytes := secret.Data[corev1.TLSPrivateKeyKey]
 
 	if !seenSecrets[sdsName] {
-		envoySecret := &tlsv3.Secret{
-			Name: sdsName,
-			Type: &tlsv3.Secret_TlsCertificate{
-				TlsCertificate: &tlsv3.TlsCertificate{
-					CertificateChain: &corev3.DataSource{
-						Specifier: &corev3.DataSource_InlineBytes{InlineBytes: certBytes},
-					},
-					PrivateKey: &corev3.DataSource{
-						Specifier: &corev3.DataSource_InlineBytes{InlineBytes: keyBytes},
-					},
-				},
-			},
-		}
+		envoySecret := newTLSCertificateSecret(sdsName, certBytes, keyBytes)
 		*envoySecrets = append(*envoySecrets, envoySecret)
 		seenSecrets[sdsName] = true
 	}
@@ -562,16 +544,7 @@ func (t *Translator) resolveCACertificate(
 	caStr := cm.Data[corev1.ServiceAccountRootCAKey]
 
 	if !seenSecrets[sdsName] {
-		envoySecret := &tlsv3.Secret{
-			Name: sdsName,
-			Type: &tlsv3.Secret_ValidationContext{
-				ValidationContext: &tlsv3.CertificateValidationContext{
-					TrustedCa: &corev3.DataSource{
-						Specifier: &corev3.DataSource_InlineBytes{InlineBytes: []byte(caStr)},
-					},
-				},
-			},
-		}
+		envoySecret := newValidationContextSecret(sdsName, []byte(caStr))
 		*envoySecrets = append(*envoySecrets, envoySecret)
 		seenSecrets[sdsName] = true
 	}
@@ -756,14 +729,14 @@ func buildExtAuthzBackendClusters(accessPolicyLister agenticlisters.XAccessPolic
 				continue // Cluster already exists for this backendRef and protocol, skip to avoid duplicates.
 			}
 			serviceFQDN := fqdnFromBackendRef(backendRef, ap.GetNamespace())
-			servicePort := uint32(defaultExternalAuthPort)
+			servicePort := uint32(constants.DefaultExternalAuthPort)
 			if backendRef.Port != nil {
 				//nolint:gosec // G115: port values are within valid uint32 bounds
 				servicePort = uint32(*backendRef.Port)
 			}
 			cluster := &clusterv3.Cluster{
 				Name:                 clusterName,
-				ConnectTimeout:       durationpb.New(defaultConnectTimeout),
+				ConnectTimeout:       durationpb.New(constants.DefaultConnectTimeout),
 				ClusterDiscoveryType: &clusterv3.Cluster_Type{Type: clusterv3.Cluster_STRICT_DNS},
 				LoadAssignment:       createClusterLoadAssignment(clusterName, serviceFQDN, servicePort),
 				LbPolicy:             clusterv3.Cluster_ROUND_ROBIN,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

**Description**
This PR refactors the pkg/translator package to improve code organization, readability, and maintainability. It addresses two main cleanup tasks:

1. Extraction of Envoy Helpers: Helper functions that directly construct Envoy resources have been moved from various files (listener.go, backend.go, httproute.go, accesspolicy.go) into a dedicated file envoy.go.

2. Centralization of Shared Constants: Constants used across multiple files in the translator package have been moved to a new centralized file pkg/constants/translator.go.

These changes separate the core Kubernetes-to-Envoy translation logic from the low-level Envoy object construction details.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
None
```
