### PR TITLE
Document MCP params matcher context for XAccessPolicy

### DIFF
--- a/api/v1alpha1/accesspolicy_types.go
+++ b/api/v1alpha1/accesspolicy_types.go
@@ -245,16 +245,31 @@ type MCPMethod struct {
 	// +required
 	Name MCPMethodName `json:"name"`
 
-	// Params allows matching against specific arguments in the MCP request.
-	// Only valid for 'get', 'call', 'subscribe', 'unsubscribe', and 'read' methods.
-	// If empty or omitted, parameter-level allowlisting is not applied, meaning the method
-	// is authorized regardless of the arguments passed in the request.
+	// Params lists values to match against the "name" field in the MCP JSON-RPC request's
+	// "params" object. In the current prototype implementation, all supported methods
+	// (prompts/get, tools/call, resources/subscribe, resources/unsubscribe, and
+	// resources/read) match against "params.name".
+	//
+	// Note: In the MCP protocol, resources/subscribe, resources/unsubscribe, and
+	// resources/read use "params.uri" rather than "params.name". Matching against
+	// "params.uri" for resource methods is not yet implemented and will be addressed
+	// separately.
+	//
+	// For example, a tools/call request with params {"name":"get-sum","arguments":{"a":2,"b":3}}
+	// is matched by a param value of "get-sum".
+	//
+	// Only valid for prompts/get, tools/call, resources/subscribe, resources/unsubscribe,
+	// and resources/read. If empty or omitted, parameter-level allowlisting is not applied,
+	// meaning the method is authorized regardless of the arguments passed in the request.
 	// +optional
 	// +listType=set
 	// +kubebuilder:validation:MaxItems=10
 	Params []MCPMethodParam `json:"params,omitempty"`
 }
 
+// MCPMethodParam is a value to match against the "name" field in the MCP JSON-RPC
+// request's "params" object. See MCPMethod.Params for current matching behavior
+// and known limitations for resource methods.
 // +kubebuilder:validation:MaxLength=20
 type MCPMethodParam string
 

--- a/docs/proposals/0008-ToolAuthAPI.md
+++ b/docs/proposals/0008-ToolAuthAPI.md
@@ -23,6 +23,20 @@ A prototype implementation exists. **Use the implemented API below**, not the or
 | `serviceAccounts: ["ns/sa"]` shorthand | `source.type: ServiceAccount` + `serviceAccount: { name, namespace? }` |
 | Rule-level external auth | `spec.action: ExternalAuth` + `spec.externalAuth` |
 
