### PR TITLE
fix: sanitize BASE_REF slashes for Docker tags

### DIFF
--- a/hack/build/Makefile.common.in
+++ b/hack/build/Makefile.common.in
@@ -24,6 +24,7 @@ REPO_ROOT?=$(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
 # Default tags for local builds
 TAG ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo latest)
 BASE_REF ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo latest)
+override BASE_REF := $(subst /,-,$(BASE_REF))
 
 # Go version to use, respected by images that build go binaries
 GO_VERSION?=$(shell cat $(REPO_ROOT)/.go-version | head -n1)


### PR DESCRIPTION
## Summary
- Prow injects `BASE_REF` as an env var, bypassing the `?=` fallback in `hack/build/Makefile.common.in` that already does `tr '/' '-'`
- Add `override BASE_REF := $(subst /,-,$(BASE_REF))` to ensure slashes are always replaced regardless of how `BASE_REF` is set
- Fixes Docker tag failures on branches with slashes (e.g. `fix/something`)

Suggested by @LiorLieberman in https://github.com/kubernetes-sigs/kube-agentic-networking/pull/305#issuecomment-4743056308

## Test plan
- [ ] CI passes on this PR (branch name has a slash, so it exercises the fix)