### PR TITLE
Ignore generated release/ directory to fix GoReleaser dirty check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ site-src/reference/spec.md
 
 # Agentic instructions
 .agents/
+# Generated release manifests
+release/


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes github release action. Fix is according to GoReleaser docs: https://goreleaser.com/resources/errors/dirty/

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
