### PR TITLE
Create the Envoy Proxy Service first to trigger LoadBalancer allocation early

### DIFF
--- a/pkg/infra/envoy/proxy.go
+++ b/pkg/infra/envoy/proxy.go
@@ -82,6 +82,14 @@ func (r *ResourceManager) EnsureProxyExist(ctx context.Context) (string, error) 
 		return "", err
 	}
 
+	// Create the Service first to trigger LoadBalancer allocation early.
+	// The LoadBalancer allocation may take 3-5 minutes in e2e/conformance tests.
+	// The Deployment can take about 1-2 minutes to be ready, so we want to start
+	// LoadBalancer allocation as early as possible.
+	if _, err := r.ensureServiceExists(ctx); err != nil {
+		return "", err
+	}
+
 	if err := r.ensureDeployment(ctx); err != nil {
 		return "", err
 	}
@@ -169,8 +177,8 @@ func (r *ResourceManager) ensureDeployment(ctx context.Context) error {
 	return fmt.Errorf("envoy deployment %s is not available yet", deployment.Name)
 }
 
-// ensureService ensures that the Service for the Envoy proxy exists and has a LoadBalancer address (IP or Hostname) assigned.
-func (r *ResourceManager) ensureService(ctx context.Context) (string, error) {
+// ensureServiceExists ensures that the Service for the Envoy proxy exists.
+func (r *ResourceManager) ensureServiceExists(ctx context.Context) (*corev1.Service, error) {
 	logger := klog.FromContext(ctx)
 	service := r.renderService()
 
@@ -180,24 +188,29 @@ func (r *ResourceManager) ensureService(ctx context.Context) (string, error) {
 			logger.Info("Creating Envoy proxy service", "name", service.Name, "namespace", service.Namespace)
 			svc, err = r.client.CoreV1().Services(service.Namespace).Create(ctx, service, metav1.CreateOptions{})
 			if err != nil {
-				return "", fmt.Errorf("failed to create envoy service: %w", err)
+				return nil, fmt.Errorf("failed to create envoy service: %w", err)
 			}
-		} else {
-			return "", fmt.Errorf("failed to get envoy service: %w", err)
+			return svc, nil
 		}
+		return nil, fmt.Errorf("failed to get envoy service: %w", err)
 	}
+	return svc, nil
+}
 
-	svc, err = r.client.CoreV1().Services(service.Namespace).Get(ctx, service.Name, metav1.GetOptions{})
+// ensureService ensures that the Service for the Envoy proxy exists and has a LoadBalancer address (IP or Hostname) assigned.
+func (r *ResourceManager) ensureService(ctx context.Context) (string, error) {
+	logger := klog.FromContext(ctx)
+	svc, err := r.ensureServiceExists(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to refresh envoy service: %w", err)
+		return "", err
 	}
 
 	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
-		return "", fmt.Errorf("envoy service %s type is %s, expected %s", service.Name, svc.Spec.Type, corev1.ServiceTypeLoadBalancer)
+		return "", fmt.Errorf("envoy service %s type is %s, expected %s", svc.Name, svc.Spec.Type, corev1.ServiceTypeLoadBalancer)
 	}
 
 	if len(svc.Status.LoadBalancer.Ingress) == 0 {
-		return "", fmt.Errorf("loadbalancer address is not assigned yet for service %s", service.Name)
+		return "", fmt.Errorf("loadbalancer address is not assigned yet for service %s", svc.Name)
 	}
 
 	ingress := svc.Status.LoadBalancer.Ingress[0]
@@ -206,7 +219,7 @@ func (r *ResourceManager) ensureService(ctx context.Context) (string, error) {
 		address = ingress.Hostname
 	}
 	if address == "" {
-		return "", fmt.Errorf("loadbalancer IP or Hostname is not assigned yet for service %s", service.Name)
+		return "", fmt.Errorf("loadbalancer IP or Hostname is not assigned yet for service %s", svc.Name)
 	}
 
 	logger.Info("Envoy proxy service is ready with LoadBalancer address!", "address", address)

--- a/pkg/infra/envoy/proxy_test.go
+++ b/pkg/infra/envoy/proxy_test.go
@@ -145,6 +145,36 @@ func TestEnsureService(t *testing.T) {
 		}
 	})
 
+	t.Run("service exists, avoids duplicate Get calls", func(t *testing.T) {
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeID,
+				Namespace: "test-ns",
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+			},
+		}
+		client := fake.NewClientset(svc)
+		rm := NewResourceManager(client, gw, "envoy-image", "cluster.local")
+
+		_, err := rm.ensureService(context.Background())
+		if err == nil {
+			t.Fatal("expected error as service has no LoadBalancer address")
+		}
+
+		actions := client.Actions()
+		getCount := 0
+		for _, action := range actions {
+			if action.GetVerb() == "get" && action.GetResource().Resource == "services" {
+				getCount++
+			}
+		}
+		if getCount != 1 {
+			t.Errorf("expected 1 Get call for services, got %d", getCount)
+		}
+	})
+
 	t.Run("service exists and has LoadBalancer IP, returns IP", func(t *testing.T) {
 		svc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -200,6 +230,60 @@ func TestEnsureService(t *testing.T) {
 		}
 		if address != "envoy.example.com" {
 			t.Errorf("ensureService() = %s, want %s", address, "envoy.example.com")
+		}
+	})
+}
+
+func TestEnsureServiceExists(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gw",
+			Namespace: "test-ns",
+		},
+	}
+	nodeID := proxyName(gw.Namespace, gw.Name)
+
+	t.Run("service not found, creates and returns service", func(t *testing.T) {
+		client := fake.NewClientset()
+		rm := NewResourceManager(client, gw, "envoy-image", "cluster.local")
+
+		svc, err := rm.ensureServiceExists(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if svc == nil {
+			t.Fatal("expected non-nil service")
+		}
+		if svc.Name != nodeID {
+			t.Errorf("expected service name %s, got %s", nodeID, svc.Name)
+		}
+
+		// Verify service was created
+		_, err = client.CoreV1().Services("test-ns").Get(context.Background(), nodeID, metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("failed to get created service: %v", err)
+		}
+	})
+
+	t.Run("service exists, returns existing service", func(t *testing.T) {
+		existingSvc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeID,
+				Namespace: "test-ns",
+			},
+		}
+		client := fake.NewClientset(existingSvc)
+		rm := NewResourceManager(client, gw, "envoy-image", "cluster.local")
+
+		svc, err := rm.ensureServiceExists(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if svc == nil {
+			t.Fatal("expected non-nil service")
+		}
+		if svc.Name != nodeID {
+			t.Errorf("expected service name %s, got %s", nodeID, svc.Name)
 		}
 	})
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind cleanup

**What this PR does / why we need it**:
The LoadBalancer allocation may take 3-5 minutes in e2e/conformance tests.  The Deployment can take about 1-2 minutes to be ready, so we want to start LoadBalancer allocation as early as possible.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
