### PR TITLE
fix: quickstart fails due to deploy_controller function collision

### DIFF
--- a/site-src/guides/quickstart/run-quickstart.sh
+++ b/site-src/guides/quickstart/run-quickstart.sh
@@ -182,8 +182,8 @@ create_kind_cluster() {
 
 install_metallb_step() {
   info "Step 1.5/9: Installing MetalLB..."
-  source dev/ci/lib.sh
-  install_metallb
+  # Subshell prevents lib.sh functions from overwriting this script's identically named functions.
+  (source dev/ci/lib.sh && install_metallb)
 }
 
 


### PR DESCRIPTION
## Summary
- Sourcing `dev/ci/lib.sh` in `install_metallb_step` leaked its `deploy_controller(tag, namespace)` into global scope, overwriting the quickstart's own no-arg `deploy_controller`
- Run the source in a subshell so lib.sh functions do not escape
- Affects all quickstart variants (`make quickstart`, `make quickstart-ollama`, `make quickstart-gemini`)

Fixes #272

## Test plan
- [x] Ran `make quickstart-ollama` end to end successfully