+### MCP `params` matching (v1alpha1)
+
+In MCP JSON-RPC requests, the `params` object is method-specific. In `spec.rules[].authorization.mcp.methods[].params`, each listed value is matched against the `name` field in the MCP request's `params` object.
+
+| MCP method | Currently matched field |
+| --- | --- |
+| `prompts/get` | `name` |
+| `tools/call` | `name` |
+| `resources/subscribe` | `name` |
+| `resources/unsubscribe` | `name` |
+| `resources/read` | `name` |
+
+**Known limitation:** In the MCP protocol, resource methods use `params.uri` rather than `params.name`. The prototype implementation currently matches `params.name` for all methods, including resources. Matching against `params.uri` for resource methods is not yet implemented and will be addressed separately.
+
 **Authoritative references:** [`api/v1alpha1/accesspolicy_types.go`](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/api/v1alpha1/accesspolicy_types.go), [site API reference](https://kube-agentic-networking.sigs.k8s.io/reference/spec/), [quickstart example](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/site-src/guides/quickstart/policy/e2e.yaml).
 
 # Non-Goals

--- a/k8s/crds/agentic.networking.x-k8s.io_xaccesspolicies.yaml
+++ b/k8s/crds/agentic.networking.x-k8s.io_xaccesspolicies.yaml
@@ -1147,11 +1147,27 @@ spec:
                                     type: string
                                   params:
                                     description: |-
-                                      Params allows matching against specific arguments in the MCP request.
-                                      Only valid for 'get', 'call', 'subscribe', 'unsubscribe', and 'read' methods.
-                                      If empty or omitted, parameter-level allowlisting is not applied, meaning the method
-                                      is authorized regardless of the arguments passed in the request.
+                                      Params lists values to match against the "name" field in the MCP JSON-RPC request's
+                                      "params" object. In the current prototype implementation, all supported methods
+                                      (prompts/get, tools/call, resources/subscribe, resources/unsubscribe, and
+                                      resources/read) match against "params.name".
+
+                                      Note: In the MCP protocol, resources/subscribe, resources/unsubscribe, and
+                                      resources/read use "params.uri" rather than "params.name". Matching against
+                                      "params.uri" for resource methods is not yet implemented and will be addressed
+                                      separately.
+
+                                      For example, a tools/call request with params {"name":"get-sum","arguments":{"a":2,"b":3}}
+                                      is matched by a param value of "get-sum".
+
+                                      Only valid for prompts/get, tools/call, resources/subscribe, resources/unsubscribe,
+                                      and resources/read. If empty or omitted, parameter-level allowlisting is not applied,
+                                      meaning the method is authorized regardless of the arguments passed in the request.
                                     items:
+                                      description: |-
+                                        MCPMethodParam is a value to match against the "name" field in the MCP JSON-RPC
+                                        request's "params" object. See MCPMethod.Params for current matching behavior
+                                        and known limitations for resource methods.
                                       maxLength: 20
                                       type: string
                                     maxItems: 10

--- a/site-src/introduction.md
+++ b/site-src/introduction.md
@@ -66,6 +66,36 @@ Key v1alpha1 concepts:
 - Tool allowlists use `authorization.type: Inline` with `mcp.methods` (for example, `tools/call` with `params` listing tool names), not a flat `tools:` list on rules.
 - See the [API reference](reference/spec/) and [quickstart](guides/quickstart/README.md) for current examples.
 
+#### MCP `params` matching
+
+In MCP JSON-RPC requests, the `params` object is method-specific. In `spec.rules[].authorization.mcp.methods[].params`, each listed value is matched against the `name` field in the MCP request's `params` object.
+
+| MCP method | Currently matched field |
+| --- | --- |
+| `prompts/get` | `name` |
+| `tools/call` | `name` |
+| `resources/subscribe` | `name` |
+| `resources/unsubscribe` | `name` |
+| `resources/read` | `name` |
+
+> **Known limitation:** In the MCP protocol, resource methods use `params.uri` rather than `params.name`. The prototype implementation currently matches `params.name` for all methods, including resources. Matching against `params.uri` for resource methods is not yet implemented and will be addressed separately.
+
+For example, a `tools/call` request such as:
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "get-sum",
+    "arguments": {"a": 2, "b": 3}
+  },
+  "jsonrpc": "2.0",
+  "id": 1
+}
+```
+
+is matched by a `params` value of `get-sum`.
+
 ## Who is working on this project?
 
 Kube Agentic Networking is a [SIG Network](https://github.com/kubernetes/community/tree/master/sig-network) project.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
In MCP, the JSON-RPC params object is method-specific, but v1alpha1 XAccessPolicy did not clearly document which MCP request field each value in [spec.rules.authorization.mcp.methods.params](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/8331f16c5a53a6f6620e05dd5342b8a681ad89c8/api/v1alpha1/accesspolicy_types.go#L215) is matched against. For example, tools/call uses params.name (the tool name), while resources/subscribe uses params.uri.
This PR documents that mapping so policy authors know what to put in params for each MCP method. 
It updates:
- API type comments on MCPMethod.Params and MCPMethodParam
- CRD OpenAPI descriptions (regenerated from the Go types)
- Site introduction docs with per-method tables and JSON-RPC examples
- The Tool Auth API proposal under v1alpha1 implementation status

**Which issue(s) this PR fixes**:
Fixes #275 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
