### PR TITLE
fix: :wrench: Raise lint timeout to 10m

### DIFF
--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -45,7 +45,7 @@ for module in $(find . -name "go.mod" | xargs -n1 dirname); do
     -e GOMODCACHE="/gomodcache" \
     -e GOCACHE="/gocache" \
     "golangci/golangci-lint:$VERSION" \
-    golangci-lint run -v --timeout=5m || failed=true
+    golangci-lint run -v --timeout=10m || failed=true
 done
 
 if ${failed}; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
-->
/kind bug

**What this PR does / why we need it**:

We've been seeing multiple timeouts for go linting on unrelated documentation PRs like #312 and #316. We will increase the timeout here to allow more time to pull the lint image and run the linting.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Unblock above PRs

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
