### PR TITLE
Allow counting attached routes even if listener references are unresolved

### DIFF
--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -206,7 +206,8 @@ func (t *Translator) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 				certValid, caValid := t.processHTTPSListenerSecrets(gateway, listener, &listenerStatus, &envoySecrets, seenSecrets)
 				if !certValid || !caValid {
 					allListenerStatuses[listener.Name] = listenerStatus
-					continue
+					// Do not continue here, allow counting attached routes even if references are unresolved.
+					// The listener will still be marked as not programmed and skipped for Envoy config generation.
 				}
 			}
 

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -346,6 +346,61 @@ func TestTranslateGatewayToXDS_Full(t *testing.T) {
 			},
 		},
 		{
+			name:    "Listener with Unresolved Secret Refs still counts AttachedRoutes",
+			gw:      newTestGateway("invalid-secret-gw", ns, []gatewayv1.SecretObjectReference{{Name: "missing-cert"}}, nil),
+			backend: newTestBackend("backend", ns),
+			routes: []*gatewayv1.HTTPRoute{
+				newTestHTTPRoute("route-1", ns, "invalid-secret-gw", "backend"),
+			},
+			policies: nil,
+			mcpSvc:   newTestService("backend-svc", ns, 3001),
+			secrets:  nil, // No secrets provided, so "missing-cert" will be unresolved
+			expected: expectedResult{
+				listeners: []expectedListener{
+					{
+						envoyName:          "", // No Envoy listener expected
+						k8sName:            "https-listener",
+						maxBackendPolicies: 0,
+						attachedRoutes:     1, // THIS IS THE KEY CHECK
+						conditions: []metav1.Condition{
+							{
+								Type:   string(gatewayv1.ListenerConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayv1.ListenerReasonAccepted),
+							},
+							{
+								Type:   string(gatewayv1.ListenerConditionProgrammed),
+								Status: metav1.ConditionFalse,
+								Reason: string(gatewayv1.ListenerReasonInvalid),
+							},
+							{
+								Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+								Status: metav1.ConditionFalse,
+								Reason: string(gatewayv1.ListenerReasonInvalidCertificateRef),
+							},
+						},
+					},
+				},
+				routes: []expectedRoute{
+					{
+						envoyName:    "route-10001",
+						k8sName:      "route-1",
+						k8sNamespace: ns,
+						parentStatuses: []gatewayv1.RouteParentStatus{
+							{
+								ParentRef:      gatewayv1.ParentReference{Name: "invalid-secret-gw"},
+								ControllerName: gatewayv1.GatewayController(constants.ControllerName),
+								Conditions: []metav1.Condition{
+									{Type: string(gatewayv1.RouteConditionAccepted), Status: metav1.ConditionTrue},
+								},
+							},
+						},
+					},
+				},
+				clusters: []string{"quickstart-ns-backend"},
+			},
+		},
+		{
 			name:    "Listener programmed with only cert Ref and use default SPIFFE trust",
 			gw:      newTestGateway("cert-only-gw", ns, []gatewayv1.SecretObjectReference{{Name: "my-cert"}}, nil),
 			backend: newTestBackend("cert-only-backend", ns),


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind bug


**What this PR does / why we need it**:
The change ensures that a Gateway listener still counts its attached routes even if its TLS certificate references (Secrets) cannot be resolved. Previously, the code would skip the rest of the processing for that listener immediately upon finding unresolved references, leading to an incorrect count of attached routes.

This gap was identified by the conformance test `TestGatewayAPIConformance/GatewayWithAttachedRoutes/Gateway_listener_should_have_AttachedRoutes_set_even_when_Gateway_has_unresolved_refs`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
