### PR TITLE
docs: align site and proposals with v1alpha1 API

### DIFF
--- a/docs/proposals/0008-ToolAuthAPI.md
+++ b/docs/proposals/0008-ToolAuthAPI.md
@@ -11,6 +11,20 @@ This proposal defines authorization policies for tool access from AI agents runn
 
 This API is **provisional** and subject to change without prior notice. Vendors and integrators should not implement or rely on it, and it must not be enabled in production environments until a stable version is released.
 
+## Implementation status (v1alpha1)
+
+A prototype implementation exists. **Use the implemented API below**, not the original proposal shapes in later sections.
+
+| Proposal | Implemented |
+|----------|-------------|
+| `Backend` / `AccessPolicy` | `XBackend` / `XAccessPolicy` |
+| `spec.type: MCP` on Backend | `spec.mcp` only (`api/v0alpha0`, version `v0alpha0`) |
+| Flat `tools: []` on rules | `action: Allow` + `authorization.type: Inline` + `mcp.methods` (e.g. `tools/call` with `params`) |
+| `serviceAccounts: ["ns/sa"]` shorthand | `source.type: ServiceAccount` + `serviceAccount: { name, namespace? }` |
+| Rule-level external auth | `spec.action: ExternalAuth` + `spec.externalAuth` |
+
+**Authoritative references:** [`api/v1alpha1/accesspolicy_types.go`](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/api/v1alpha1/accesspolicy_types.go), [site API reference](https://kube-agentic-networking.sigs.k8s.io/reference/spec/), [quickstart example](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/site-src/guides/quickstart/policy/e2e.yaml).
+
 # Non-Goals
 
 The authentication of MCP tool access is not within the scope of this proposal, and will be explored separately in the future.
@@ -303,27 +317,40 @@ The following example shows how we can utilize AccessPolicy, Backend and HTTPRou
 
 ```yaml
 apiVersion: agentic.networking.x-k8s.io/v1alpha1
-kind: AccessPolicy
+kind: XAccessPolicy
 metadata:
   name: access-policy-server1
 spec:
-  # AccessPolicy targets a single Backend.
   targetRefs:
   - group: agentic.networking.x-k8s.io
-    kind: Backend
+    kind: XBackend
     name: mcp-server1
+  action: Allow
   rules:
-  - source:
-      serviceAccounts:
-      - "default/sa1"
-    tools:
-    - "add"
-    - "subtract"
-  - source:
-      serviceAccounts:
-      - "default/sa2"
-    tools:
-    - "subtract"
+  - name: sa1-tools
+    source:
+      type: ServiceAccount
+      serviceAccount:
+        name: sa1
+        namespace: default
+    authorization:
+      type: Inline
+      mcp:
+        methods:
+        - name: tools/call
+          params: ["add", "subtract"]
+  - name: sa2-tools
+    source:
+      type: ServiceAccount
+      serviceAccount:
+        name: sa2
+        namespace: default
+    authorization:
+      type: Inline
+      mcp:
+        methods:
+        - name: tools/call
+          params: ["subtract"]
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -344,37 +371,43 @@ spec:
           type: ReplacePrefixMatch
           replacePrefixMatch: /mcp
     backendRefs:
-    - name: mcp-server1 # server1 running in the Kubernetes cluster
+    - name: mcp-server1
       group: agentic.networking.x-k8s.io
-      kind: Backend
+      kind: XBackend
 ---
-# Define a Backend resource for server1, which runs in the K8s cluster.
-apiVersion: agentic.networking.x-k8s.io/v1alpha1
-kind: Backend
+apiVersion: agentic.networking.x-k8s.io/v0alpha0
+kind: XBackend
 metadata:
   name: mcp-server1
 spec:
-  type: MCP
   mcp:
     serviceName: server1-svc
     port: 9000
     path: /mcp
 ---
 apiVersion: agentic.networking.x-k8s.io/v1alpha1
-kind: AccessPolicy
+kind: XAccessPolicy
 metadata:
   name: access-policy-server2
 spec:
   targetRefs:
   - group: agentic.networking.x-k8s.io
-    kind: Backend
+    kind: XBackend
     name: mcp-server2
+  action: Allow
   rules:
-  - source:
-      serviceAccounts:
-      - "default/sa2"
-    tools:
-    - "read_wiki_structure"
+  - name: sa2-wiki
+    source:
+      type: ServiceAccount
+      serviceAccount:
+        name: sa2
+        namespace: default
+    authorization:
+      type: Inline
+      mcp:
+        methods:
+        - name: tools/call
+          params: ["read_wiki_structure"]
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -397,15 +430,13 @@ spec:
     backendRefs:
     - name: mcp-server2
       group: agentic.networking.x-k8s.io
-      kind: Backend
+      kind: XBackend
 ---
-# Define a Backend resource for server2, which is external.
-apiVersion: agentic.networking.x-k8s.io/v1alpha1
-kind: Backend
+apiVersion: agentic.networking.x-k8s.io/v0alpha0
+kind: XBackend
 metadata:
   name: mcp-server2
 spec:
-  type: MCP
   mcp:
     hostname: mcp.deepwiki.com
     port: 443

--- a/docs/proposals/0017-DynamicAuth.md
+++ b/docs/proposals/0017-DynamicAuth.md
@@ -17,6 +17,20 @@ A set of new fields proposed to be added the AccessPolicy API can be used in con
 
 This API is **provisional** and subject to change without prior notice. Vendors and integrators should not implement or rely on it, and it must not be enabled in production environments until a stable version is released.
 
+### Implementation status (v1alpha1)
+
+Partially implemented in the prototype:
+
+| Proposal concept | v1alpha1 status |
+|----------------|-----------------|
+| `InlineTools` + flat `tools:` list | **`Inline`** + `mcp.methods` (e.g. `tools/call` with `params`) |
+| Rule-level `ExternalAuth` | **`spec.action: ExternalAuth`** + `spec.externalAuth` |
+| `CEL` authorization | Implemented (`authorization.type: CEL`) |
+| OIDC / JWT sources | **Not implemented** |
+| Dynamic tool discovery without enumeration | **Not implemented** |
+
+See [`api/v1alpha1/accesspolicy_types.go`](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/api/v1alpha1/accesspolicy_types.go) and the [site API reference](https://kube-agentic-networking.sigs.k8s.io/reference/spec/). YAML examples below reflect the original proposal, not the implemented API.
+
 ----
 
 ## Non-Goals

--- a/docs/proposals/0059-AccessPolicyTargetRefs.md
+++ b/docs/proposals/0059-AccessPolicyTargetRefs.md
@@ -4,23 +4,23 @@ Status: Provisional<br/>
 
 # Allow AccessPolicy to Target Gateway Objects
 
-Currently, the [AccessPolicy](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/docs/proposals/0008-ToolAuthAPI.md#accesspolicy-crd) resource is only allowed to target [Backends](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/docs/proposals/0008-ToolAuthAPI.md#backend-crd).
+Currently, the [XAccessPolicy](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/api/v1alpha1/accesspolicy_types.go) resource is only allowed to target [XBackends](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/api/v0alpha0/backend_types.go).
 
 This has scalability issues when a given Tool Authorization policy needs to be enforced for all the traffic managed by a [Gateway](https://gateway-api.sigs.k8s.io/api-types/gateway/) object.
 
-This proposal allows `AccessPolicy` to target `Gateway` objects, in addition to `Backend` objects with following restrictions:
+This proposal allows `XAccessPolicy` to target `Gateway` objects, in addition to `XBackend` objects with following restrictions:
 
-1. A single `AccessPolicy` object targeting a Gateway and a Backend at the same time is NOT allowed.
+1. A single `XAccessPolicy` object targeting a Gateway and a XBackend at the same time is NOT allowed.
 
-1. It is allowed to have `AccessPolicy` objects targeting a `Gateway` object and `AccessPolicy` objects targeting a `Backend` object behind the `Gateway` object. In this case, the `AccessPolicy` objects targeting the `Gateway` object will be evaluated first. Among the `AccessPolicy` objects targeting the `Gateway` object, the ones with earlier creationTimestamp will be evaluated first. For the policies with the same creationTimestamp, the ones appearing first in alphabetical order by `{namespace}/{name}` will be evaluated first.
+1. It is allowed to have `XAccessPolicy` objects targeting a `Gateway` object and `XAccessPolicy` objects targeting a `XBackend` object behind the `Gateway` object. In this case, the `XAccessPolicy` objects targeting the `Gateway` object will be evaluated first. Among the `XAccessPolicy` objects targeting the `Gateway` object, the ones with earlier creationTimestamp will be evaluated first. For the policies with the same creationTimestamp, the ones appearing first in alphabetical order by `{namespace}/{name}` will be evaluated first.
 
-    * If any of the `AccessPolicy` objects targeting the `Gateway` object denies the access, the HTTP request will be denied. The `AccessPolicy` objects targeting the `Backend` object will NOT be evaluated in this case.
+    * If any of the `XAccessPolicy` objects targeting the `Gateway` object denies the access, the HTTP request will be denied. The `XAccessPolicy` objects targeting the `XBackend` object will NOT be evaluated in this case.
 
-    * If all the `AccessPolicy` objects targeting the `Gateway` object allow the access, the `AccessPolicy` objects targeting the `Backend` object will be evaluated. Among the `AccessPolicy` objects targeting the `Backend` object, the ones with earlier creationTimestamp will be evaluated first. For the policies with the same creationTimestamp, the ones appearing first in alphabetical order by `{namespace}/{name}` will be evaluated first.
+    * If all the `XAccessPolicy` objects targeting the `Gateway` object allow the access, the `XAccessPolicy` objects targeting the `XBackend` object will be evaluated. Among the `XAccessPolicy` objects targeting the `XBackend` object, the ones with earlier creationTimestamp will be evaluated first. For the policies with the same creationTimestamp, the ones appearing first in alphabetical order by `{namespace}/{name}` will be evaluated first.
 
-        * if any of the `AccessPolicy` objects targeting the `Backend` object denies the access, the HTTP request will be denied.
+        * if any of the `XAccessPolicy` objects targeting the `XBackend` object denies the access, the HTTP request will be denied.
 
-        * if all the `AccessPolicy` objects targeting the `Backend` object allow the access, the HTTP request will be allowed.
+        * if all the `XAccessPolicy` objects targeting the `XBackend` object allow the access, the HTTP request will be allowed.
 
 ## Example
 
@@ -30,13 +30,13 @@ We have a Gateway, an HTTPRoute and a Backend:
 
 *   **Gateway**: `prod-gateway`
 *   **HTTPRoute**: `payment-route` (attached to `prod-gateway`, routes to `payment-service`)
-*   **Backend**: `payment-service`
+*   **XBackend**: `payment-service`
 
-We also have the following AccessPolicies applied:
+We also have the following XAccessPolicies applied:
 
 1.  `gateway-policy-audit` (Targets `prod-gateway`). Created at T1.
 2.  `gateway-policy-region` (Targets `prod-gateway`). Created at T2 (T1 < T2).
-3.  `backend-policy-admin` (Targets `payment-service`).
+3.  `backend-policy-admin` (Targets `payment-service` XBackend).
 
 The graph shows the relationships between these resources:
 
@@ -45,16 +45,16 @@ graph TD
     %% 1. Policies at the Top
     subgraph PolicyLayer [Policy Attachments]
         direction LR
-        GPA1(AccessPolicy: gateway-policy-audit)
-        GPR1(AccessPolicy: gateway-policy-region)
-        BPA1(AccessPolicy: backend-policy-admin)
+        GPA1(XAccessPolicy: gateway-policy-audit)
+        GPR1(XAccessPolicy: gateway-policy-region)
+        BPA1(XAccessPolicy: backend-policy-admin)
     end
 
     %% 2. Infrastructure & Routing on the same line
     %% We define the order here: Gateway <-> Route <-> Backend
     GW(Gateway: prod-gateway)
     Route(HTTPRoute: payment-route)
-    BE(Backend: payment-service)
+    BE(XBackend: payment-service)
 
     %% Invisible links to force horizontal alignment
     GW ~~~ Route ~~~ BE
@@ -110,19 +110,19 @@ type AccessPolicySpec struct {
 	// +required
 	// +kubebuilder:validation:MinItems=1
 	// +listType=atomic
-	// +kubebuilder:validation:XValidation:rule="self.all(x, (x.group == 'agentic.prototype.x-k8s.io' && x.kind == 'XBackend') || (x.group == 'gateway.networking.k8s.io' && x.kind == 'Gateway'))",message="TargetRef must have group agentic.prototype.x-k8s.io and kind XBackend, or group gateway.networking.k8s.io and kind Gateway"
+	// +kubebuilder:validation:XValidation:rule="self.all(x, (x.group == 'agentic.networking.x-k8s.io' && x.kind == 'XBackend') || (x.group == 'gateway.networking.k8s.io' && x.kind == 'Gateway'))",message="TargetRef must have group agentic.networking.x-k8s.io and kind XBackend, or group gateway.networking.k8s.io and kind Gateway"
     // +kubebuilder:validation:XValidation:rule="self.all(ref, ref.kind == self[0].kind)",message="All targetRefs must have the same Kind"
-	TargetRefs []gwapiv1.LocalPolicyTargetReference `json:"targetRefs"`
+	TargetRefs []gwapiv1.LocalPolicyTargetReferenceWithSectionName `json:"targetRefs"`
 }
 ```
 
-Currently, the `InlineTools` type of [AuthorizationRule](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/docs/proposals/0017-DynamicAuth.md) supports a list of tool names, which works well for `AccessPolicy` targeting `Backend` objects. However, it does not work well for `AccessPolicy` targeting `Gateway` objects, because there could be tool name conflicts between different backends behind the same `Gateway`. We will address this in a separate proposal.
+In v1alpha1, the `Inline` authorization type uses `mcp.methods` (for example, `tools/call` with `params`) instead of a flat tool name list. This works well for `XAccessPolicy` targeting `XBackend` objects. It does not work well for `XAccessPolicy` targeting `Gateway` objects, because there could be tool name conflicts between different backends behind the same `Gateway`. We will address this in a separate proposal.
 
 ## Support requirements in implementation
 
 * An implementation MUST support at least one of the following:
 
-    * `AccessPolicy` objects targeting `Gateway` objects
-    * `AccessPolicy` objects targeting `Backend` objects
+    * `XAccessPolicy` objects targeting `Gateway` objects
+    * `XAccessPolicy` objects targeting `XBackend` objects
 
-* If an implementation supports allowing `AccessPolicy` to target both `Gateway` and `Backend` objects, it MUST support the evaluation flow described above.
+* If an implementation supports allowing `XAccessPolicy` to target both `Gateway` and `XBackend` objects, it MUST support the evaluation flow described above.

--- a/site-src/guides/external-auth-quickstart/README.md
+++ b/site-src/guides/external-auth-quickstart/README.md
@@ -13,8 +13,8 @@ In this example, we'll use [Authorino](https://github.com/kuadrant/authorino)[^1
 [^1]: Authorino is a Kubernetes-native authorization service that is part of the [Kuadrant](https://kuadrant.io/) CNCF project.
 
 The agent will attempt to access tools from two MCP servers:
-1. **Local MCP backend**: Controlled by an inline tool allowlist (`InlineTools` authorization type)
-2. **Remote MCP backend**: Controlled by an external authorizer (`ExternalAuth` authorization type)
+1. **Local MCP backend**: Controlled by an `XAccessPolicy` with `action: Allow` and inline MCP method allowlisting (`authorization.type: Inline`)
+2. **Remote MCP backend**: Controlled by an `XAccessPolicy` with `action: ExternalAuth` that delegates to an external authorizer
 
 In this example, the external authorizer enforces a **repository-based access policy** — the agent can only access specific approved GitHub repositories when using remote MCP tools.
 
@@ -127,7 +127,7 @@ The `run-external-auth-quickstart.sh` script performs the following steps:
    - Installs Authorino Operator (using Helm)
    - Creates an instance of the authorization service
    - Configures repository-based access rules (only specific approved repos) for all hosts delegating authorization to the service
-3. **Applies external auth policies** by updating the `XAccessPolicy` for the remote MCP backend to use `ExternalAuth` type
+3. **Applies external auth policies** by updating the `XAccessPolicy` for the remote MCP backend to set `spec.action: ExternalAuth`
 
 ## Understanding External Authorization Policies
 
@@ -166,7 +166,7 @@ spec:
 
 - **`action: ExternalAuth`**: Delegates authorization decisions to an external service instead of using inline rules
 - **`externalAuth.backendRef`**: Points to the external authorization service
-- **`externalAuthProtocol: GRPC`**: Specifies the protocol to communicate with the external authorizer
+- **`externalAuth.protocol: GRPC`**: Specifies the protocol to communicate with the external authorizer
 
 When the agent attempts to call a tool on the remote MCP backend, the gateway will:
 1. Intercept the request
@@ -199,7 +199,7 @@ spec:
 
 This Rego policy extracts the `repoName` argument from the tool call parameters and allows access only if the repository is in the allowed list.
 
-**Key insight**: While inline `InlineTools` authorization can only allow/deny tools by name, external authorization can inspect **tool arguments** and make context-aware decisions. This enables fine-grained, argument-level policy enforcement.
+**Key insight**: While inline `Allow` policies with `authorization.type: Inline` can only allow/deny tools by name (via `tools/call` `params`), external authorization can inspect **tool arguments** and make context-aware decisions. This enables fine-grained, argument-level policy enforcement.
 
 ## Chat with the Agent
 
@@ -297,9 +297,9 @@ Simply update the `externalAuth.backendRef` in your `XAccessPolicy` to point to 
 
 A: In the reference implementation, if the gateway cannot reach the external authorizer, the default behavior is to **deny** the request. This fail-closed approach ensures that access is not granted when the authorization system is down. The specific failure behavior may vary depending on your Agentic Networking implementation and gateway configuration.
 
-**Q: Can I combine `InlineTools` and `ExternalAuth` in the same policy?**
+**Q: Can I combine inline allowlists and external authorization on the same backend?**
 
-A: Yes, you can create multiple rules targeting the same gateway or backend, each with different sources and authorization types. However, there is currently a maximum of one authorization rule with type `ExternalAuth` per policy, but a policy can combine multiple `InlineTools` rules with one `ExternalAuth` rule. The controller will merge these rules appropriately.
+A: Yes, but use **separate `XAccessPolicy` resources** — each policy has one `spec.action` (`Allow` or `ExternalAuth`). This quickstart does exactly that: one `Allow` policy for the local backend and one `ExternalAuth` policy for the remote backend. On a single target, `ExternalAuth` policies are evaluated first; if they allow the request, all `Allow` policies on that target must also allow it.
 
 **Q: How does the external authorizer receive request context?**
 

--- a/site-src/guides/quickstart/README.md
+++ b/site-src/guides/quickstart/README.md
@@ -192,8 +192,10 @@ Want to see policy changes in action? Let's flip the script for the `local-mcp-b
      namespace: quickstart-ns
    spec:
      targetRefs:
-       - kind: XBackend
+       - group: agentic.networking.x-k8s.io
+         kind: XBackend
          name: local-mcp-backend
+     action: Allow
      rules:
        - name: updated-rule
          source:

--- a/site-src/guides/quickstart/policy/e2e.yaml
+++ b/site-src/guides/quickstart/policy/e2e.yaml
@@ -43,7 +43,7 @@ metadata:
   name: auth-policy-local-mcp
   namespace: quickstart-ns
 spec:
-  # AuthPolicy targets a single HTTPRoute.
+  # XAccessPolicy targets the local MCP XBackend.
   targetRefs:
     - group: agentic.networking.x-k8s.io
       kind: XBackend

--- a/site-src/introduction.md
+++ b/site-src/introduction.md
@@ -57,8 +57,14 @@ This defines authorization policies for tool access from AI agents running insid
 
 The API introduces 2 new CRDs:
 
-- [XBackend](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/api/v0alpha0/backend_types.go): describes a backend in agentic networking
-- [XAccessPolicy](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/api/v0alpha0/accesspolicy_types.go): describes who can access what (the permissions/grants) in relation to the agentic networking backends
+- [XBackend](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/api/v0alpha0/backend_types.go) (`agentic.networking.x-k8s.io/v0alpha0`): describes a backend in agentic networking.
+- [XAccessPolicy](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/api/v1alpha1/accesspolicy_types.go) (`agentic.networking.x-k8s.io/v1alpha1`): describes who can access what in relation to agentic networking backends or Gateways. The v1alpha1 API is the storage version; an older v0alpha0 shape is still served for compatibility but should not be used for new policies.
+
+Key v1alpha1 concepts:
+
+- `spec.action`: `Allow` (inline authorization in rules) or `ExternalAuth` (delegate to `spec.externalAuth`).
+- Tool allowlists use `authorization.type: Inline` with `mcp.methods` (for example, `tools/call` with `params` listing tool names), not a flat `tools:` list on rules.
+- See the [API reference](reference/spec/) and [quickstart](guides/quickstart/README.md) for current examples.
 
 ## Who is working on this project?
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR aligns user-facing documentation with the implemented API: correct resource names and versions, the spec.action + authorization.type: Inline / mcp.methods model, and spec-level ExternalAuth. It adds a site API reference page (fixing the broken Reference nav) and adds implementation-status notes on design proposals so historical docs are clearly distinguished from what ships today.

**Which issue(s) this PR fixes**:
Fixes #274 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
