### PR TITLE
implement optional rules and configurable base MCP method matching

### DIFF
--- a/api/v1alpha1/accesspolicy_types.go
+++ b/api/v1alpha1/accesspolicy_types.go
@@ -87,10 +87,10 @@ const (
 type MCPBaseProtocolMethodsOption string
 
 const (
-	// SKIP_BASE_PROTOCOL_METHODS skips matching on the base MCP protocol methods.
-	SKIP_BASE_PROTOCOL_METHODS MCPBaseProtocolMethodsOption = "SKIP_BASE_PROTOCOL_METHODS"
-	// MATCH_BASE_PROTOCOL_METHODS matches on the base MCP protocol methods.
-	MATCH_BASE_PROTOCOL_METHODS MCPBaseProtocolMethodsOption = "MATCH_BASE_PROTOCOL_METHODS"
+	// MCPBaseProtocolMethodsOptionSkip skips matching on the base MCP protocol methods.
+	MCPBaseProtocolMethodsOptionSkip MCPBaseProtocolMethodsOption = "SKIP_BASE_PROTOCOL_METHODS"
+	// MCPBaseProtocolMethodsOptionMatch matches on the base MCP protocol methods.
+	MCPBaseProtocolMethodsOptionMatch MCPBaseProtocolMethodsOption = "MATCH_BASE_PROTOCOL_METHODS"
 )
 
 // AccessRule specifies an authorization rule for a specified target.
@@ -218,12 +218,15 @@ type MCPAttributes struct {
 	Methods []MCPMethod `json:"methods,omitempty"`
 
 	// MCPBaseProtocolMethodsOption specifies whether to match on base MCP protocol methods.
-	// Optional. If specified, matches on the MCP protocol’s non-access specific methods namely:
+	// Optional. If specified, matches on the MCP protocol’s non-access specific methods and transport prerequisites namely:
 	// * initialize
+	// * tools/list
 	// * completion/
 	// * logging/
 	// * notifications/
 	// * ping
+	// * HTTP GET requests (needed for SSE stream connection)
+	// * HTTP DELETE requests with mcp-session-id header (needed for session close)
 	// Defaults to SKIP_BASE_PROTOCOL_METHODS if not specified
 	// +optional
 	// +kubebuilder:default=SKIP_BASE_PROTOCOL_METHODS

--- a/api/v1alpha1/accesspolicy_types.go
+++ b/api/v1alpha1/accesspolicy_types.go
@@ -60,13 +60,15 @@ type AccessPolicySpec struct {
 	ExternalAuth *gwapiv1.HTTPExternalAuthFilter `json:"externalAuth,omitempty"`
 
 	// Rules defines a list of rules to be applied to the target.
-	// An AccessPolicy must have at least one rule.
-	// +required
-	// +kubebuilder:validation:MinItems=1
+	// The interpretation of these rules depends on the Action:
+	// - For ActionTypeAllow: A request is allowed if it matches any of the rules.
+	// - For ActionTypeExternalAuth: A request is delegated to the external authorizer if it matches any of the rules.
+	// If omitted, the policy applies to all traffic (equivalent to matching any request).
+	// +optional
 	// +kubebuilder:validation:MaxItems=10
 	// +listType=atomic
 	// +kubebuilder:validation:XValidation:rule="self.all(r, self.filter(x, x.name == r.name).size() == 1)",message="AccessRule names must be unique"
-	Rules []AccessRule `json:"rules"`
+	Rules []AccessRule `json:"rules,omitempty"`
 }
 
 // AccessPolicyActionType identifies a type of action for access policy.
@@ -79,6 +81,16 @@ const (
 
 	// ActionTypeExternalAuth is used to identify that the request should be delegated to an external auth service if rules match.
 	ActionTypeExternalAuth AccessPolicyActionType = "ExternalAuth"
+)
+
+// +kubebuilder:validation:Enum=SKIP_BASE_PROTOCOL_METHODS;MATCH_BASE_PROTOCOL_METHODS
+type MCPBaseProtocolMethodsOption string
+
+const (
+	// SKIP_BASE_PROTOCOL_METHODS skips matching on the base MCP protocol methods.
+	SKIP_BASE_PROTOCOL_METHODS MCPBaseProtocolMethodsOption = "SKIP_BASE_PROTOCOL_METHODS"
+	// MATCH_BASE_PROTOCOL_METHODS matches on the base MCP protocol methods.
+	MATCH_BASE_PROTOCOL_METHODS MCPBaseProtocolMethodsOption = "MATCH_BASE_PROTOCOL_METHODS"
 )
 
 // AccessRule specifies an authorization rule for a specified target.
@@ -204,6 +216,18 @@ type MCPAttributes struct {
 	// +listType=map
 	// +listMapKey=name
 	Methods []MCPMethod `json:"methods,omitempty"`
+
+	// MCPBaseProtocolMethodsOption specifies whether to match on base MCP protocol methods.
+	// Optional. If specified, matches on the MCP protocol’s non-access specific methods namely:
+	// * initialize
+	// * completion/
+	// * logging/
+	// * notifications/
+	// * ping
+	// Defaults to SKIP_BASE_PROTOCOL_METHODS if not specified
+	// +optional
+	// +kubebuilder:default=SKIP_BASE_PROTOCOL_METHODS
+	MCPBaseProtocolMethodsOption MCPBaseProtocolMethodsOption `json:"mcpBaseProtocolMethodsOption,omitempty"`
 }
 
 // MCPMethod defines a specific MCP method and its associated parameters.

--- a/conformance/tests/accesspolicy-accepted.yaml
+++ b/conformance/tests/accesspolicy-accepted.yaml
@@ -19,6 +19,7 @@ spec:
       authorization:
         type: Inline
         mcp:
+          mcpBaseProtocolMethodsOption: MATCH_BASE_PROTOCOL_METHODS
           methods:
             - name: tools/call
               params:

--- a/k8s/crds/agentic.networking.x-k8s.io_xaccesspolicies.yaml
+++ b/k8s/crds/agentic.networking.x-k8s.io_xaccesspolicies.yaml
@@ -1067,7 +1067,10 @@ spec:
               rules:
                 description: |-
                   Rules defines a list of rules to be applied to the target.
-                  An AccessPolicy must have at least one rule.
+                  The interpretation of these rules depends on the Action:
+                  - For ActionTypeAllow: A request is allowed if it matches any of the rules.
+                  - For ActionTypeExternalAuth: A request is delegated to the external authorizer if it matches any of the rules.
+                  If omitted, the policy applies to all traffic (equivalent to matching any request).
                 items:
                   description: AccessRule specifies an authorization rule for a specified
                     target.
@@ -1092,6 +1095,21 @@ spec:
                             If omitted, the policy does not check MCP-level parameters, allowing all MCP traffic that
                             successfully passes through the matched HTTP routing envelope.
                           properties:
+                            mcpBaseProtocolMethodsOption:
+                              default: SKIP_BASE_PROTOCOL_METHODS
+                              description: |-
+                                MCPBaseProtocolMethodsOption specifies whether to match on base MCP protocol methods.
+                                Optional. If specified, matches on the MCP protocol’s non-access specific methods namely:
+                                * initialize
+                                * completion/
+                                * logging/
+                                * notifications/
+                                * ping
+                                Defaults to SKIP_BASE_PROTOCOL_METHODS if not specified
+                              enum:
+                              - SKIP_BASE_PROTOCOL_METHODS
+                              - MATCH_BASE_PROTOCOL_METHODS
+                              type: string
                             methods:
                               description: |-
                                 Methods is a list of specific MCP functional methods to match.
@@ -1236,7 +1254,6 @@ spec:
                   - source
                   type: object
                 maxItems: 10
-                minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
@@ -1311,7 +1328,6 @@ spec:
                   rule: self.all(ref, ref.kind == self[0].kind)
             required:
             - action
-            - rules
             - targetRefs
             type: object
             x-kubernetes-validations:

--- a/k8s/crds/agentic.networking.x-k8s.io_xaccesspolicies.yaml
+++ b/k8s/crds/agentic.networking.x-k8s.io_xaccesspolicies.yaml
@@ -1099,12 +1099,15 @@ spec:
                               default: SKIP_BASE_PROTOCOL_METHODS
                               description: |-
                                 MCPBaseProtocolMethodsOption specifies whether to match on base MCP protocol methods.
-                                Optional. If specified, matches on the MCP protocol’s non-access specific methods namely:
+                                Optional. If specified, matches on the MCP protocol’s non-access specific methods and transport prerequisites namely:
                                 * initialize
+                                * tools/list
                                 * completion/
                                 * logging/
                                 * notifications/
                                 * ping
+                                * HTTP GET requests (needed for SSE stream connection)
+                                * HTTP DELETE requests with mcp-session-id header (needed for session close)
                                 Defaults to SKIP_BASE_PROTOCOL_METHODS if not specified
                               enum:
                               - SKIP_BASE_PROTOCOL_METHODS

--- a/pkg/translator/accesspolicy.go
+++ b/pkg/translator/accesspolicy.go
@@ -206,8 +206,8 @@ func (t *Translator) mergeAllowPoliciesToRBAC(policies []*agenticv1alpha1.XAcces
 			if rule.Authorization != nil {
 				switch rule.Authorization.Type {
 				case agenticv1alpha1.AuthorizationRuleTypeInline:
-					if permission := t.translateMCPToRBACPermission(&rule.Authorization.MCP); permission != nil {
-						rbacPolicy.Permissions = []*rbacconfigv3.Permission{permission}
+					if permissions := t.translateMCPToRBACPermissions(&rule.Authorization.MCP); len(permissions) > 0 {
+						rbacPolicy.Permissions = permissions
 					}
 				case agenticv1alpha1.AuthorizationRuleTypeCEL:
 					if rule.Authorization.CEL != nil {
@@ -341,8 +341,8 @@ func (t *Translator) translateAccessPolicyToRBAC(accessPolicy *agenticv1alpha1.X
 			switch rule.Authorization.Type {
 			case agenticv1alpha1.AuthorizationRuleTypeInline:
 				// TODO: Only MCP is currently supported. Add support for more generic inline auth in the future
-				if permission := t.translateMCPToRBACPermission(&rule.Authorization.MCP); permission != nil {
-					rbacPolicy.Permissions = []*rbacconfigv3.Permission{permission}
+				if permissions := t.translateMCPToRBACPermissions(&rule.Authorization.MCP); len(permissions) > 0 {
+					rbacPolicy.Permissions = permissions
 				}
 			case agenticv1alpha1.AuthorizationRuleTypeCEL:
 				if rule.Authorization.CEL != nil {
@@ -393,64 +393,122 @@ func (t *Translator) translateAccessPolicyToRBAC(accessPolicy *agenticv1alpha1.X
 	return rbacConfig
 }
 
-func (t *Translator) translateMCPToRBACPermission(mcp *agenticv1alpha1.MCPAttributes) *rbacconfigv3.Permission {
+func (t *Translator) translateMCPToRBACPermissions(mcp *agenticv1alpha1.MCPAttributes) []*rbacconfigv3.Permission {
 	if mcp == nil {
-		return buildAnyPermission()
+		return []*rbacconfigv3.Permission{buildAnyPermission()}
 	}
 
-	var methodPermissions []*rbacconfigv3.Permission
+	var permissions []*rbacconfigv3.Permission
 	for _, method := range mcp.Methods {
-		methodPermissions = append(methodPermissions, translateMCPMethodToRBACPermission(method))
+		permissions = append(permissions, translateMCPMethodToRBACPermission(method))
 	}
 
-	if mcp.MCPBaseProtocolMethodsOption == agenticv1alpha1.MATCH_BASE_PROTOCOL_METHODS {
-		methodPermissions = append(methodPermissions, buildBaseProtocolMethodsPermission())
+	if mcp.MCPBaseProtocolMethodsOption == agenticv1alpha1.MCPBaseProtocolMethodsOptionMatch {
+		permissions = append(permissions, buildBaseProtocolMethodsRules()...)
 	}
 
-	if len(methodPermissions) == 0 {
+	if len(permissions) == 0 {
 		// If both methods and base protocol methods are empty/skipped, we fall back to allowing anything
 		// to maintain backward compatibility for policies that don't specify methods.
 		// TODO: Re-evaluate this default if strict explicit allow is required when `mcp` is present but empty.
-		return buildAnyPermission()
+		return []*rbacconfigv3.Permission{buildAnyPermission()}
 	}
 
-	if len(methodPermissions) == 1 {
-		return methodPermissions[0]
-	}
-
-	return &rbacconfigv3.Permission{
-		Rule: &rbacconfigv3.Permission_OrRules{
-			OrRules: &rbacconfigv3.Permission_Set{
-				Rules: methodPermissions,
-			},
-		},
-	}
+	return permissions
 }
 
-func buildBaseProtocolMethodsPermission() *rbacconfigv3.Permission {
-	return &rbacconfigv3.Permission{
-		Rule: &rbacconfigv3.Permission_SourcedMetadata{
-			SourcedMetadata: &rbacconfigv3.SourcedMetadata{
-				MetadataMatcher: &matcherv3.MetadataMatcher{
-					Filter: constants.MCPProxyFilterName,
-					Path:   []*matcherv3.MetadataMatcher_PathSegment{{Segment: &matcherv3.MetadataMatcher_PathSegment_Key{Key: "method"}}},
-					Value: &matcherv3.ValueMatcher{
-						MatchPattern: &matcherv3.ValueMatcher_OrMatch{
-							OrMatch: &matcherv3.OrMatcher{
-								ValueMatchers: []*matcherv3.ValueMatcher{
-									{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "initialize"}}}},
-									{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "completion/"}}}},
-									{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "logging/"}}}},
-									{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "notifications/"}}}},
-									{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "ping"}}}},
+func buildBaseProtocolMethodsRules() []*rbacconfigv3.Permission {
+	var rules []*rbacconfigv3.Permission
+
+	// 1. MCP Base Methods metadata matchers (one permission per method)
+	methods := []string{"initialize", "tools/list", "ping"}
+	prefixes := []string{"completion/", "logging/", "notifications/"}
+
+	for _, m := range methods {
+		rules = append(rules, &rbacconfigv3.Permission{
+			Rule: &rbacconfigv3.Permission_SourcedMetadata{
+				SourcedMetadata: &rbacconfigv3.SourcedMetadata{
+					MetadataMatcher: &matcherv3.MetadataMatcher{
+						Filter: constants.MCPProxyFilterName,
+						Path:   []*matcherv3.MetadataMatcher_PathSegment{{Segment: &matcherv3.MetadataMatcher_PathSegment_Key{Key: "method"}}},
+						Value: &matcherv3.ValueMatcher{
+							MatchPattern: &matcherv3.ValueMatcher_StringMatch{
+								StringMatch: &matcherv3.StringMatcher{
+									MatchPattern: &matcherv3.StringMatcher_Exact{Exact: m},
 								},
 							},
 						},
 					},
 				},
 			},
-		},
+		})
 	}
+
+	for _, p := range prefixes {
+		rules = append(rules, &rbacconfigv3.Permission{
+			Rule: &rbacconfigv3.Permission_SourcedMetadata{
+				SourcedMetadata: &rbacconfigv3.SourcedMetadata{
+					MetadataMatcher: &matcherv3.MetadataMatcher{
+						Filter: constants.MCPProxyFilterName,
+						Path:   []*matcherv3.MetadataMatcher_PathSegment{{Segment: &matcherv3.MetadataMatcher_PathSegment_Key{Key: "method"}}},
+						Value: &matcherv3.ValueMatcher{
+							MatchPattern: &matcherv3.ValueMatcher_StringMatch{
+								StringMatch: &matcherv3.StringMatcher{
+									MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: p},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+	}
+
+	// 2. HTTP GET permission (for SSE stream connection)
+	rules = append(rules, &rbacconfigv3.Permission{
+		Rule: &rbacconfigv3.Permission_Header{
+			Header: &routev3.HeaderMatcher{
+				Name: ":method",
+				HeaderMatchSpecifier: &routev3.HeaderMatcher_StringMatch{
+					StringMatch: &matcherv3.StringMatcher{
+						MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "GET"},
+					},
+				},
+			},
+		},
+	})
+
+	// 3. HTTP DELETE permission with session-id header presence (for session close)
+	rules = append(rules, &rbacconfigv3.Permission{
+		Rule: &rbacconfigv3.Permission_AndRules{
+			AndRules: &rbacconfigv3.Permission_Set{
+				Rules: []*rbacconfigv3.Permission{
+					{
+						Rule: &rbacconfigv3.Permission_Header{
+							Header: &routev3.HeaderMatcher{
+								Name: ":method",
+								HeaderMatchSpecifier: &routev3.HeaderMatcher_StringMatch{
+									StringMatch: &matcherv3.StringMatcher{
+										MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "DELETE"},
+									},
+								},
+							},
+						},
+					},
+					{
+						Rule: &rbacconfigv3.Permission_Header{
+							Header: &routev3.HeaderMatcher{
+								Name:                 constants.MCPSessionIDHeader,
+								HeaderMatchSpecifier: &routev3.HeaderMatcher_PresentMatch{PresentMatch: true},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	return rules
 }
 
 func translateMCPMethodToRBACPermission(method agenticv1alpha1.MCPMethod) *rbacconfigv3.Permission {

--- a/pkg/translator/accesspolicy.go
+++ b/pkg/translator/accesspolicy.go
@@ -172,15 +172,7 @@ func (t *Translator) buildBackendLevelRBACOverrides(backend *agenticv0alpha0.XBa
 // buildRBACConfigWithCommonPolicies generates an RBAC config for an AccessPolicy.
 // It includes the common policies needed for MCP session management to avoid blocking basic operations.
 func (t *Translator) buildRBACConfigWithCommonPolicies(accessPolicy *agenticv1alpha1.XAccessPolicy) *rbacv3.RBAC {
-	rbacConfig := t.translateAccessPolicyToRBAC(accessPolicy)
-
-	// Add common policies to avoid blocking basic MCP operations.
-	// These are added to the 'Rules' section which is where allowed traffic is defined.
-	addPolicyToRBACRules(rbacConfig, constants.AllowMCPSessionClosePolicyName, buildAllowMCPSessionClosePolicy())
-	addPolicyToRBACRules(rbacConfig, constants.AllowAnyoneToInitializeAndListToolsPolicyName, buildAllowAnyoneToInitializeAndListToolsPolicy())
-	addPolicyToRBACRules(rbacConfig, constants.AllowHTTPGetPolicyName, buildAllowHTTPGetPolicy())
-
-	return rbacConfig
+	return t.translateAccessPolicyToRBAC(accessPolicy)
 }
 
 func (t *Translator) mergeAllowPoliciesToRBAC(policies []*agenticv1alpha1.XAccessPolicy) *rbacv3.RBAC {
@@ -238,10 +230,6 @@ func (t *Translator) mergeAllowPoliciesToRBAC(policies []*agenticv1alpha1.XAcces
 		}
 	}
 
-	addPolicyToRBACRules(rbacConfig, constants.AllowMCPSessionClosePolicyName, buildAllowMCPSessionClosePolicy())
-	addPolicyToRBACRules(rbacConfig, constants.AllowAnyoneToInitializeAndListToolsPolicyName, buildAllowAnyoneToInitializeAndListToolsPolicy())
-	addPolicyToRBACRules(rbacConfig, constants.AllowHTTPGetPolicyName, buildAllowHTTPGetPolicy())
-
 	return rbacConfig
 }
 
@@ -293,6 +281,34 @@ func convertSAtoSPIFFEID(trustDomain, namespace, saName string) string {
 
 func (t *Translator) translateAccessPolicyToRBAC(accessPolicy *agenticv1alpha1.XAccessPolicy) *rbacv3.RBAC {
 	rbacConfig := &rbacv3.RBAC{}
+
+	if len(accessPolicy.Spec.Rules) == 0 {
+		if accessPolicy.Spec.Action == agenticv1alpha1.ActionTypeExternalAuth && accessPolicy.Spec.ExternalAuth != nil {
+			hash, err := externalAuthUniqueID(accessPolicy.Spec.ExternalAuth)
+			if err != nil {
+				klog.Errorf("Failed to generate unique ID for externalAuth config in AccessPolicy %s/%s: %v", accessPolicy.Namespace, accessPolicy.Name, err)
+				return rbacConfig
+			}
+			rbacConfig.ShadowRulesStatPrefix = fmt.Sprintf("%s_%s_", constants.ExternalAuthzShadowRulePrefix, hash)
+
+			rbacPolicy := &rbacconfigv3.Policy{
+				Principals:  []*rbacconfigv3.Principal{buildAnyPrincipal()},
+				Permissions: []*rbacconfigv3.Permission{buildAnyPermission()},
+			}
+
+			policyName := accessPolicy.Name // Use policy name as rule name
+
+			addPolicyToRBACShadowRules(rbacConfig, policyName, rbacPolicy)
+
+			// Ensure the regular Rules section transparently allows all traffic through so that secondary policies evaluate non-matching streams.
+			allowAllPolicy := &rbacconfigv3.Policy{
+				Principals:  []*rbacconfigv3.Principal{buildAnyPrincipal()},
+				Permissions: []*rbacconfigv3.Permission{buildAnyPermission()},
+			}
+			addPolicyToRBACRules(rbacConfig, policyName, allowAllPolicy)
+		}
+		return rbacConfig
+	}
 
 	// Each AccessRule in the XAccessPolicy is translated into a named policy within the Envoy RBAC filter.
 	for _, rule := range accessPolicy.Spec.Rules {
@@ -378,13 +394,24 @@ func (t *Translator) translateAccessPolicyToRBAC(accessPolicy *agenticv1alpha1.X
 }
 
 func (t *Translator) translateMCPToRBACPermission(mcp *agenticv1alpha1.MCPAttributes) *rbacconfigv3.Permission {
-	if mcp == nil || len(mcp.Methods) == 0 {
+	if mcp == nil {
 		return buildAnyPermission()
 	}
 
 	var methodPermissions []*rbacconfigv3.Permission
 	for _, method := range mcp.Methods {
 		methodPermissions = append(methodPermissions, translateMCPMethodToRBACPermission(method))
+	}
+
+	if mcp.MCPBaseProtocolMethodsOption == agenticv1alpha1.MATCH_BASE_PROTOCOL_METHODS {
+		methodPermissions = append(methodPermissions, buildBaseProtocolMethodsPermission())
+	}
+
+	if len(methodPermissions) == 0 {
+		// If both methods and base protocol methods are empty/skipped, we fall back to allowing anything
+		// to maintain backward compatibility for policies that don't specify methods.
+		// TODO: Re-evaluate this default if strict explicit allow is required when `mcp` is present but empty.
+		return buildAnyPermission()
 	}
 
 	if len(methodPermissions) == 1 {
@@ -395,6 +422,32 @@ func (t *Translator) translateMCPToRBACPermission(mcp *agenticv1alpha1.MCPAttrib
 		Rule: &rbacconfigv3.Permission_OrRules{
 			OrRules: &rbacconfigv3.Permission_Set{
 				Rules: methodPermissions,
+			},
+		},
+	}
+}
+
+func buildBaseProtocolMethodsPermission() *rbacconfigv3.Permission {
+	return &rbacconfigv3.Permission{
+		Rule: &rbacconfigv3.Permission_SourcedMetadata{
+			SourcedMetadata: &rbacconfigv3.SourcedMetadata{
+				MetadataMatcher: &matcherv3.MetadataMatcher{
+					Filter: constants.MCPProxyFilterName,
+					Path:   []*matcherv3.MetadataMatcher_PathSegment{{Segment: &matcherv3.MetadataMatcher_PathSegment_Key{Key: "method"}}},
+					Value: &matcherv3.ValueMatcher{
+						MatchPattern: &matcherv3.ValueMatcher_OrMatch{
+							OrMatch: &matcherv3.OrMatcher{
+								ValueMatchers: []*matcherv3.ValueMatcher{
+									{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "initialize"}}}},
+									{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "completion/"}}}},
+									{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "logging/"}}}},
+									{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "notifications/"}}}},
+									{MatchPattern: &matcherv3.ValueMatcher_StringMatch{StringMatch: &matcherv3.StringMatcher{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "ping"}}}},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/pkg/translator/accesspolicy_test.go
+++ b/pkg/translator/accesspolicy_test.go
@@ -310,7 +310,17 @@ func TestBuildRBACConfigWithCommonPolicies(t *testing.T) {
 	tr := &Translator{}
 	policy := &agenticv1alpha1.XAccessPolicy{
 		Spec: agenticv1alpha1.AccessPolicySpec{
-			Rules: []agenticv1alpha1.AccessRule{{Name: "custom-rule"}},
+			Rules: []agenticv1alpha1.AccessRule{
+				{
+					Name: "custom-rule",
+					Authorization: &agenticv1alpha1.AuthorizationRule{
+						Type: agenticv1alpha1.AuthorizationRuleTypeInline,
+						MCP: agenticv1alpha1.MCPAttributes{
+							MCPBaseProtocolMethodsOption: agenticv1alpha1.MATCH_BASE_PROTOCOL_METHODS,
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -318,15 +328,59 @@ func TestBuildRBACConfigWithCommonPolicies(t *testing.T) {
 
 	expectedPolicies := []string{
 		"custom-rule",
-		constants.AllowMCPSessionClosePolicyName,
-		constants.AllowAnyoneToInitializeAndListToolsPolicyName,
-		constants.AllowHTTPGetPolicyName,
 	}
 
-	for _, p := range expectedPolicies {
-		if _, ok := rbac.GetRules().GetPolicies()[p]; !ok {
-			t.Errorf("Expected policy %s not found", p)
-		}
+	if len(rbac.GetRules().GetPolicies()) != len(expectedPolicies) {
+		t.Errorf("Expected %d policies, got %d", len(expectedPolicies), len(rbac.GetRules().GetPolicies()))
+	}
+
+	rbacPolicy := rbac.GetRules().GetPolicies()["custom-rule"]
+	if rbacPolicy == nil {
+		t.Fatal("Expected policy 'custom-rule' not found")
+	}
+
+	permissions := rbacPolicy.GetPermissions()
+	if len(permissions) != 1 {
+		t.Errorf("Expected 1 permission, got %d", len(permissions))
+	}
+}
+
+func TestBuildRBACConfigWithoutCommonPolicies(t *testing.T) {
+	tr := &Translator{}
+	policy := &agenticv1alpha1.XAccessPolicy{
+		Spec: agenticv1alpha1.AccessPolicySpec{
+			Rules: []agenticv1alpha1.AccessRule{
+				{
+					Name: "custom-rule",
+					Authorization: &agenticv1alpha1.AuthorizationRule{
+						Type: agenticv1alpha1.AuthorizationRuleTypeInline,
+						MCP:  agenticv1alpha1.MCPAttributes{
+							// Defaults to SKIP_BASE_PROTOCOL_METHODS
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rbac := tr.buildRBACConfigWithCommonPolicies(policy)
+
+	expectedPolicies := []string{
+		"custom-rule",
+	}
+
+	if len(rbac.GetRules().GetPolicies()) != len(expectedPolicies) {
+		t.Errorf("Expected %d policies, got %d", len(expectedPolicies), len(rbac.GetRules().GetPolicies()))
+	}
+
+	rbacPolicy := rbac.GetRules().GetPolicies()["custom-rule"]
+	if rbacPolicy == nil {
+		t.Fatal("Expected policy 'custom-rule' not found")
+	}
+
+	permissions := rbacPolicy.GetPermissions()
+	if len(permissions) != 1 || !permissions[0].GetAny() {
+		t.Errorf("Expected 'Any' permission for empty methods and skipped base methods")
 	}
 }
 
@@ -711,6 +765,34 @@ func TestTranslateAccessPolicyToRBAC(t *testing.T) {
 			expectedShadowRules: map[string]expectedRule{
 				"rule-ext-auth": {
 					principal:           "spiffe://example.com/ns/default/sa/caller",
+					permissions:         []string{},
+					expectAnyPermission: true,
+				},
+			},
+			expectShadowStatPrefix: true,
+		},
+		{
+			name: "external authz with empty rules",
+			accessPolicy: &agenticv1alpha1.XAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "policy-ext-auth-empty-rules"},
+				Spec: agenticv1alpha1.AccessPolicySpec{
+					Action: agenticv1alpha1.ActionTypeExternalAuth,
+					ExternalAuth: &gatewayv1.HTTPExternalAuthFilter{
+						ExternalAuthProtocol: gatewayv1.HTTPRouteExternalAuthGRPCProtocol,
+						BackendRef: gatewayv1.BackendObjectReference{
+							Name: "ext-auth-svc",
+						},
+					},
+				},
+			},
+			expectedRules: map[string]expectedRule{
+				"policy-ext-auth-empty-rules": {
+					permissions:         []string{},
+					expectAnyPermission: true,
+				},
+			},
+			expectedShadowRules: map[string]expectedRule{
+				"policy-ext-auth-empty-rules": {
 					permissions:         []string{},
 					expectAnyPermission: true,
 				},

--- a/pkg/translator/accesspolicy_test.go
+++ b/pkg/translator/accesspolicy_test.go
@@ -316,7 +316,7 @@ func TestBuildRBACConfigWithCommonPolicies(t *testing.T) {
 					Authorization: &agenticv1alpha1.AuthorizationRule{
 						Type: agenticv1alpha1.AuthorizationRuleTypeInline,
 						MCP: agenticv1alpha1.MCPAttributes{
-							MCPBaseProtocolMethodsOption: agenticv1alpha1.MATCH_BASE_PROTOCOL_METHODS,
+							MCPBaseProtocolMethodsOption: agenticv1alpha1.MCPBaseProtocolMethodsOptionMatch,
 						},
 					},
 				},
@@ -326,22 +326,82 @@ func TestBuildRBACConfigWithCommonPolicies(t *testing.T) {
 
 	rbac := tr.buildRBACConfigWithCommonPolicies(policy)
 
-	expectedPolicies := []string{
-		"custom-rule",
-	}
-
-	if len(rbac.GetRules().GetPolicies()) != len(expectedPolicies) {
-		t.Errorf("Expected %d policies, got %d", len(expectedPolicies), len(rbac.GetRules().GetPolicies()))
-	}
-
 	rbacPolicy := rbac.GetRules().GetPolicies()["custom-rule"]
 	if rbacPolicy == nil {
 		t.Fatal("Expected policy 'custom-rule' not found")
 	}
 
 	permissions := rbacPolicy.GetPermissions()
-	if len(permissions) != 1 {
-		t.Errorf("Expected 1 permission, got %d", len(permissions))
+	if len(permissions) != 8 {
+		t.Fatalf("Expected 8 permissions, got %d", len(permissions))
+	}
+
+	// Verify MCP base methods (exact matches)
+	expectedExact := map[string]bool{
+		"initialize": false,
+		"tools/list": false,
+		"ping":       false,
+	}
+	for i := 0; i < 3; i++ {
+		mcpRule := permissions[i].GetSourcedMetadata()
+		if mcpRule == nil || mcpRule.GetMetadataMatcher() == nil {
+			t.Fatalf("Expected SourcedMetadata for rule %d, got %+v", i, permissions[i])
+		}
+		val := mcpRule.GetMetadataMatcher().GetValue().GetStringMatch().GetExact()
+		if _, ok := expectedExact[val]; ok {
+			expectedExact[val] = true
+		} else {
+			t.Errorf("Unexpected exact match value: %q", val)
+		}
+	}
+	for val, found := range expectedExact {
+		if !found {
+			t.Errorf("Expected exact match for %q not found", val)
+		}
+	}
+
+	// Verify MCP base methods (prefix matches)
+	expectedPrefix := map[string]bool{
+		"completion/":    false,
+		"logging/":       false,
+		"notifications/": false,
+	}
+	for i := 3; i < 6; i++ {
+		mcpRule := permissions[i].GetSourcedMetadata()
+		if mcpRule == nil || mcpRule.GetMetadataMatcher() == nil {
+			t.Fatalf("Expected SourcedMetadata for rule %d, got %+v", i, permissions[i])
+		}
+		val := mcpRule.GetMetadataMatcher().GetValue().GetStringMatch().GetPrefix()
+		if _, ok := expectedPrefix[val]; ok {
+			expectedPrefix[val] = true
+		} else {
+			t.Errorf("Unexpected prefix match value: %q", val)
+		}
+	}
+	for val, found := range expectedPrefix {
+		if !found {
+			t.Errorf("Expected prefix match for %q not found", val)
+		}
+	}
+
+	// Rule 6: HTTP GET
+	getRule := permissions[6].GetHeader()
+	if getRule == nil || getRule.GetName() != ":method" || getRule.GetStringMatch().GetExact() != "GET" {
+		t.Errorf("Expected HTTP GET header matcher, got %+v", permissions[6])
+	}
+
+	// Rule 7: HTTP DELETE with session-id header
+	deleteRule := permissions[7].GetAndRules()
+	if deleteRule == nil || len(deleteRule.GetRules()) != 2 {
+		t.Fatalf("Expected AndRules for HTTP DELETE, got %+v", permissions[7])
+	}
+	delMethodRule := deleteRule.GetRules()[0].GetHeader()
+	if delMethodRule == nil || delMethodRule.GetName() != ":method" || delMethodRule.GetStringMatch().GetExact() != "DELETE" {
+		t.Errorf("Expected HTTP DELETE method matcher, got %+v", deleteRule.GetRules()[0])
+	}
+	sessionHeaderRule := deleteRule.GetRules()[1].GetHeader()
+	if sessionHeaderRule == nil || sessionHeaderRule.GetName() != constants.MCPSessionIDHeader || !sessionHeaderRule.GetPresentMatch() {
+		t.Errorf("Expected session-id header presence matcher, got %+v", deleteRule.GetRules()[1])
 	}
 }
 

--- a/site-src/guides/quickstart/policy/e2e.yaml
+++ b/site-src/guides/quickstart/policy/e2e.yaml
@@ -59,6 +59,7 @@ spec:
       authorization:
         type: Inline
         mcp:
+          mcpBaseProtocolMethodsOption: MATCH_BASE_PROTOCOL_METHODS
           methods:
             - name: tools/call
               params:
@@ -86,6 +87,7 @@ spec:
       authorization:
         type: Inline
         mcp:
+          mcpBaseProtocolMethodsOption: MATCH_BASE_PROTOCOL_METHODS
           methods:
             - name: tools/call
               params:

--- a/tests/cel/accesspolicy_v1alpha1_test.go
+++ b/tests/cel/accesspolicy_v1alpha1_test.go
@@ -250,6 +250,12 @@ func TestValidateXAccessPolicyV1Alpha1(t *testing.T) {
 			},
 			wantErrors: []string{"cel must not be specified when type is set to 'Inline'"},
 		},
+		{
+			desc: "valid policy with empty rules",
+			mutate: func(p *v1alpha1.XAccessPolicy) {
+				p.Spec.Rules = nil
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/tests/e2e/testdata/backend-policy-extauth.yaml
+++ b/tests/e2e/testdata/backend-policy-extauth.yaml
@@ -19,6 +19,7 @@ spec:
       authorization:
         type: Inline
         mcp:
+          mcpBaseProtocolMethodsOption: MATCH_BASE_PROTOCOL_METHODS
           methods:
             - name: tools/call
               params:
@@ -33,6 +34,7 @@ spec:
       authorization:
         type: Inline
         mcp:
+          mcpBaseProtocolMethodsOption: MATCH_BASE_PROTOCOL_METHODS
           methods:
             - name: tools/call
               params:

--- a/tests/e2e/testdata/backend-policy.yaml
+++ b/tests/e2e/testdata/backend-policy.yaml
@@ -19,6 +19,7 @@ spec:
       authorization:
         type: Inline
         mcp:
+          mcpBaseProtocolMethodsOption: MATCH_BASE_PROTOCOL_METHODS
           methods:
             - name: tools/call
               params:

--- a/tests/e2e/testdata/cel-all-failures.yaml
+++ b/tests/e2e/testdata/cel-all-failures.yaml
@@ -19,3 +19,18 @@ spec:
       type: CEL
       cel:
         expression: "request.mcp.tool_name == 'non-existent'"
+  # Note: A second rule is required here to allow the base MCP protocol methods (such as connection initialization,
+  # listing tools, and keep-alive pings). CEL rules currently only evaluate tool calls (`tools/call`), and thus
+  # cannot be used to establish the connection itself. Using a separate inline rule is more convenient than
+  # trying to manually specify connection methods within CEL rules.
+  # TODO(github.com/kubernetes-sigs/kube-agentic-networking/issues/123): Explore allowing base protocol methods
+  # automatically or via CEL configuration to remove the need for this separate rule.
+  - name: allow-base-mcp
+    source:
+      type: ServiceAccount
+      serviceAccount:
+        name: e2e-tester-sa
+    authorization:
+      type: Inline
+      mcp:
+        mcpBaseProtocolMethodsOption: MATCH_BASE_PROTOCOL_METHODS

--- a/tests/e2e/testdata/cel-macros.yaml
+++ b/tests/e2e/testdata/cel-macros.yaml
@@ -22,3 +22,17 @@ spec:
           request.path.startsWith('/mc') &&
           request.headers['mcp-protocol-version'].contains('2025') &&
           request.mcp.tool_name.matches('^get-[a-z]+$')
+  # Note: A second rule is added here to allow the base MCP protocol methods (such as "initializate",
+  # tools.list, etc). Using a separate inline rule is more convenient than
+  # trying to manually specify connection methods within CEL rules.
+  # TODO(https://github.com/kubernetes-sigs/kube-agentic-networking/issues/288): Explore allowing base protocol methods
+  # automatically or via CEL configuration to remove the need for this separate rule.
+  - name: allow-base-mcp
+    source:
+      type: ServiceAccount
+      serviceAccount:
+        name: e2e-tester-sa
+    authorization:
+      type: Inline
+      mcp:
+        mcpBaseProtocolMethodsOption: MATCH_BASE_PROTOCOL_METHODS

--- a/tests/e2e/testdata/cel-multi-rule.yaml
+++ b/tests/e2e/testdata/cel-multi-rule.yaml
@@ -28,3 +28,17 @@ spec:
       type: CEL
       cel:
         expression: "request.mcp.tool_name == 'non-existent'"
+  # Note: A second rule is added here to allow the base MCP protocol methods (such as "initializate",
+  # tools.list, etc). Using a separate inline rule is more convenient than
+  # trying to manually specify connection methods within CEL rules.
+  # TODO(https://github.com/kubernetes-sigs/kube-agentic-networking/issues/288): Explore allowing base protocol methods
+  # automatically or via CEL configuration to remove the need for this separate rule.
+  - name: allow-base-mcp
+    source:
+      type: ServiceAccount
+      serviceAccount:
+        name: e2e-tester-sa
+    authorization:
+      type: Inline
+      mcp:
+        mcpBaseProtocolMethodsOption: MATCH_BASE_PROTOCOL_METHODS

--- a/tests/e2e/testdata/cel-policy.yaml
+++ b/tests/e2e/testdata/cel-policy.yaml
@@ -19,3 +19,17 @@ spec:
       type: CEL
       cel:
         expression: "request.mcp.tool_name == 'get-sum'"
+  # Note: A second rule is added here to allow the base MCP protocol methods (such as "initializate",
+  # tools.list, etc). Using a separate inline rule is more convenient than
+  # trying to manually specify connection methods within CEL rules.
+  # TODO(https://github.com/kubernetes-sigs/kube-agentic-networking/issues/288): Explore allowing base protocol methods
+  # automatically or via CEL configuration to remove the need for this separate rule.
+  - name: allow-base-mcp
+    source:
+      type: ServiceAccount
+      serviceAccount:
+        name: e2e-tester-sa
+    authorization:
+      type: Inline
+      mcp:
+        mcpBaseProtocolMethodsOption: MATCH_BASE_PROTOCOL_METHODS

--- a/tests/e2e/testdata/gateway-policy.yaml
+++ b/tests/e2e/testdata/gateway-policy.yaml
@@ -19,6 +19,7 @@ spec:
       authorization:
         type: Inline
         mcp:
+          mcpBaseProtocolMethodsOption: MATCH_BASE_PROTOCOL_METHODS
           methods:
             - name: tools/call
               params:


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR makes the `rules` field in AccessPolicy optional and introduces a new enum field MCPBaseProtocolMethodsOption to control the injection of default allowed rules for basic MCP operations.

TODO: what about HTTP GET (Required for SSE Transport), HTTP DELETE (Required for Session Close), and tools/list? should we allow those as part of the base methods?

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #276, #277

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
rules are now optional and new mcpBaseProtocolMethodsOption is implemented
```

