### PR TITLE
Fix: Treat explicit empty MCP methods as deny-by-default in RBAC

### DIFF
--- a/api/v1alpha1/accesspolicy_types.go
+++ b/api/v1alpha1/accesspolicy_types.go
@@ -50,7 +50,7 @@ type AccessPolicySpec struct {
 	// 1. ExternalAuth runs before all other Allow policies.
 	// 2. If an ExternalAuth server denies the request, the request is denied.
 	// 3. If it allows the request, processing continues for all other allow policies for that target.
-	// 4. The request is allowed only if all allow policies allow it.
+	// 4. The request is allowed if any allow policy allows it.
 	// +required
 	Action AccessPolicyActionType `json:"action"`
 
@@ -209,7 +209,8 @@ type MCPAttributes struct {
 	// Methods is a list of specific MCP functional methods to match.
 	// If specified, only MCP requests with a method
 	// that matches one of these items will be authorized.
-	// If empty or omitted, no method-level allowlisting is applied, meaning all
+	// If set to an empty list, no MCP methods are permitted (deny-by-default).
+	// If omitted, no method-level allowlisting is applied, meaning all
 	// MCP methods (e.g., all tools, prompts, and resources) are permitted.
 	// +kubebuilder:validation:MaxItems=10
 	// +optional

--- a/k8s/crds/agentic.networking.x-k8s.io_xaccesspolicies.yaml
+++ b/k8s/crds/agentic.networking.x-k8s.io_xaccesspolicies.yaml
@@ -822,7 +822,7 @@ spec:
                   1. ExternalAuth runs before all other Allow policies.
                   2. If an ExternalAuth server denies the request, the request is denied.
                   3. If it allows the request, processing continues for all other allow policies for that target.
-                  4. The request is allowed only if all allow policies allow it.
+                  4. The request is allowed if any allow policy allows it.
                 enum:
                 - Allow
                 - ExternalAuth
@@ -1117,7 +1117,8 @@ spec:
                                 Methods is a list of specific MCP functional methods to match.
                                 If specified, only MCP requests with a method
                                 that matches one of these items will be authorized.
-                                If empty or omitted, no method-level allowlisting is applied, meaning all
+                                If set to an empty list, no MCP methods are permitted (deny-by-default).
+                                If omitted, no method-level allowlisting is applied, meaning all
                                 MCP methods (e.g., all tools, prompts, and resources) are permitted.
                               items:
                                 description: MCPMethod defines a specific MCP method

--- a/pkg/translator/accesspolicy.go
+++ b/pkg/translator/accesspolicy.go
@@ -180,57 +180,72 @@ func (t *Translator) mergeAllowPoliciesToRBAC(policies []*agenticv1alpha1.XAcces
 
 	for _, policy := range policies {
 		for _, rule := range policy.Spec.Rules {
-			policyName := rule.Name
-			source := t.ruleSourceToPrincipalName(policy.Namespace, rule.Source)
-
-			var principalIDs []*rbacconfigv3.Principal
-			if source != "" {
-				principalIDs = append(principalIDs, &rbacconfigv3.Principal{
-					Identifier: &rbacconfigv3.Principal_Authenticated_{
-						Authenticated: &rbacconfigv3.Principal_Authenticated{
-							PrincipalName: &matcherv3.StringMatcher{
-								MatchPattern: &matcherv3.StringMatcher_Exact{Exact: source},
-							},
-						},
-					},
-				})
+			rbacPolicy, ok := t.buildAllowRBACPolicyFromRule(policy.Namespace, rule)
+			if !ok {
+				continue
 			}
-			if len(principalIDs) == 0 {
-				principalIDs = []*rbacconfigv3.Principal{buildAnyPrincipal()}
-			}
-
-			rbacPolicy := &rbacconfigv3.Policy{
-				Principals: principalIDs,
-			}
-
-			if rule.Authorization != nil {
-				switch rule.Authorization.Type {
-				case agenticv1alpha1.AuthorizationRuleTypeInline:
-					if permissions := t.translateMCPToRBACPermissions(&rule.Authorization.MCP); len(permissions) > 0 {
-						rbacPolicy.Permissions = permissions
-					}
-				case agenticv1alpha1.AuthorizationRuleTypeCEL:
-					if rule.Authorization.CEL != nil {
-						ast, err := CompileCelExpression(rule.Authorization.CEL.Expression)
-						if err != nil {
-							klog.Errorf("Failed to compile CEL expression %q: %v", rule.Authorization.CEL.Expression, err)
-							continue
-						}
-						rbacPolicy.Condition = ast.Expr()
-						rbacPolicy.Permissions = []*rbacconfigv3.Permission{buildToolsCallMethodPermission()}
-					}
-				}
-			}
-
-			if len(rbacPolicy.GetPermissions()) == 0 {
-				rbacPolicy.Permissions = []*rbacconfigv3.Permission{buildAnyPermission()}
-			}
-
+			policyName := fmt.Sprintf("%s/%s/%s", policy.Namespace, policy.Name, rule.Name)
 			addPolicyToRBACRules(rbacConfig, policyName, rbacPolicy)
 		}
 	}
 
 	return rbacConfig
+}
+
+// buildAllowRBACPolicyFromRule translates an AccessRule into an Envoy RBAC allow policy.
+// The second return value is false when the rule contributes no allow permissions (for example,
+// an explicit empty MCP methods allowlist) and should be omitted from the merged RBAC config.
+func (t *Translator) buildAllowRBACPolicyFromRule(policyNamespace string, rule agenticv1alpha1.AccessRule) (*rbacconfigv3.Policy, bool) {
+	source := t.ruleSourceToPrincipalName(policyNamespace, rule.Source)
+
+	var principalIDs []*rbacconfigv3.Principal
+	if source != "" {
+		principalIDs = append(principalIDs, &rbacconfigv3.Principal{
+			Identifier: &rbacconfigv3.Principal_Authenticated_{
+				Authenticated: &rbacconfigv3.Principal_Authenticated{
+					PrincipalName: &matcherv3.StringMatcher{
+						MatchPattern: &matcherv3.StringMatcher_Exact{Exact: source},
+					},
+				},
+			},
+		})
+	}
+	if len(principalIDs) == 0 {
+		principalIDs = []*rbacconfigv3.Principal{buildAnyPrincipal()}
+	}
+
+	rbacPolicy := &rbacconfigv3.Policy{
+		Principals: principalIDs,
+	}
+
+	if rule.Authorization == nil {
+		rbacPolicy.Permissions = []*rbacconfigv3.Permission{buildAnyPermission()}
+		return rbacPolicy, true
+	}
+
+	switch rule.Authorization.Type {
+	case agenticv1alpha1.AuthorizationRuleTypeInline:
+		permissions := t.translateMCPToRBACPermissions(&rule.Authorization.MCP)
+		if permissions == nil {
+			return nil, false
+		}
+		rbacPolicy.Permissions = permissions
+	case agenticv1alpha1.AuthorizationRuleTypeCEL:
+		if rule.Authorization.CEL == nil {
+			return nil, false
+		}
+		ast, err := CompileCelExpression(rule.Authorization.CEL.Expression)
+		if err != nil {
+			klog.Errorf("Failed to compile CEL expression %q: %v", rule.Authorization.CEL.Expression, err)
+			return nil, false
+		}
+		rbacPolicy.Condition = ast.Expr()
+		rbacPolicy.Permissions = []*rbacconfigv3.Permission{buildToolsCallMethodPermission()}
+	default:
+		return nil, false
+	}
+
+	return rbacPolicy, true
 }
 
 // findAccessPoliciesForTarget finds all AccessPolicies that target the given resource.
@@ -314,51 +329,15 @@ func (t *Translator) translateAccessPolicyToRBAC(accessPolicy *agenticv1alpha1.X
 	for _, rule := range accessPolicy.Spec.Rules {
 		policyName := rule.Name
 
-		source := t.ruleSourceToPrincipalName(accessPolicy.Namespace, rule.Source)
-
-		var principalIDs []*rbacconfigv3.Principal
-		if source != "" {
-			principalIDs = append(principalIDs, &rbacconfigv3.Principal{
-				Identifier: &rbacconfigv3.Principal_Authenticated_{
-					Authenticated: &rbacconfigv3.Principal_Authenticated{
-						PrincipalName: &matcherv3.StringMatcher{
-							MatchPattern: &matcherv3.StringMatcher_Exact{Exact: source},
-						},
-					},
-				},
-			})
-		}
-
-		if len(principalIDs) == 0 {
-			principalIDs = []*rbacconfigv3.Principal{buildAnyPrincipal()}
-		}
-
-		rbacPolicy := &rbacconfigv3.Policy{
-			Principals: principalIDs,
-		}
-
-		if rule.Authorization != nil {
-			switch rule.Authorization.Type {
-			case agenticv1alpha1.AuthorizationRuleTypeInline:
-				// TODO: Only MCP is currently supported. Add support for more generic inline auth in the future
-				if permissions := t.translateMCPToRBACPermissions(&rule.Authorization.MCP); len(permissions) > 0 {
-					rbacPolicy.Permissions = permissions
-				}
-			case agenticv1alpha1.AuthorizationRuleTypeCEL:
-				if rule.Authorization.CEL != nil {
-					ast, err := CompileCelExpression(rule.Authorization.CEL.Expression)
-					if err != nil {
-						klog.Errorf("Failed to compile CEL expression %q: %v", rule.Authorization.CEL.Expression, err)
-						continue
-					}
-					rbacPolicy.Condition = ast.Expr()
-					rbacPolicy.Permissions = []*rbacconfigv3.Permission{buildToolsCallMethodPermission()}
-				}
-			}
-		}
-
 		// Handle ExternalAuth at policy level
 		if accessPolicy.Spec.Action == agenticv1alpha1.ActionTypeExternalAuth && accessPolicy.Spec.ExternalAuth != nil {
+			rbacPolicy, ok := t.buildAllowRBACPolicyFromRule(accessPolicy.Namespace, rule)
+			if !ok {
+				rbacPolicy = &rbacconfigv3.Policy{
+					Principals:  []*rbacconfigv3.Principal{buildAnyPrincipal()},
+					Permissions: []*rbacconfigv3.Permission{buildAnyPermission()},
+				}
+			}
 			hash, err := externalAuthUniqueID(accessPolicy.Spec.ExternalAuth)
 			if err != nil {
 				klog.Errorf("Failed to generate unique ID for externalAuth config in AccessPolicy %s/%s: %v", accessPolicy.Namespace, accessPolicy.Name, err)
@@ -379,23 +358,32 @@ func (t *Translator) translateAccessPolicyToRBAC(accessPolicy *agenticv1alpha1.X
 				Permissions: []*rbacconfigv3.Permission{buildAnyPermission()},
 			}
 			addPolicyToRBACRules(rbacConfig, policyName, allowAllPolicy)
-		} else {
-			// Action is Allow
-			// Ensure permissions is never empty to satisfy Envoy's schema validation (min_items: 1).
-			// Spec guidance: If omitted, all access from the specified source is allowed.
-			if len(rbacPolicy.GetPermissions()) == 0 {
-				rbacPolicy.Permissions = []*rbacconfigv3.Permission{buildAnyPermission()}
-			}
-			addPolicyToRBACRules(rbacConfig, policyName, rbacPolicy)
+			continue
 		}
+
+		// Action is Allow
+		rbacPolicy, ok := t.buildAllowRBACPolicyFromRule(accessPolicy.Namespace, rule)
+		if !ok {
+			continue
+		}
+		addPolicyToRBACRules(rbacConfig, policyName, rbacPolicy)
 	}
 
 	return rbacConfig
 }
 
+// translateMCPToRBACPermissions converts MCP attributes into RBAC permissions.
+// Returns nil when an explicit empty methods allowlist is configured (deny-by-default for tool calls).
+// Returns any-permission when methods are omitted, meaning no MCP-level restriction is applied.
 func (t *Translator) translateMCPToRBACPermissions(mcp *agenticv1alpha1.MCPAttributes) []*rbacconfigv3.Permission {
 	if mcp == nil {
 		return []*rbacconfigv3.Permission{buildAnyPermission()}
+	}
+
+	// An explicit empty methods list establishes deny-by-default for tool calls.
+	if mcp.Methods != nil && len(mcp.Methods) == 0 &&
+		mcp.MCPBaseProtocolMethodsOption != agenticv1alpha1.MCPBaseProtocolMethodsOptionMatch {
+		return nil
 	}
 
 	var permissions []*rbacconfigv3.Permission
@@ -408,10 +396,10 @@ func (t *Translator) translateMCPToRBACPermissions(mcp *agenticv1alpha1.MCPAttri
 	}
 
 	if len(permissions) == 0 {
-		// If both methods and base protocol methods are empty/skipped, we fall back to allowing anything
-		// to maintain backward compatibility for policies that don't specify methods.
-		// TODO: Re-evaluate this default if strict explicit allow is required when `mcp` is present but empty.
-		return []*rbacconfigv3.Permission{buildAnyPermission()}
+		if mcp.Methods == nil {
+			return []*rbacconfigv3.Permission{buildAnyPermission()}
+		}
+		return nil
 	}
 
 	return permissions

--- a/pkg/translator/accesspolicy_test.go
+++ b/pkg/translator/accesspolicy_test.go
@@ -672,13 +672,7 @@ func TestTranslateAccessPolicyToRBAC(t *testing.T) {
 				}
 				return p
 			}(),
-			expectedRules: map[string]expectedRule{
-				"rule-1": {
-					principal:           "spiffe://example.com/ns/default/sa/caller",
-					permissions:         []string{},
-					expectAnyPermission: true,
-				},
-			},
+			expectedRules: map[string]expectedRule{},
 		},
 		{
 			name:         "one rule with nil authorization",
@@ -874,6 +868,74 @@ func TestTranslateAccessPolicyToRBAC(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMergeAllowPoliciesToRBAC(t *testing.T) {
+	denyByDefault := &agenticv1alpha1.XAccessPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "deny-by-default"},
+		Spec: agenticv1alpha1.AccessPolicySpec{
+			Action: agenticv1alpha1.ActionTypeAllow,
+			Rules: []agenticv1alpha1.AccessRule{
+				{
+					Name: "deny-all-tools",
+					Source: agenticv1alpha1.AccessRuleSource{
+						Type: agenticv1alpha1.AuthorizationSourceTypeSPIFFE,
+						SPIFFE: func() *agenticv1alpha1.AuthorizationSourceSPIFFE {
+							s := agenticv1alpha1.AuthorizationSourceSPIFFE("spiffe://example.com/ns/default/sa/caller")
+							return &s
+						}(),
+					},
+					Authorization: &agenticv1alpha1.AuthorizationRule{
+						Type: agenticv1alpha1.AuthorizationRuleTypeInline,
+						MCP: agenticv1alpha1.MCPAttributes{
+							Methods: []agenticv1alpha1.MCPMethod{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	allowOneTool := &agenticv1alpha1.XAccessPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "allow-one-tool"},
+		Spec: agenticv1alpha1.AccessPolicySpec{
+			Action: agenticv1alpha1.ActionTypeAllow,
+			Rules: []agenticv1alpha1.AccessRule{
+				{
+					Name: "allow-tool-a",
+					Source: agenticv1alpha1.AccessRuleSource{
+						Type: agenticv1alpha1.AuthorizationSourceTypeSPIFFE,
+						SPIFFE: func() *agenticv1alpha1.AuthorizationSourceSPIFFE {
+							s := agenticv1alpha1.AuthorizationSourceSPIFFE("spiffe://example.com/ns/default/sa/caller")
+							return &s
+						}(),
+					},
+					Authorization: &agenticv1alpha1.AuthorizationRule{
+						Type: agenticv1alpha1.AuthorizationRuleTypeInline,
+						MCP: agenticv1alpha1.MCPAttributes{
+							Methods: []agenticv1alpha1.MCPMethod{
+								{
+									Name:   "tools/call",
+									Params: []agenticv1alpha1.MCPMethodParam{"tool-a"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tr := &Translator{agenticIdentityTrustDomain: testTrustDomain}
+	rbac := tr.mergeAllowPoliciesToRBAC([]*agenticv1alpha1.XAccessPolicy{denyByDefault, allowOneTool})
+
+	expectedRules := map[string]expectedRule{
+		"default/allow-one-tool/allow-tool-a": {
+			principal:   "spiffe://example.com/ns/default/sa/caller",
+			permissions: []string{"tool-a"},
+		},
+	}
+	verifyRBAC(t, rbac.GetRules(), expectedRules)
 }
 
 func TestBuildAllowMCPSessionClosePolicy(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
AccessPolicy RBAC translation incorrectly treated an explicit empty MCP methods allowlist as allow-all, so policies intended to deny tool access instead granted it. When multiple Allow policies targeted the same backend or gateway, rules could also collide on name and overwrite each other in the merged RBAC config.
This PR fixes that by:
- Treating explicit mcp.methods: [] as deny-by-default (the rule contributes no allow permissions)
- Preserving allow-all behavior when methods is omitted
- Using unique RBAC policy keys ({namespace}/{policy-name}/{rule-name}) when merging multiple Allow policies on the same target
- Aligning merged evaluation with permit-overrides semantics: a request is allowed if any Allow policy permits it

**Which issue(s) this PR fixes**:
Fixes #217 

**Does this PR introduce a user-facing change?**:
```release-note
Fixed AccessPolicy RBAC so explicit empty `mcp.methods: []` denies tool access instead of allowing all MCP traffic.
```
