### PR TITLE
chore: trigger rebuild of quickstart-everything-mcp image

### DIFF
--- a/site-src/guides/quickstart/mcpserver/Dockerfile
+++ b/site-src/guides/quickstart/mcpserver/Dockerfile
@@ -1,5 +1,5 @@
-# Simple Dockerfile that runs the published mcp-everything server package via npx.
-# Quick & minimal — no build step, downloads package at container start.
+# Dockerfile that runs the published mcp-everything server package via npx.
+# Quick and minimal: no build step, downloads package at container start.
 FROM node:20-slim
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

- The `quickstart-everything-mcp:main` image is missing from the staging registry, causing e2e failures on all open PRs (`ImagePullBackOff`)
- The post-submit job that publishes this image (`post-agentic-net-push-everything-mcp-image`) only triggers when files under `site-src/guides/quickstart/mcpserver/` change ([job config](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/k8s-staging-agentic-net.yaml))
- Last change to that directory was April 2 (`cf8c85b`). The `:main` tag may have expired due to a registry retention policy
- This PR touches the Dockerfile to trigger a rebuild on merge

## Context

Failing e2e example: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kube-agentic-networking/291/pull-kube-agentic-networking-e2e/2069434551347712000

Error from logs:
```
Failed to pull image "us-central1-docker.pkg.dev/k8s-staging-images/agentic-net/quickstart-everything-mcp:main"
us-central1-docker.pkg.dev/k8s-staging-images/agentic-net/quickstart-everything-mcp:main: not found
```

Longer-term, the e2e setup should probably build this image locally (like it does for the controller) instead of pulling from the registry.