### PR TITLE
Add a make rule to help developing controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,25 @@ dev-reload-agent: ## Build, load and restart ADK agent in Kind with safety check
 	@echo "Restarting adk-agent pods..."
 	kubectl rollout restart deployment/adk-agent -n $(NAMESPACE)
 
+.PHONY: dev-reload-controller
+dev-reload-controller: build ## Build and reload controller image into Kind cluster
+	@if [[ "$(CONTEXT)" != kind-* ]]; then \
+		echo "Error: Current context is '$(CONTEXT)', not a Kind cluster."; \
+		exit 1; \
+	fi
+	@CLUSTER_NAME=$$(echo $(CONTEXT) | sed 's/kind-//'); \
+	echo "Loading image into Kind cluster: $$CLUSTER_NAME..."; \
+	kind load docker-image $(REGISTRY)/$(IMAGE_NAME):$(TAG) --name $$CLUSTER_NAME
+
+	@echo "Updating Deployment in namespace: agentic-net-system..."
+	kubectl patch deployment agentic-net-controller -n agentic-net-system --type=json \
+		-p='[{"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "IfNotPresent"}]'
+	
+	kubectl set image deployment/agentic-net-controller manager=$(REGISTRY)/$(IMAGE_NAME):$(TAG) -n agentic-net-system
+	
+	@echo "Restarting agentic-net-controller pods..."
+	kubectl rollout restart deployment/agentic-net-controller -n agentic-net-system
+
 ##@Docs
 
 .PHONY: build-docs


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
- **Local Iteration**: Added `dev-reload-controller` to the `Makefile`. This target builds the controller image, loads it into the active Kind cluster, patches the deployment with `IfNotPresent` pull policy, and triggers a rollout restart.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
None
```
