### PR TITLE
conformance: add receipt admission vectors

### DIFF
--- a/conformance/resources/receipt-admission/v0/README.md
+++ b/conformance/resources/receipt-admission/v0/README.md
@@ -1,0 +1,62 @@
+# Receipt admission conformance vectors (v0)
+
+Envelope-neutral conformance vectors for the receipt-based admission-control discussion in
+[#243](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/243). They pin four admission
+concerns, in the order a controller evaluates them, and every expected outcome is reproducible from the
+bytes in `vectors.json` alone.
+
+- **resolution** — the chain reference is fetched before anything is verified. A present but unresolvable
+  reference is rejected, because a committed digest in the annotation is not sufficient on its own.
+- **binding** — the controller recomputes the manifest digest from the object it actually received and
+  compares it to the chain's committed value, so a chain produced for one object cannot admit a
+  different one.
+- **declared-vs-observed** — for a bound chain, an independent observation of the effect either agrees
+  with, diverges from, or simply does not see what the receipt declares. A receipt is the agent
+  session's own account, so a missing observation is inconclusive, never confirmation.
+- **canonicalization** — the same object content under reordered keys and added whitespace must produce
+  one digest, so the profile (not a coincidence of two serializers) is what makes recompute
+  interoperable.
+
+These vectors deliberately do not define the final canonicalization profile for Kubernetes objects;
+they make that open question explicit and stay reproducible independent of it.
+
+## Format
+
+`vectors.json` carries a machine-readable canonicalization block and a list of vectors. A second
+implementation reproduces every verdict from these fields without any shared code:
+
+```json
+"canonicalization": {
+  "profile": "jcs-json-v1",
+  "description": "RFC 8785 (JCS) over the JSON object, restricted here to strings, objects, and small integers, so RFC 8785 number formatting is not exercised; a full implementation is required for general objects",
+  "hash": "sha256",
+  "digest_encoding": "hex",
+  "digest_prefix": "sha256:"
+}
+```
+
+To recompute a manifest digest: canonicalize the object under the named profile, hash it with the named
+hash, encode per `digest_encoding`, and prefix with `digest_prefix`. The committed digest is checked by
+recomputation, not trusted as supplied.
+
+## Verdicts
+
+- `resolution`: `unresolvable` (reason `chain_reference_unresolvable_digest_alone_insufficient`).
+- `binding`: `bound` | `digest_mismatch` | `missing_commitment`.
+- `grounding` (bound chains): `confirmed` | `contradicted` | `unobserved`, each with a `grounding_reason`.
+- `canonicalization`: `all_variants_match` | `variant_mismatch`.
+
+The required failure case is `g2`/`g3`: a cryptographically valid, bound chain whose independent observed
+effect diverges from the declaration. Vector `g5` is the case where a controller-signed attestation
+covers the submitted object but the effect is unobserved; it carries the distinct reason
+`object_attestation_not_effect_observation`, so attesting the object is never read as observing the
+effect, and it stays `unobserved`.
+
+## Scope
+
+Signature and chain-integrity verification is the emitter side and is assumed valid here; these vectors
+isolate resolution, binding, declared-vs-observed, and canonicalization. They are recompute-only and make
+no claim about any implementation. The canonical profile id `jcs-json-v1` is a placeholder for these
+fixtures; the production Kubernetes object profile (YAML/JSON normalization, defaulting, field ordering)
+is the open question for the proposal, and the committing and recomputing sides must share one named
+profile or recompute is not deterministic across implementations.

--- a/conformance/resources/receipt-admission/v0/README.md
+++ b/conformance/resources/receipt-admission/v0/README.md
@@ -1,7 +1,7 @@
 # Receipt admission conformance vectors (v0)
 
 Envelope-neutral conformance vectors for the receipt-based admission-control discussion in
-[#243](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/243). They pin four admission
+[#243](https://github.com/kubernetes-sigs/kube-agentic-networking/issues/243). They pin five admission
 concerns, in the order a controller evaluates them, and every expected outcome is reproducible from the
 bytes in `vectors.json` alone.
 
@@ -16,9 +16,21 @@ bytes in `vectors.json` alone.
 - **canonicalization** — the same object content under reordered keys and added whitespace must produce
   one digest, so the profile (not a coincidence of two serializers) is what makes recompute
   interoperable.
+- **stage** — a commitment names the pipeline stage it was computed at, and the kind is fixed per stage
+  value in a closed table: `agent-declared` and `controller-observed-object` are object stages verified
+  by recompute, `observed-effect` is verified by compare. The verb derives from the stage alone, so
+  there is no separate stage-kind field that can drift. The required stage selects the verb, and a
+  commitment whose stage differs rejects with two distinct reasons in both directions: within the object
+  kind a digest mismatch (cross-stage being the pipeline/defaulting case, same-stage being tampering),
+  across kinds a stage-kind mismatch decided before any recompute or compare. This is the defaulting case
+  from the thread: the API server defaults and mutates the object before the validating controller sees
+  it, so an `agent-declared` commitment recomputed at the `controller-observed-object` stage must reject,
+  which is the pipeline, not tampering.
 
 These vectors deliberately do not define the final canonicalization profile for Kubernetes objects;
-they make that open question explicit and stay reproducible independent of it.
+they make that open question explicit and stay reproducible independent of it. The `stage` family
+likewise does not assume a final field name in the proposal; it pins the verification contract a named
+stage field has to satisfy.
 
 ## Format
 
@@ -45,6 +57,9 @@ recomputation, not trusted as supplied.
 - `binding`: `bound` | `digest_mismatch` | `missing_commitment`.
 - `grounding` (bound chains): `confirmed` | `contradicted` | `unobserved`, each with a `grounding_reason`.
 - `canonicalization`: `all_variants_match` | `variant_mismatch`.
+- `stage`: `bound` | `cross_stage_digest_mismatch` | `digest_mismatch` | `stage_kind_mismatch` |
+  `confirmed` | `contradicted` | `unobserved` | `unknown_stage`, each with a `stage_reason`. The
+  `stage -> kind -> verb` table is machine-readable in `spec.stage_model`.
 
 The required failure case is `g2`/`g3`: a cryptographically valid, bound chain whose independent observed
 effect diverges from the declaration. Vector `g5` is the case where a controller-signed attestation
@@ -52,11 +67,15 @@ covers the submitted object but the effect is unobserved; it carries the distinc
 `object_attestation_not_effect_observation`, so attesting the object is never read as observing the
 effect, and it stays `unobserved`.
 
+In the `stage` family, `st3` is the defaulting cross-stage reject (a pipeline digest mismatch, kept
+distinct from the `st4` same-stage tampering reject), and `st5`/`st6` are the cross-kind category error
+rejected before any recompute or compare, in both directions.
+
 ## Scope
 
 Signature and chain-integrity verification is the emitter side and is assumed valid here; these vectors
-isolate resolution, binding, declared-vs-observed, and canonicalization. They are recompute-only and make
-no claim about any implementation. The canonical profile id `jcs-json-v1` is a placeholder for these
+isolate resolution, binding, declared-vs-observed, canonicalization, and stage. They are recompute-only
+and make no claim about any implementation. The canonical profile id `jcs-json-v1` is a placeholder for these
 fixtures; the production Kubernetes object profile (YAML/JSON normalization, defaulting, field ordering)
 is the open question for the proposal, and the committing and recomputing sides must share one named
 profile or recompute is not deterministic across implementations.

--- a/conformance/resources/receipt-admission/v0/vectors.json
+++ b/conformance/resources/receipt-admission/v0/vectors.json
@@ -1,0 +1,301 @@
+{
+  "canonicalization": {
+    "description": "RFC 8785 (JCS) over the JSON object, restricted here to strings, objects, and small integers, so RFC 8785 number formatting is not exercised; a full implementation is required for general objects",
+    "digest_encoding": "hex",
+    "digest_prefix": "sha256:",
+    "hash": "sha256",
+    "profile": "jcs-json-v1"
+  },
+  "schema": "receipt_admission_conformance_vectors.v0",
+  "spec": {
+    "binding_verdicts": {
+      "bound": "recomputed digest of the admitted object equals the committed manifest digest",
+      "digest_mismatch": "committed digest present but != recomputed digest",
+      "missing_commitment": "the chain commits to no manifest digest"
+    },
+    "canonicalization_verdicts": {
+      "all_variants_match": "every raw variant of the same content canonicalizes to one digest",
+      "variant_mismatch": "the profile failed to normalize the variants to a single digest"
+    },
+    "evaluation_order": "resolve the chain reference, then binding, then (for a bound chain) declared-vs-observed grounding. Absence of `chain_reference` means the chain is already resolved / in hand.",
+    "grounding_reasons": {
+      "no_independent_observation": "no observation of the effect at all",
+      "object_attestation_not_effect_observation": "a controller-signed attestation covers the submitted object, not the runtime effect, so it is not confirmation",
+      "observed_diverges_from_declared": "an independent observation disagrees with the declaration",
+      "observed_matches_declared": "confirmed by an independent observation"
+    },
+    "grounding_verdicts": {
+      "confirmed": "bound chain; an independent observed effect matches the declared decision, effect, and target",
+      "contradicted": "bound chain; an independent observed effect diverges in decision, effect, or target (the required failure case)",
+      "unobserved": "bound chain; no independent observation of the effect, so the receipt stays a declaration, never confirmed"
+    },
+    "kubernetes_profile_note": "A canonical profile for real Kubernetes objects (YAML/JSON normalization, defaulting, field ordering) is out of scope here and is the open profile question for the proposal; the agent committing the digest and the controller recomputing it must share one named profile, or recompute is not deterministic across implementations.",
+    "non_claims": [
+      "recompute-only; no producer or signer is trusted",
+      "envelope-neutral; composes with a compound-digest chain without owning its format",
+      "reproducible from these bytes alone, without reading the reference runner",
+      "declaration is not effect; a missing observation is inconclusive, never confirmation"
+    ],
+    "recompute_rule": "The controller recomputes the manifest digest from the object it received and compares it to the chain's committed value; the committed value is never trusted as-is.",
+    "resolution_verdicts": {
+      "unresolvable": "the chain reference is present but cannot be resolved; a committed digest alone is not sufficient to admit"
+    },
+    "rules": [
+      "The chain reference is resolved before anything is verified.",
+      "Binding is evaluated before grounding; grounding is evaluated only for a bound chain.",
+      "Only an independent observation of the effect drives grounding.",
+      "A receipt is the agent session's own account: a declaration, not proof the effect occurred.",
+      "A controller-signed attestation covers the submitted object, not the runtime effect, so it never produces 'confirmed' on its own."
+    ],
+    "signature_scope_note": "Signature and chain-integrity verification is the emitter-side family and is assumed valid in these vectors."
+  },
+  "vectors": [
+    {
+      "admitted_object": {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+          "name": "deploy-key-agent",
+          "namespace": "ci"
+        },
+        "spec": {
+          "replicas": 1
+        }
+      },
+      "chain_reference": {
+        "present": true,
+        "resolvable": false,
+        "uri": "oci://registry.example/agent-session/receipts:sha256-deadbeef"
+      },
+      "committed_manifest_digest": "sha256:7229caa820ff06fe2efd4bacd805b0f75891bd66297d234c450d9d30a3a41ff0",
+      "expected": {
+        "reason": "chain_reference_unresolvable_digest_alone_insufficient",
+        "resolution": "unresolvable"
+      },
+      "family": "resolution",
+      "id": "r1_chain_reference_unresolvable"
+    },
+    {
+      "admitted_object": {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+          "name": "deploy-key-agent",
+          "namespace": "ci"
+        },
+        "spec": {
+          "replicas": 1
+        }
+      },
+      "committed_manifest_digest": "sha256:7229caa820ff06fe2efd4bacd805b0f75891bd66297d234c450d9d30a3a41ff0",
+      "expected": {
+        "binding": "bound"
+      },
+      "family": "binding",
+      "id": "b1_binding_match"
+    },
+    {
+      "admitted_object": {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+          "name": "deploy-key-agent",
+          "namespace": "ci"
+        },
+        "spec": {
+          "replicas": 1
+        }
+      },
+      "committed_manifest_digest": "sha256:fcdcc8440646b5ab133e5f2f8bf44067dfb2d5d5470a809252bff2e9c3b10abb",
+      "expected": {
+        "binding": "digest_mismatch"
+      },
+      "family": "binding",
+      "id": "b2_binding_digest_mismatch"
+    },
+    {
+      "admitted_object": {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+          "name": "deploy-key-agent",
+          "namespace": "ci"
+        },
+        "spec": {
+          "replicas": 1
+        }
+      },
+      "committed_manifest_digest": null,
+      "expected": {
+        "binding": "missing_commitment"
+      },
+      "family": "binding",
+      "id": "b3_binding_missing_commitment"
+    },
+    {
+      "admitted_object": {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+          "name": "deploy-key-agent",
+          "namespace": "ci"
+        },
+        "spec": {
+          "replicas": 1
+        }
+      },
+      "chain_cryptographically_valid": true,
+      "committed_manifest_digest": "sha256:7229caa820ff06fe2efd4bacd805b0f75891bd66297d234c450d9d30a3a41ff0",
+      "expected": {
+        "binding": "bound",
+        "grounding": "confirmed",
+        "grounding_reason": "observed_matches_declared"
+      },
+      "family": "declared_vs_observed",
+      "id": "g1_observed_confirms",
+      "observed_effect": {
+        "decision": "allow",
+        "effect": "create_deploy_key",
+        "target": "sha256:repo-a"
+      },
+      "receipt_declares": {
+        "decision": "allow",
+        "effect": "create_deploy_key",
+        "target": "sha256:repo-a"
+      }
+    },
+    {
+      "admitted_object": {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+          "name": "deploy-key-agent",
+          "namespace": "ci"
+        },
+        "spec": {
+          "replicas": 1
+        }
+      },
+      "chain_cryptographically_valid": true,
+      "committed_manifest_digest": "sha256:7229caa820ff06fe2efd4bacd805b0f75891bd66297d234c450d9d30a3a41ff0",
+      "expected": {
+        "binding": "bound",
+        "grounding": "contradicted",
+        "grounding_reason": "observed_diverges_from_declared"
+      },
+      "family": "declared_vs_observed",
+      "id": "g2_observed_contradicts_effect",
+      "observed_effect": {
+        "decision": "deny",
+        "effect": "blocked",
+        "target": "sha256:repo-a"
+      },
+      "receipt_declares": {
+        "decision": "allow",
+        "effect": "create_deploy_key",
+        "target": "sha256:repo-a"
+      }
+    },
+    {
+      "admitted_object": {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+          "name": "deploy-key-agent",
+          "namespace": "ci"
+        },
+        "spec": {
+          "replicas": 1
+        }
+      },
+      "chain_cryptographically_valid": true,
+      "committed_manifest_digest": "sha256:7229caa820ff06fe2efd4bacd805b0f75891bd66297d234c450d9d30a3a41ff0",
+      "expected": {
+        "binding": "bound",
+        "grounding": "contradicted",
+        "grounding_reason": "observed_diverges_from_declared"
+      },
+      "family": "declared_vs_observed",
+      "id": "g3_observed_contradicts_target",
+      "observed_effect": {
+        "decision": "allow",
+        "effect": "create_deploy_key",
+        "target": "sha256:repo-b"
+      },
+      "receipt_declares": {
+        "decision": "allow",
+        "effect": "create_deploy_key",
+        "target": "sha256:repo-a"
+      }
+    },
+    {
+      "admitted_object": {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+          "name": "deploy-key-agent",
+          "namespace": "ci"
+        },
+        "spec": {
+          "replicas": 1
+        }
+      },
+      "chain_cryptographically_valid": true,
+      "committed_manifest_digest": "sha256:7229caa820ff06fe2efd4bacd805b0f75891bd66297d234c450d9d30a3a41ff0",
+      "expected": {
+        "binding": "bound",
+        "grounding": "unobserved",
+        "grounding_reason": "no_independent_observation"
+      },
+      "family": "declared_vs_observed",
+      "id": "g4_effect_unobserved",
+      "observed_effect": null,
+      "receipt_declares": {
+        "decision": "allow",
+        "effect": "create_deploy_key",
+        "target": "sha256:repo-a"
+      }
+    },
+    {
+      "admitted_object": {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+          "name": "deploy-key-agent",
+          "namespace": "ci"
+        },
+        "spec": {
+          "replicas": 1
+        }
+      },
+      "chain_cryptographically_valid": true,
+      "committed_manifest_digest": "sha256:7229caa820ff06fe2efd4bacd805b0f75891bd66297d234c450d9d30a3a41ff0",
+      "controller_object_attestation": true,
+      "expected": {
+        "binding": "bound",
+        "grounding": "unobserved",
+        "grounding_reason": "object_attestation_not_effect_observation"
+      },
+      "family": "declared_vs_observed",
+      "id": "g5_controller_object_attested_effect_unobserved",
+      "observed_effect": null,
+      "receipt_declares": {
+        "decision": "allow",
+        "effect": "create_deploy_key",
+        "target": "sha256:repo-a"
+      }
+    },
+    {
+      "expected": {
+        "canonicalization": "all_variants_match",
+        "digest": "sha256:7229caa820ff06fe2efd4bacd805b0f75891bd66297d234c450d9d30a3a41ff0"
+      },
+      "family": "canonicalization",
+      "id": "c1_canonicalization_stress_same_content",
+      "raw_object_variants": [
+        "{\"spec\":{\"replicas\":1},\"metadata\":{\"namespace\":\"ci\",\"name\":\"deploy-key-agent\"},\"kind\":\"Deployment\",\"apiVersion\":\"apps/v1\"}",
+        "{\n  \"apiVersion\": \"apps/v1\",\n  \"kind\": \"Deployment\",\n  \"metadata\": {\n    \"name\": \"deploy-key-agent\",\n    \"namespace\": \"ci\"\n  },\n  \"spec\": { \"replicas\": 1 }\n}"
+      ]
+    }
+  ]
+}

