### PR TITLE
feat: Add make setup-cluster target for local dev cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,14 @@ test-e2e-only: ## Run E2E tests against the current cluster without setup.
 	@echo "...Running E2E tests against cluster: $$(kubectl config current-context)"
 	cd tests && go clean -testcache && go test -v ./e2e/...
 
+.PHONY: setup-cluster
+setup-cluster: ## Create a local Kind cluster with MetalLB, CRDs, and the controller deployed.
+	./dev/ci/setup-cluster.sh
+
+.PHONY: teardown-cluster
+teardown-cluster: ## Delete the local dev cluster created by setup-cluster.
+	kind delete cluster --name "$${CLUSTER_NAME:-kan-dev}"
+
 .PHONY: verify
 verify: ## Run go vet
 	hack/verify-all.sh -v

--- a/dev/ci/setup-cluster.sh
+++ b/dev/ci/setup-cluster.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME:-kan-dev}"
+
+# Source common library relative to this script
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+setup_cluster_with_controller "${CLUSTER_NAME}"
+
+echo ""
+echo "Cluster '${CLUSTER_NAME}' is ready."
+echo "Context: kind-${CLUSTER_NAME}"
+echo ""
+echo "To run conformance tests:"
+echo "  GATEWAY_CLASS=kube-agentic-networking make conformance"
+echo ""
+echo "To tear down:"
+echo "  make teardown-cluster"

--- a/hack/build/Makefile.common.in
+++ b/hack/build/Makefile.common.in
@@ -23,7 +23,7 @@ REPO_ROOT?=$(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
 
 # Default tags for local builds
 TAG ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo latest)
-BASE_REF ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo latest)
+BASE_REF ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo latest)
 
 # Go version to use, respected by images that build go binaries
 GO_VERSION?=$(shell cat $(REPO_ROOT)/.go-version | head -n1)


### PR DESCRIPTION
## Summary

- Adds `make setup-cluster` target that creates a local Kind cluster with MetalLB, CRDs, and the controller deployed (without running tests or deploying app workloads)
- Adds `make teardown-cluster` target to destroy the cluster
- New thin wrapper script `dev/ci/setup-cluster.sh` that sources `dev/ci/lib.sh` and calls `setup_cluster_with_controller()`

Closes #269

## Test plan

- [x] Verify `make setup-cluster` creates a Kind cluster named `kan-dev` with MetalLB and the controller running
- [x] Verify `make teardown-cluster` deletes the cluster
- [x] Verify `CLUSTER_NAME=custom make setup-cluster` uses the custom name
- [ ] Verify conformance tests can run against the cluster: `GATEWAY_CLASS=kube-agentic-networking make conformance`