--- a/conformance/resources/receipt-admission/v0/vectors.json
+++ b/conformance/resources/receipt-admission/v0/vectors.json
@@ -45,9 +45,37 @@
       "Binding is evaluated before grounding; grounding is evaluated only for a bound chain.",
       "Only an independent observation of the effect drives grounding.",
       "A receipt is the agent session's own account: a declaration, not proof the effect occurred.",
-      "A controller-signed attestation covers the submitted object, not the runtime effect, so it never produces 'confirmed' on its own."
+      "A controller-signed attestation covers the submitted object, not the runtime effect, so it never produces 'confirmed' on its own.",
+      "A commitment names its stage; the required stage selects the verb. Object stages recompute, the effect stage compares. A cross-kind check is a category error rejected before any verb runs; a cross-stage object check is a pipeline digest mismatch, not tampering."
     ],
-    "signature_scope_note": "Signature and chain-integrity verification is the emitter-side family and is assumed valid in these vectors."
+    "signature_scope_note": "Signature and chain-integrity verification is the emitter-side family and is assumed valid in these vectors.",
+    "stage_model": {
+      "note": "A commitment names the pipeline stage it was computed at. The kind is fixed per stage value in a closed table, so the verification verb derives from the stage alone; there is no separate stage-kind field that can drift out of agreement with stage. Object stages verify by recompute; the effect stage verifies by compare.",
+      "stage_to_kind_to_verb": {
+        "agent-declared": {
+          "kind": "object",
+          "verb": "recompute"
+        },
+        "controller-observed-object": {
+          "kind": "object",
+          "verb": "recompute"
+        },
+        "observed-effect": {
+          "kind": "effect",
+          "verb": "compare"
+        }
+      }
+    },
+    "stage_verdicts": {
+      "bound": "object stage; the commitment digest equals the recompute at the named stage",
+      "confirmed": "effect stage; an independent observation matches the declaration",
+      "contradicted": "effect stage; an independent observation diverges from the declaration",
+      "cross_stage_digest_mismatch": "object kind, commitment stage differs from the recompute stage; a digest mismatch caused by the pipeline (e.g. defaulting), not tampering",
+      "digest_mismatch": "object kind, same stage; the recompute diverges (tampering)",
+      "stage_kind_mismatch": "the required stage and the commitment stage are different kinds; a category error rejected before any recompute or compare",
+      "unknown_stage": "the named stage is not in the closed enum",
+      "unobserved": "effect stage; no independent observation, so the receipt stays a declaration"
+    }
   },
   "vectors": [
     {
@@ -296,6 +324,157 @@
         "{\"spec\":{\"replicas\":1},\"metadata\":{\"namespace\":\"ci\",\"name\":\"deploy-key-agent\"},\"kind\":\"Deployment\",\"apiVersion\":\"apps/v1\"}",
         "{\n  \"apiVersion\": \"apps/v1\",\n  \"kind\": \"Deployment\",\n  \"metadata\": {\n    \"name\": \"deploy-key-agent\",\n    \"namespace\": \"ci\"\n  },\n  \"spec\": { \"replicas\": 1 }\n}"
       ]
+    },
+    {
+      "commitment": {
+        "object_digest": "sha256:7229caa820ff06fe2efd4bacd805b0f75891bd66297d234c450d9d30a3a41ff0",
+        "stage": "agent-declared"
+      },
+      "expected": {
+        "stage": "bound",
+        "stage_reason": "recompute_matches_at_named_stage"
+      },
+      "family": "stage",
+      "id": "st1_agent_declared_bound",
+      "recompute_object": {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+          "name": "deploy-key-agent",
+          "namespace": "ci"
+        },
+        "spec": {
+          "replicas": 1
+        }
+      },
+      "required_stage": "agent-declared"
+    },
+    {
+      "commitment": {
+        "object_digest": "sha256:09ba9cedc033ff71103dcd7efda1f3be9bb6cd2889a34360a87320cec2fe51ba",
+        "stage": "controller-observed-object"
+      },
+      "expected": {
+        "stage": "bound",
+        "stage_reason": "recompute_matches_at_named_stage"
+      },
+      "family": "stage",
+      "id": "st2_controller_observed_bound",
+      "recompute_object": {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+          "name": "deploy-key-agent",
+          "namespace": "ci"
+        },
+        "spec": {
+          "progressDeadlineSeconds": 600,
+          "replicas": 1
+        }
+      },
+      "required_stage": "controller-observed-object"
+    },
+    {
+      "commitment": {
+        "object_digest": "sha256:7229caa820ff06fe2efd4bacd805b0f75891bd66297d234c450d9d30a3a41ff0",
+        "stage": "agent-declared"
+      },
+      "expected": {
+        "stage": "cross_stage_digest_mismatch",
+        "stage_reason": "commitment_stage_differs_from_recompute_stage_pipeline_not_tamper"
+      },
+      "family": "stage",
+      "id": "st3_cross_stage_defaulting_reject",
+      "recompute_object": {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+          "name": "deploy-key-agent",
+          "namespace": "ci"
+        },
+        "spec": {
+          "progressDeadlineSeconds": 600,
+          "replicas": 1
+        }
+      },
+      "required_stage": "controller-observed-object"
+    },
+    {
+      "commitment": {
+        "object_digest": "sha256:09ba9cedc033ff71103dcd7efda1f3be9bb6cd2889a34360a87320cec2fe51ba",
+        "stage": "controller-observed-object"
+      },
+      "expected": {
+        "stage": "digest_mismatch",
+        "stage_reason": "same_stage_recompute_diverges_tamper"
+      },
+      "family": "stage",
+      "id": "st4_same_stage_tamper_reject",
+      "recompute_object": {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+          "name": "deploy-key-agent",
+          "namespace": "ci"
+        },
+        "spec": {
+          "progressDeadlineSeconds": 600,
+          "replicas": 5
+        }
+      },
+      "required_stage": "controller-observed-object"
+    },
+    {
+      "commitment": {
+        "declares": {
+          "decision": "allow",
+          "effect": "create_deploy_key",
+          "target": "sha256:repo-a"
+        },
+        "stage": "observed-effect"
+      },
+      "expected": {
+        "stage": "stage_kind_mismatch",
+        "stage_reason": "cross_kind_decided_before_verb"
+      },
+      "family": "stage",
+      "id": "st5_cross_kind_effect_vs_object_reject",
+      "required_stage": "controller-observed-object"
+    },
+    {
+      "commitment": {
+        "object_digest": "sha256:09ba9cedc033ff71103dcd7efda1f3be9bb6cd2889a34360a87320cec2fe51ba",
+        "stage": "controller-observed-object"
+      },
+      "expected": {
+        "stage": "stage_kind_mismatch",
+        "stage_reason": "cross_kind_decided_before_verb"
+      },
+      "family": "stage",
+      "id": "st6_cross_kind_object_vs_effect_reject",
+      "required_stage": "observed-effect"
+    },
+    {
+      "commitment": {
+        "declares": {
+          "decision": "allow",
+          "effect": "create_deploy_key",
+          "target": "sha256:repo-a"
+        },
+        "stage": "observed-effect"
+      },
+      "expected": {
+        "stage": "confirmed",
+        "stage_reason": "observed_matches_declared"
+      },
+      "family": "stage",
+      "id": "st7_observed_effect_confirmed",
+      "observed_effect": {
+        "decision": "allow",
+        "effect": "create_deploy_key",
+        "target": "sha256:repo-a"
+      },
+      "required_stage": "observed-effect"
     }
   ]
 }


### PR DESCRIPTION
Adds envelope-neutral vectors for the receipt-based admission discussion in #243. The vectors pin four admission concerns: chain-reference resolution, manifest binding, declared-vs-observed outcome, and canonicalization. They intentionally do not define the final Kubernetes object canonicalization profile; they make that open question explicit. Expected outcomes are reproducible from the bytes in `vectors.json` alone.